### PR TITLE
fix(build): include <cstdlib> before nvtx3 so Windows finds _wgetenv

### DIFF
--- a/src/core/nvtx.h
+++ b/src/core/nvtx.h
@@ -1,5 +1,11 @@
 #pragma once
 
+// NVTX3's initialization path calls _wgetenv on Windows (getenv elsewhere) without including
+// <stdlib.h> itself, so it relies on the includer having reached it first. This header is the
+// project's only entry point to nvtx3, so pulling <cstdlib> in here satisfies that dependency
+// once, for every consumer, whatever order its own includes happen to land in.
+#include <cstdlib>
+
 #include <nvtx3/nvToolsExt.h>
 
 #include <array>


### PR DESCRIPTION
## Problem

A clean Release configure of `master` does not build on Windows with CUDA 12.8 and MSVC 19.44:

```
nvtx3\nvtxDetail\nvtxInit.h(164): error C3861: '_wgetenv': identifier not found
FAILED: src/CMakeFiles/ninfer_ops.dir/ops/wrapper/sparse_moe.cpp.obj
```

## Root cause

NVTX3's initialization path calls `_wgetenv` on Windows (`getenv` elsewhere) without including `<stdlib.h>` itself, so it depends on the includer having reached a standard header first. A translation unit whose first include is its own project header — `ops/wrapper/sparse_moe.cpp` includes `ninfer/ops/sparse_moe.h` then `core/nvtx.h` — reaches nvtx3 before anything pulls in `<stdlib.h>`, and the declaration is missing.

This is latent rather than new: it only bites translation units with that particular include order.

## Fix

`src/core/nvtx.h` is the project's only entry point to nvtx3, so `<cstdlib>` is included there once, for every consumer, rather than patched per file.

## Verification

Fresh build directory configured the same way as a working `build-ninja` (Ninja, Release, `CMAKE_CUDA_ARCHITECTURES=86`, `BUILD_TESTING=ON`, `-DCMAKE_CUDA_FLAGS=-Xcompiler=/Zc:__cplusplus`, vcpkg toolchain):

- before: `ninfer_ops` fails on `sparse_moe.cpp` as above
- after: `ninfer_ops` builds and the dependent test targets link

No behaviour change — this adds a standard-library include and nothing else.

*Note: this repository has no CI workflows, so the evidence above is from local builds on an RTX 3090 / Windows 11 / CUDA 12.8 / MSVC 19.44 host.*
