### PR TITLE
fix(qwen3.6): render zero-argument tool calls instead of throwing

### DIFF
--- a/src/targets/qwen3_6/impl/frontend/chat_template.cpp
+++ b/src/targets/qwen3_6/impl/frontend/chat_template.cpp
@@ -167,8 +167,8 @@ std::string parameter_text(const OrderedJson& value) {
     return tojson_text(value);
 }
 
-std::string render_tool_call(const ToolCall& call, bool allow_empty_arguments) {
-    if (allow_empty_arguments && call.arguments_json.empty()) {
+std::string render_tool_call(const ToolCall& call) {
+    if (call.arguments_json.empty()) {
         return "<tool_call>\n<function=" + call.name + ">\n</function>\n</tool_call>";
     }
     OrderedJson args = OrderedJson::parse(call.arguments_json);
@@ -418,7 +418,7 @@ RenderedChat CompiledChatTemplate::render(const std::vector<ChatMessage>& messag
                 } else {
                     rendered += "\n";
                 }
-                rendered += render_tool_call(message.tool_calls[call_index], effort_template);
+                rendered += render_tool_call(message.tool_calls[call_index]);
             }
         }
         rendered += "<|im_end|>\n";

--- a/tests/targets/qwen3_6/test_frontend.cpp
+++ b/tests/targets/qwen3_6/test_frontend.cpp
@@ -466,6 +466,19 @@ int test_reasoning_effort_chat_template() {
                           .text.ends_with("<tool_call>\n<function=f>\n</function>\n"
                                           "</tool_call><|im_end|>\n"),
                       "empty tool arguments did not follow the reasoning-effort template");
+
+    // A zero-parameter tool call is legal on both templates: the official jinja renders the same
+    // empty <function> block either way, the reasoning-effort one via an explicit
+    // arguments != '' guard and the thinking-toggle one by iterating no arguments at all.
+    // Parsing "" as JSON instead threw, so any no-argument tool 500'd on a toggle-template model.
+    fi::ChatRenderOptions toggle_no_generation;
+    toggle_no_generation.add_generation_prompt = false;
+    failures += check(thinking_toggle_template()
+                          .render({chat_message("user", "call"), empty_arguments},
+                                  toggle_no_generation)
+                          .text.ends_with("<tool_call>\n<function=f>\n</function>\n"
+                                          "</tool_call><|im_end|>\n"),
+                      "empty tool arguments were rejected by the thinking-toggle template");
     return failures;
 }
 


### PR DESCRIPTION
## Problem

A tool call whose `arguments` is an empty string makes the whole request fail with a 500 on any model whose artifact carries the **thinking-toggle** chat template — Qwen3.6-35B-A3B among them:

```json
{"error":{"code":null,"type":"internal_error","message":
 "[json.exception.parse_error.101] parse error at line 1, column 1: attempting to parse an empty input; ..."}}
```

### Reproducer

```bash
curl -s http://127.0.0.1:8080/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model":"qwen3.6-35b-a3b","max_tokens":32,
  "messages":[
    {"role":"user","content":"what time is it"},
    {"role":"assistant","tool_calls":[{"id":"c1","type":"function",
      "function":{"name":"get_time","arguments":""}}]},
    {"role":"tool","tool_call_id":"c1","content":"12:04"}]}'
```

Any tool that takes no parameters produces this shape, so agentic use of a toggle-template model breaks on the first such call.

## Root cause

`render_tool_call()` only short-circuited empty arguments when `allow_empty_arguments` was set, and the single call site passed `effort_template` for it. On a toggle-template model the flag is false, so empty arguments reach `OrderedJson::parse("")`, which throws.

That distinction does not exist in the templates. Both render a zero-parameter call as the same empty `<function>` block:

| template | jinja | rendering |
|---|---|---|
| reasoning-effort | `{%- if tool_call.arguments is defined and tool_call.arguments != '' %}` | `<tool_call>\n<function=f>\n</function>\n</tool_call>` |
| thinking-toggle | `{%- if tool_call.arguments is defined %}` then iterates no arguments | identical |

## Fix

The flag is removed; empty arguments are always a no-parameter call. Smallest change that makes the two templates agree with the jinja they were derived from.

## Verification

- Regression test added for the toggle template alongside the existing reasoning-effort one in `tests/targets/qwen3_6/test_frontend.cpp`.
- `ninfer_qwen3_6_frontend_test` passes.
- End to end on Qwen3.6-35B-A3B: the request above now completes, and the model consumes the tool result (`"I called the get_time function and received 12:04"`).

*Note: this repository has no CI workflows, so the evidence above is from local builds and runs on an RTX 3090 / Windows 11 / CUDA 12.8 host. Requires #2 to build from a clean configure.*
