### PR TITLE
fix(serve): grant OpenAI Responses requests a private long-anchor checkpoint

### DIFF
--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
@@ -119,7 +119,8 @@ rem --- Profile A: speculation on. ~240 tok/s decode. ---
   --kv-dtype rk8v4 ^
   --spec mtp --draft-tokens 3 --lm-head-draft ^
   --prefill-chunk 512 ^
-  --max-pending-requests 16
+  --max-pending-requests 16 ^
+  --max-private-continuations 8 --max-shared-prefixes 4 --host-state-slots 16 --host-kv-mib 8192
 
 rem --- Profile B: maximum context, no speculation. ~183 tok/s decode. ---
 rem "%SERVER%" "%MODEL%" ^

--- a/src/serve/openai_responses.h
+++ b/src/serve/openai_responses.h
@@ -34,6 +34,10 @@ struct OpenAIResponsesPromptRequest {
     std::vector<nlohmann::json> input_items;
     std::optional<std::string> instructions;
     std::optional<std::string> previous_response_id;
+    // Client-supplied cache bucketing hint (OpenAI's prompt_cache_key). Independent of `store`:
+    // it identifies a client-managed conversation lineage for cache retention purposes even when
+    // the caller never wants a retrievable Response object.
+    std::optional<std::string> prompt_cache_key;
 };
 
 struct OpenAIResponsesCreateRequest {

--- a/src/serve/openai_responses_request.cpp
+++ b/src/serve/openai_responses_request.cpp
@@ -1246,6 +1246,14 @@ OpenAIResponsesCreateRequest parse_openai_responses_create_request(const Json& b
     OpenAIResponsesCreateRequest out;
     out.prompt                  = std::move(parsed.prompt);
     out.prompt.prompt_cache_key = std::move(prompt_cache_key);
+    // Anthropic clients get a private long-anchor checkpoint at the prompt end whenever they send
+    // cache_control:ephemeral (anthropic_messages_request.cpp), so a growing tool-calling exchange
+    // -- many requests, no new user turn between them -- keeps a resumable point past the single
+    // automatic TurnClosure boundary (which sits before the *last user message*, not the latest
+    // request). The Responses API has no equivalent client-supplied marker, so grant the same
+    // opportunity whenever the client has signaled caching intent via prompt_cache_key.
+    out.prompt.generation.private_cache_boundary_at_prompt_end =
+        out.prompt.prompt_cache_key.has_value();
     out.tools                   = std::move(parsed.wire_tools);
     out.tool_choice             = std::move(parsed.wire_tool_choice);
     out.tool_identities         = std::move(parsed.tool_identities);

--- a/src/serve/openai_responses_request.cpp
+++ b/src/serve/openai_responses_request.cpp
@@ -1101,10 +1101,20 @@ void validate_metadata(const Json& body, Json& metadata) {
     metadata = body.at("metadata");
 }
 
-void parse_prompt_cache_hints(const Json& body) {
-    require_string_hint(body, "prompt_cache_key");
+// Returns the validated prompt_cache_key, if any. It identifies a client-managed conversation
+// lineage for cache retention purposes; it is independent of `store` (response-object
+// persistence) and of prompt_cache_options.mode (explicit shared-prefix breakpoints).
+std::optional<std::string> parse_prompt_cache_hints(const Json& body) {
+    require_string_hint(body, "prompt_cache_key", ninfer::kMaximumContextCacheSessionKeyBytes);
     require_string_hint(body, "safety_identifier", 64);
     require_string_hint(body, "user");
+    std::optional<std::string> prompt_cache_key;
+    if (body.contains("prompt_cache_key") && !body.at("prompt_cache_key").is_null()) {
+        prompt_cache_key = body.at("prompt_cache_key").get<std::string>();
+        if (prompt_cache_key->empty()) {
+            bad_request("prompt_cache_key must not be empty", "prompt_cache_key");
+        }
+    }
 
     if (body.contains("prompt_cache_retention") && !body.at("prompt_cache_retention").is_null()) {
         if (!body.at("prompt_cache_retention").is_string()) {
@@ -1117,7 +1127,7 @@ void parse_prompt_cache_hints(const Json& body) {
         }
     }
     if (!body.contains("prompt_cache_options") || body.at("prompt_cache_options").is_null()) {
-        return;
+        return prompt_cache_key;
     }
     const Json& options = body.at("prompt_cache_options");
     if (!options.is_object()) {
@@ -1139,6 +1149,7 @@ void parse_prompt_cache_hints(const Json& body) {
         (!options.at("ttl").is_string() || options.at("ttl").get<std::string>() != "30m")) {
         bad_request("prompt_cache_options.ttl must be '30m'", "prompt_cache_options");
     }
+    return prompt_cache_key;
 }
 
 void reject_unsupported_platform_fields(const Json& body) {
@@ -1229,17 +1240,18 @@ OpenAIResponsesCreateRequest parse_openai_responses_create_request(const Json& b
     require_object(body);
     validate_common_top_level(body, true);
     reject_unsupported_platform_fields(body);
-    parse_prompt_cache_hints(body);
+    std::optional<std::string> prompt_cache_key = parse_prompt_cache_hints(body);
 
     ParsedPromptFields parsed = parse_prompt_fields(body, limits);
     OpenAIResponsesCreateRequest out;
-    out.prompt              = std::move(parsed.prompt);
-    out.tools               = std::move(parsed.wire_tools);
-    out.tool_choice         = std::move(parsed.wire_tool_choice);
-    out.tool_identities     = std::move(parsed.tool_identities);
-    out.parallel_tool_calls = parsed.parallel_tool_calls;
-    out.store               = optional_bool(body, "store", true);
-    out.stream              = optional_bool(body, "stream", false);
+    out.prompt                  = std::move(parsed.prompt);
+    out.prompt.prompt_cache_key = std::move(prompt_cache_key);
+    out.tools                   = std::move(parsed.wire_tools);
+    out.tool_choice             = std::move(parsed.wire_tool_choice);
+    out.tool_identities         = std::move(parsed.tool_identities);
+    out.parallel_tool_calls     = parsed.parallel_tool_calls;
+    out.store                   = optional_bool(body, "store", true);
+    out.stream                  = optional_bool(body, "stream", false);
     validate_metadata(body, out.metadata);
 
     // Codex attaches per-request tracing information here. It is an opaque client hint and has no

--- a/src/serve/openai_responses_state.cpp
+++ b/src/serve/openai_responses_state.cpp
@@ -185,10 +185,25 @@ resolve_openai_responses_prompt(const OpenAIResponsesPromptRequest& request,
         } else if (store_response) {
             resolved.session_key = *response_id;
         }
-        resolved.cache_hints.session_key = resolved.session_key;
-        resolved.cache_hints.retention =
-            store_response ? CacheRetentionHint::LiveSession : CacheRetentionHint::Disposable;
-        resolved.cache_hints.update_session_index = store_response;
+
+        // Cache retention identity is independent of `store`: `store` only controls whether this
+        // Response object becomes retrievable by id later. A client that manages its own history
+        // client-side (never sends previous_response_id, never wants a retrievable Response) can
+        // still name its own conversation lineage via prompt_cache_key, so the Engine keeps its
+        // checkpoints instead of grading them Disposable and losing them to the first request from
+        // any other lineage. Only take this path when there is no parent chain and no store-based
+        // session already in play, so it never changes behavior for clients using those mechanisms
+        // (in particular, a stored parent consumed by a store=false reply must stay Disposable and
+        // must not advance the session index).
+        const bool use_prompt_cache_key =
+            !parent_record && !store_response && request.prompt_cache_key.has_value();
+
+        resolved.cache_hints.session_key =
+            use_prompt_cache_key ? request.prompt_cache_key : resolved.session_key;
+        resolved.cache_hints.retention = (store_response || use_prompt_cache_key)
+                                             ? CacheRetentionHint::LiveSession
+                                             : CacheRetentionHint::Disposable;
+        resolved.cache_hints.update_session_index = store_response || use_prompt_cache_key;
     }
     return resolved;
 }

--- a/tests/test_openai_responses.cpp
+++ b/tests/test_openai_responses.cpp
@@ -826,6 +826,11 @@ int test_prompt_cache_key_retention() {
         parse_openai_responses_create_request(keyed, limits());
     failures += check(keyed_request.prompt.prompt_cache_key == "pi-session-1",
                       "prompt_cache_key reaches the wire-independent prompt");
+    failures += check(
+        keyed_request.prompt.generation.private_cache_boundary_at_prompt_end,
+        "prompt_cache_key grants a private long-anchor opportunity, matching the Anthropic "
+        "cache_control:ephemeral path, so a growing tool-calling exchange keeps a resumable point "
+        "past the single automatic TurnClosure boundary");
     const OpenAIResponsesResolvedPrompt keyed_resolved =
         resolve_openai_responses_prompt(keyed_request.prompt, store, "resp_keyed_1", false);
     failures += check(
@@ -845,6 +850,8 @@ int test_prompt_cache_key_retention() {
                               ninfer::CacheRetentionHint::Disposable &&
                           !unkeyed_resolved.cache_hints.update_session_index,
                       "store=false with no prompt_cache_key stays Disposable as before");
+    failures += check(!unkeyed_request.prompt.generation.private_cache_boundary_at_prompt_end,
+                      "no prompt_cache_key grants no private long-anchor opportunity, unchanged");
 
     // prompt_cache_key must never override an existing previous_response_id chain: the
     // store=false-consumes-parent-without-advancing behavior must be unchanged.

--- a/tests/test_openai_responses.cpp
+++ b/tests/test_openai_responses.cpp
@@ -810,6 +810,63 @@ int test_previous_response_call_graph() {
     return failures;
 }
 
+// A client that never sends previous_response_id or store=true (it manages its own history
+// client-side, e.g. resending the full growing transcript every turn) can still name its own
+// conversation lineage via prompt_cache_key. That must grant the same cache retention a stored
+// session gets, without ever depending on a retrievable Response object.
+int test_prompt_cache_key_retention() {
+    OpenAIResponsesStore store(16, 1ULL << 20);
+    const Json base = {{"model", "m"}, {"input", "hello"}};
+    int failures    = 0;
+
+    Json keyed                = base;
+    keyed["prompt_cache_key"] = "pi-session-1";
+    keyed["store"]            = false;
+    const OpenAIResponsesCreateRequest keyed_request =
+        parse_openai_responses_create_request(keyed, limits());
+    failures += check(keyed_request.prompt.prompt_cache_key == "pi-session-1",
+                      "prompt_cache_key reaches the wire-independent prompt");
+    const OpenAIResponsesResolvedPrompt keyed_resolved =
+        resolve_openai_responses_prompt(keyed_request.prompt, store, "resp_keyed_1", false);
+    failures += check(
+        keyed_resolved.cache_hints.session_key == "pi-session-1" &&
+            keyed_resolved.cache_hints.retention == ninfer::CacheRetentionHint::LiveSession &&
+            keyed_resolved.cache_hints.update_session_index && !keyed_resolved.session_key,
+        "prompt_cache_key grants LiveSession retention without store or a stored session_key");
+
+    Json unkeyed     = base;
+    unkeyed["store"] = false;
+    const OpenAIResponsesCreateRequest unkeyed_request =
+        parse_openai_responses_create_request(unkeyed, limits());
+    const OpenAIResponsesResolvedPrompt unkeyed_resolved =
+        resolve_openai_responses_prompt(unkeyed_request.prompt, store, "resp_unkeyed_1", false);
+    failures += check(!unkeyed_resolved.cache_hints.session_key &&
+                          unkeyed_resolved.cache_hints.retention ==
+                              ninfer::CacheRetentionHint::Disposable &&
+                          !unkeyed_resolved.cache_hints.update_session_index,
+                      "store=false with no prompt_cache_key stays Disposable as before");
+
+    // prompt_cache_key must never override an existing previous_response_id chain: the
+    // store=false-consumes-parent-without-advancing behavior must be unchanged.
+    const OpenAIResponseContext context =
+        append_openai_response_context({}, {text_turn(ninfer::ChatRole::User, "hi")});
+    store.put(stored_parent(context));
+    Json chained = {{"model", "m"},
+                    {"previous_response_id", "resp_parent"},
+                    {"prompt_cache_key", "pi-session-1"},
+                    {"input", "next"}};
+    const OpenAIResponsesCreateRequest chained_request =
+        parse_openai_responses_create_request(chained, limits());
+    const OpenAIResponsesResolvedPrompt chained_resolved =
+        resolve_openai_responses_prompt(chained_request.prompt, store, "resp_chained_1", false);
+    failures += check(
+        chained_resolved.session_key == "responses-session" &&
+            chained_resolved.cache_hints.retention == ninfer::CacheRetentionHint::Disposable &&
+            !chained_resolved.cache_hints.update_session_index,
+        "prompt_cache_key does not upgrade a store=false reply to an existing parent session");
+    return failures;
+}
+
 int test_response_object() {
     const OpenAIResponsesCreateRequest request =
         parse_openai_responses_create_request(Json{{"model", "m"},
@@ -968,6 +1025,7 @@ int main() {
     failures += test_namespace_tools();
     failures += test_explicit_rejections();
     failures += test_previous_response_call_graph();
+    failures += test_prompt_cache_key_retention();
     failures += test_response_object();
     failures += test_sse_sequence_and_failures();
     failures += test_input_tokens_uses_shared_state_path();


### PR DESCRIPTION
## Summary
- Anthropic clients get a private long-anchor checkpoint at the prompt end whenever they send `cache_control:ephemeral` (`anthropic_messages_request.cpp`, via `GenerationRequest::private_cache_boundary_at_prompt_end`). The OpenAI Responses adapter had no equivalent path — that field was set in exactly one place in the whole codebase, and it wasn't this one.
- Without it, the only private checkpoint a Responses request can ever publish is the automatic, structural `TurnClosure` boundary: the point right before the *current* turn's replaceable assistant suffix, i.e. before the last real user message. A long tool-calling exchange — many requests, many tool round-trips, no new user message in between — is one ongoing turn from the engine's perspective, so that boundary never advances no matter how many further requests extend it.
- Follows directly from #5: reproduced live on top of that retention fix, a 15-request linear chain extending a ~12.7k-token base by ~190 tokens/step stayed pinned at the turn-1 checkpoint for every single step (constant `cache=12529`, growing miss, growing wall time). Wiring the same `private_cache_boundary_at_prompt_end` signal Anthropic already uses — gated on `prompt_cache_key`, consistent with #5 — switched `reuse=` from `private_turn_closure` to `private_long_anchor`, and `cache=` tracked `input_tokens` almost exactly (~194-token gap, one round's worth) for all 15 steps, each completing in ~0.7s regardless of how large the conversation grew.

## Test plan
- [x] New assertions in `test_prompt_cache_key_retention`: `prompt_cache_key` present → `private_cache_boundary_at_prompt_end` true; absent → false (unchanged).
- [x] Full `ctest --test-dir build-ninja` — 101/101 passing.
- [x] Live 15-request linear chain against a real server, before/after — see summary above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)