### PR TITLE
fix(serve): decouple OpenAI Responses cache retention from store

### DIFF
--- a/src/serve/openai_responses.h
+++ b/src/serve/openai_responses.h
@@ -34,6 +34,10 @@ struct OpenAIResponsesPromptRequest {
     std::vector<nlohmann::json> input_items;
     std::optional<std::string> instructions;
     std::optional<std::string> previous_response_id;
+    // Client-supplied cache bucketing hint (OpenAI's prompt_cache_key). Independent of `store`:
+    // it identifies a client-managed conversation lineage for cache retention purposes even when
+    // the caller never wants a retrievable Response object.
+    std::optional<std::string> prompt_cache_key;
 };
 
 struct OpenAIResponsesCreateRequest {

--- a/src/serve/openai_responses_request.cpp
+++ b/src/serve/openai_responses_request.cpp
@@ -1101,10 +1101,20 @@ void validate_metadata(const Json& body, Json& metadata) {
     metadata = body.at("metadata");
 }
 
-void parse_prompt_cache_hints(const Json& body) {
-    require_string_hint(body, "prompt_cache_key");
+// Returns the validated prompt_cache_key, if any. It identifies a client-managed conversation
+// lineage for cache retention purposes; it is independent of `store` (response-object
+// persistence) and of prompt_cache_options.mode (explicit shared-prefix breakpoints).
+std::optional<std::string> parse_prompt_cache_hints(const Json& body) {
+    require_string_hint(body, "prompt_cache_key", ninfer::kMaximumContextCacheSessionKeyBytes);
     require_string_hint(body, "safety_identifier", 64);
     require_string_hint(body, "user");
+    std::optional<std::string> prompt_cache_key;
+    if (body.contains("prompt_cache_key") && !body.at("prompt_cache_key").is_null()) {
+        prompt_cache_key = body.at("prompt_cache_key").get<std::string>();
+        if (prompt_cache_key->empty()) {
+            bad_request("prompt_cache_key must not be empty", "prompt_cache_key");
+        }
+    }
 
     if (body.contains("prompt_cache_retention") && !body.at("prompt_cache_retention").is_null()) {
         if (!body.at("prompt_cache_retention").is_string()) {
@@ -1117,7 +1127,7 @@ void parse_prompt_cache_hints(const Json& body) {
         }
     }
     if (!body.contains("prompt_cache_options") || body.at("prompt_cache_options").is_null()) {
-        return;
+        return prompt_cache_key;
     }
     const Json& options = body.at("prompt_cache_options");
     if (!options.is_object()) {
@@ -1139,6 +1149,7 @@ void parse_prompt_cache_hints(const Json& body) {
         (!options.at("ttl").is_string() || options.at("ttl").get<std::string>() != "30m")) {
         bad_request("prompt_cache_options.ttl must be '30m'", "prompt_cache_options");
     }
+    return prompt_cache_key;
 }
 
 void reject_unsupported_platform_fields(const Json& body) {
@@ -1229,17 +1240,18 @@ OpenAIResponsesCreateRequest parse_openai_responses_create_request(const Json& b
     require_object(body);
     validate_common_top_level(body, true);
     reject_unsupported_platform_fields(body);
-    parse_prompt_cache_hints(body);
+    std::optional<std::string> prompt_cache_key = parse_prompt_cache_hints(body);
 
     ParsedPromptFields parsed = parse_prompt_fields(body, limits);
     OpenAIResponsesCreateRequest out;
-    out.prompt              = std::move(parsed.prompt);
-    out.tools               = std::move(parsed.wire_tools);
-    out.tool_choice         = std::move(parsed.wire_tool_choice);
-    out.tool_identities     = std::move(parsed.tool_identities);
-    out.parallel_tool_calls = parsed.parallel_tool_calls;
-    out.store               = optional_bool(body, "store", true);
-    out.stream              = optional_bool(body, "stream", false);
+    out.prompt                  = std::move(parsed.prompt);
+    out.prompt.prompt_cache_key = std::move(prompt_cache_key);
+    out.tools                   = std::move(parsed.wire_tools);
+    out.tool_choice             = std::move(parsed.wire_tool_choice);
+    out.tool_identities         = std::move(parsed.tool_identities);
+    out.parallel_tool_calls     = parsed.parallel_tool_calls;
+    out.store                   = optional_bool(body, "store", true);
+    out.stream                  = optional_bool(body, "stream", false);
     validate_metadata(body, out.metadata);
 
     // Codex attaches per-request tracing information here. It is an opaque client hint and has no

--- a/src/serve/openai_responses_state.cpp
+++ b/src/serve/openai_responses_state.cpp
@@ -185,10 +185,25 @@ resolve_openai_responses_prompt(const OpenAIResponsesPromptRequest& request,
         } else if (store_response) {
             resolved.session_key = *response_id;
         }
-        resolved.cache_hints.session_key = resolved.session_key;
-        resolved.cache_hints.retention =
-            store_response ? CacheRetentionHint::LiveSession : CacheRetentionHint::Disposable;
-        resolved.cache_hints.update_session_index = store_response;
+
+        // Cache retention identity is independent of `store`: `store` only controls whether this
+        // Response object becomes retrievable by id later. A client that manages its own history
+        // client-side (never sends previous_response_id, never wants a retrievable Response) can
+        // still name its own conversation lineage via prompt_cache_key, so the Engine keeps its
+        // checkpoints instead of grading them Disposable and losing them to the first request from
+        // any other lineage. Only take this path when there is no parent chain and no store-based
+        // session already in play, so it never changes behavior for clients using those mechanisms
+        // (in particular, a stored parent consumed by a store=false reply must stay Disposable and
+        // must not advance the session index).
+        const bool use_prompt_cache_key =
+            !parent_record && !store_response && request.prompt_cache_key.has_value();
+
+        resolved.cache_hints.session_key =
+            use_prompt_cache_key ? request.prompt_cache_key : resolved.session_key;
+        resolved.cache_hints.retention = (store_response || use_prompt_cache_key)
+                                             ? CacheRetentionHint::LiveSession
+                                             : CacheRetentionHint::Disposable;
+        resolved.cache_hints.update_session_index = store_response || use_prompt_cache_key;
     }
     return resolved;
 }

--- a/tests/test_openai_responses.cpp
+++ b/tests/test_openai_responses.cpp
@@ -810,6 +810,63 @@ int test_previous_response_call_graph() {
     return failures;
 }
 
+// A client that never sends previous_response_id or store=true (it manages its own history
+// client-side, e.g. resending the full growing transcript every turn) can still name its own
+// conversation lineage via prompt_cache_key. That must grant the same cache retention a stored
+// session gets, without ever depending on a retrievable Response object.
+int test_prompt_cache_key_retention() {
+    OpenAIResponsesStore store(16, 1ULL << 20);
+    const Json base = {{"model", "m"}, {"input", "hello"}};
+    int failures    = 0;
+
+    Json keyed                = base;
+    keyed["prompt_cache_key"] = "pi-session-1";
+    keyed["store"]            = false;
+    const OpenAIResponsesCreateRequest keyed_request =
+        parse_openai_responses_create_request(keyed, limits());
+    failures += check(keyed_request.prompt.prompt_cache_key == "pi-session-1",
+                      "prompt_cache_key reaches the wire-independent prompt");
+    const OpenAIResponsesResolvedPrompt keyed_resolved =
+        resolve_openai_responses_prompt(keyed_request.prompt, store, "resp_keyed_1", false);
+    failures += check(
+        keyed_resolved.cache_hints.session_key == "pi-session-1" &&
+            keyed_resolved.cache_hints.retention == ninfer::CacheRetentionHint::LiveSession &&
+            keyed_resolved.cache_hints.update_session_index && !keyed_resolved.session_key,
+        "prompt_cache_key grants LiveSession retention without store or a stored session_key");
+
+    Json unkeyed     = base;
+    unkeyed["store"] = false;
+    const OpenAIResponsesCreateRequest unkeyed_request =
+        parse_openai_responses_create_request(unkeyed, limits());
+    const OpenAIResponsesResolvedPrompt unkeyed_resolved =
+        resolve_openai_responses_prompt(unkeyed_request.prompt, store, "resp_unkeyed_1", false);
+    failures += check(!unkeyed_resolved.cache_hints.session_key &&
+                          unkeyed_resolved.cache_hints.retention ==
+                              ninfer::CacheRetentionHint::Disposable &&
+                          !unkeyed_resolved.cache_hints.update_session_index,
+                      "store=false with no prompt_cache_key stays Disposable as before");
+
+    // prompt_cache_key must never override an existing previous_response_id chain: the
+    // store=false-consumes-parent-without-advancing behavior must be unchanged.
+    const OpenAIResponseContext context =
+        append_openai_response_context({}, {text_turn(ninfer::ChatRole::User, "hi")});
+    store.put(stored_parent(context));
+    Json chained = {{"model", "m"},
+                    {"previous_response_id", "resp_parent"},
+                    {"prompt_cache_key", "pi-session-1"},
+                    {"input", "next"}};
+    const OpenAIResponsesCreateRequest chained_request =
+        parse_openai_responses_create_request(chained, limits());
+    const OpenAIResponsesResolvedPrompt chained_resolved =
+        resolve_openai_responses_prompt(chained_request.prompt, store, "resp_chained_1", false);
+    failures += check(
+        chained_resolved.session_key == "responses-session" &&
+            chained_resolved.cache_hints.retention == ninfer::CacheRetentionHint::Disposable &&
+            !chained_resolved.cache_hints.update_session_index,
+        "prompt_cache_key does not upgrade a store=false reply to an existing parent session");
+    return failures;
+}
+
 int test_response_object() {
     const OpenAIResponsesCreateRequest request =
         parse_openai_responses_create_request(Json{{"model", "m"},
@@ -968,6 +1025,7 @@ int main() {
     failures += test_namespace_tools();
     failures += test_explicit_rejections();
     failures += test_previous_response_call_graph();
+    failures += test_prompt_cache_key_retention();
     failures += test_response_object();
     failures += test_sse_sequence_and_failures();
     failures += test_input_tokens_uses_shared_state_path();


### PR DESCRIPTION
## Summary
- `store` only controls whether a Response object is retrievable by id later; it has no bearing on prompt-cache eligibility in the real OpenAI API. This adapter conflated the two, so every `store=false` request (the normal choice for a stateless client resending its own growing history each turn) was tagged `CacheRetentionHint::Disposable` — the lowest eviction-weight class — with no `session_key`, so its checkpoints lost every eviction tie-break and cache reuse never advanced past whatever fragment happened to survive.
- Reproduced live: a 62-turn agent session pinned at the same ~4,859-token cache hit for 29 consecutive turns while `input` grew past 80,000 tokens, each turn re-prefilling almost everything (230+s TTFT) — even after raising the private-continuation catalog size, ruling out a capacity explanation. A controlled two-request replay confirmed the reuse mechanism itself is fine (~99.85% hit) once retention isn't fighting it.
- Fix: use the client-supplied `prompt_cache_key` (OpenAI's standard cache-bucketing hint) as the session identity for retention when there's no `previous_response_id` chain and no `store=true` session already in play. Strictly additive — `previous_response_id`/`store` chaining is unaffected, and a `store=false` reply against an existing stored parent still consumes it without advancing the session (regression-tested).

## Test plan
- [x] `ctest --test-dir build-ninja -R openai_responses` — new `test_prompt_cache_key_retention` covers: prompt_cache_key grants LiveSession retention + advances the session with no store/parent; no-key falls back to prior Disposable behavior unchanged; prompt_cache_key never upgrades a `store=false` reply against an existing `previous_response_id` parent (protects the pre-existing "consumes parent without advancing" case).
- [x] Full `ctest --test-dir build-ninja` — 101/101 passing (5 real-model tests skipped, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)