### PR TITLE
chore(scripts): raise the C1 launcher's context-cache catalog capacity

### DIFF
--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
@@ -119,7 +119,8 @@ rem --- Profile A: speculation on. ~240 tok/s decode. ---
   --kv-dtype rk8v4 ^
   --spec mtp --draft-tokens 3 --lm-head-draft ^
   --prefill-chunk 512 ^
-  --max-pending-requests 16
+  --max-pending-requests 16 ^
+  --max-private-continuations 8 --max-shared-prefixes 4 --host-state-slots 16 --host-kv-mib 8192
 
 rem --- Profile B: maximum context, no speculation. ~183 tok/s decode. ---
 rem "%SERVER%" "%MODEL%" ^


### PR DESCRIPTION
## Summary
- Context-cache catalog sizes default off \`--max-concurrency\` (private=2x concurrency, shared=concurrency), so the C1 (\`--max-concurrency 1\`) launcher shipped with just 2 private-continuation slots and 1 shared-prefix slot for the whole server.
- Measured live: a single actively-growing conversation on this profile was getting only ~5% turn-to-turn cache reuse (see the companion retention-fix PR for the root cause there), and independent of that fix, this tiny catalog caps how many distinct conversations/lineages the server can keep warm at once.
- Raises \`--max-private-continuations\`, \`--max-shared-prefixes\`, and \`--host-state-slots\`. These are Host (pinned system RAM) capacities, a separate budget from Device VRAM (already tight on this profile) — \`--host-kv-mib\` is left at its 8192 MiB default pending real headroom measurement.

## Test plan
- [x] Server starts cleanly on an RTX 3090 with the new flags (verified live).
- Not a code change; no new automated test applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)