### PR TITLE
perf(sm_86): re-route decode extents and fix concurrent-serving admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,25 @@ the new sustained test: every request generated 1,024 tokens with CUDA Graphs en
 The prompts were **29-34 input tokens** and the server's maximum context window was **8,192 tokens
 per request**. Each measured sequence therefore reached roughly 1,053-1,058 tokens including its
 generated output. This is a long-output/decode benchmark, not an 8K-prompt or long-prefill test.
-C1-C4 used an 8,192-token shared KV pool; C8 used 16,384 tokens so all eight requested outputs
-could be admitted simultaneously.
+C1 used an 8,192-token shared KV pool; C2-C8 used 16,384 tokens so every requested output could be
+admitted simultaneously.
 
 | Cohort | Total output | End-to-end throughput | Decode throughput | MTP acceptance | Mean TTFT | Peak VRAM |
 |---:|---:|---:|---:|---:|---:|---:|
-| C1 | 1,024 tokens | **70.19 tok/s** | **71.00 tok/s** | 61.13% | 149 ms | 19,641 MiB |
-| C2 | 2,048 tokens | **89.43 tok/s** | **90.66 tok/s** | 59.66% | 262 ms | 20,022 MiB |
-| C4 | 4,096 tokens | **97.89 tok/s** | **100.28 tok/s** | 59.63% | 538 ms | 20,641 MiB |
-| C8 | 8,192 tokens | **161.28 tok/s** | **165.33 tok/s** | 56.84% | 1,215 ms | 22,138 MiB |
+| C1 | 1,024 tokens | **77.84 tok/s** | **78.71 tok/s** | 71.27% | 133 ms | 19,475 MiB |
+| C2 | 2,048 tokens | **94.75 tok/s** | **96.04 tok/s** | 62.17% | 225 ms | 19,919 MiB |
+| C4 | 4,096 tokens | **136.43 tok/s** | **139.91 tok/s** | 66.15% | 420 ms | 20,247 MiB |
+| C8 | 8,192 tokens | **240.34 tok/s** | **250.26 tok/s** | 69.74% | 866 ms | 20,903 MiB |
 
-C1 is the responsive choice for a single user. C8 delivers **2.3x the total throughput** when
+C1 is the responsive choice for a single user. C8 delivers **3.2x the total throughput** when
 several requests are active. The C8 long-output test uses a 16K shared KV pool so all eight
 1,024-token responses can be admitted together.
+
+Concurrent decode extents are what the sm_86 kernel routes are selected for. A decode round covers
+`concurrency x (draft window + 1)` token columns, and above the single-token point the cost of a
+route is set by its padded tile width rather than by the live column count. Selecting the narrowest
+tile that still covers each extent is worth 40% at C4 and C8; C1, whose four columns already sit on
+the exact-T routes, is unchanged.
 
 ### Prompt-processing speed
 

--- a/docs/rtx-3090-linux.md
+++ b/docs/rtx-3090-linux.md
@@ -34,7 +34,7 @@ docker run --rm --gpus all \
   ninfer-serve models/qwen3_8_27b.ninfer \
   --host 0.0.0.0 --port 8080 \
   --max-context 65536 --kv-capacity 65536 \
-  --max-concurrency 1 --max-pending-requests 16 \
+  --max-concurrency 1 --max-pending-requests 16 --pending-timeout-ms 600000 \
   --prefill-chunk 1024 --kv-dtype int8 \
   --spec mtp --draft-tokens 3 --lm-head-draft
 ```

--- a/docs/rtx-3090-windows.md
+++ b/docs/rtx-3090-windows.md
@@ -48,7 +48,7 @@ headroom and may reject an otherwise viable compact-35B configuration.
 .\ninfer-serve.exe models\qwen3_6_35b_a3b.ninfer `
   --host 127.0.0.1 --port 8080 `
   --max-context 4096 --kv-capacity 4096 `
-  --max-concurrency 4 --max-pending-requests 32 `
+  --max-concurrency 4 --max-pending-requests 32 --pending-timeout-ms 600000 `
   --prefill-chunk 512 --kv-dtype int8 `
   --spec mtp --draft-tokens 3 --lm-head-draft
 ```
@@ -69,8 +69,8 @@ to use MTP3:
 .\ninfer-serve.exe models\qwen3_8_27b.ninfer `
   --host 127.0.0.1 --port 8080 `
   --max-context 8192 --kv-capacity 8192 `
-  --max-concurrency 8 --max-pending-requests 32 `
-  --prefill-chunk 1024 --kv-dtype int8 `
+  --max-concurrency 8 --max-pending-requests 32 --pending-timeout-ms 600000 `
+  --prefill-chunk 512 --kv-dtype int8 `
   --spec mtp --draft-tokens 3 --lm-head-draft
 ```
 

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -99,6 +99,13 @@ request is waiting or prefilling. A peer whose TCP stack remains connected and a
 cannot be distinguished from a reading application; proxies must close their upstream NInfer
 connection when the downstream client disappears.
 
+The HTTP transport is thread-per-connection, and a worker stays with a connection for its whole
+life, including the idle window between keep-alive requests. The pool therefore reserves one base
+worker per admissible request (`max_concurrency + max_pending_requests + 1`) and grows on demand up
+to 64 further workers for connections that are merely open; the extra workers retire once idle.
+Without that headroom a client-side connection pool of otherwise idle sockets occupies every worker
+and the server accepts real requests strictly one at a time.
+
 ## OpenAI Chat Completions
 
 ```bash
@@ -663,7 +670,7 @@ The table lists executable defaults. The startup example selects a long-context 
 | `--kv-capacity N\|auto` | explicit shared Main Text KV capacity, or maximize it from remaining GPU memory; omitted means `--max-context` | `8192` |
 | `--max-concurrency N` | maximum admitted requests; valid range `1..8` | `1` |
 | `--max-pending-requests N` | additional requests allowed to wait for admission | `16` |
-| `--pending-timeout-ms N` | maximum preparation-plus-admission wait | `30000` |
+| `--pending-timeout-ms N` | maximum preparation-plus-admission wait | `600000` |
 | `--prefill-chunk N` | text-prefill chunk | `1024` |
 | `--log-stats-interval-ms N` | aggregate throughput report interval; `0` disables it | `5000` |
 | `--device N` | CUDA device index | `0` |
@@ -833,7 +840,20 @@ CPU/media preparation and completed model results whose response has not yet bee
 capacity returns HTTP 429 with code `server_overloaded`. The absolute
 `--pending-timeout-ms` deadline starts before preparation, covers media acquisition and Engine FIFO
 waiting, and returns HTTP 503 with code `request_queue_timeout` if admission does not occur in time.
-There is no admission ETA or unbounded overflow queue.
+There is no admission ETA or unbounded overflow queue. Because there is no preemption, a queued
+request waits out the generations ahead of it, so the deadline has to be scaled to the longest
+response the deployment allows rather than to a connection timeout: at C1 on an RTX 3090 a single
+6,500-token response occupies the engine for about 106 seconds. The 600,000 ms default admits a
+queued caller behind roughly ten such responses; lower it only to fail fast on purpose.
+
+One request owns the staged prefill at a time, and the executor alternates a single prefill chunk
+with a single decode round, so `--prefill-chunk` sets the worst-case pause every active stream sees
+while a new prompt is ingested. On an RTX 3090 ingesting a 4,900-token prompt behind four active
+streams, the largest inter-token gap measured 1,043 ms at chunk 1024, 515 ms at 512, and 312 ms at
+256, against an 82 ms median decode interval; the ingesting request's own prefill rate fell only
+from 1,135 to 1,130 to 1,110 tok/s. Prefill is not batched across requests at any chunk size, so a
+smaller chunk trades almost no ingestion throughput for a proportionally smaller stall. The shipped
+concurrent launcher uses 512.
 
 Input memory is bounded by the outstanding-request count and the per-request
 `--max-request-mib` limit. Media requests additionally share one preparation permit, so a waiting

--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
@@ -128,7 +128,7 @@ rem --- Profile A: speculation on. ~240 tok/s decode. ---
   --kv-dtype rk8v4 ^
   --spec mtp --draft-tokens 3 --lm-head-draft ^
   --prefill-chunk 512 ^
-  --max-pending-requests 16 ^
+  --max-pending-requests 16 --pending-timeout-ms 600000 ^
   --vision --vision-residency overlay ^
   --max-private-continuations 8 --max-shared-prefixes 4 --host-state-slots 16 --host-kv-mib 8192
 
@@ -140,6 +140,6 @@ rem   --max-context %CONTEXT% ^
 rem   --kv-capacity %CONTEXT% ^
 rem   --kv-dtype rk8v4 ^
 rem   --prefill-chunk 512 ^
-rem   --max-pending-requests 16
+rem   --max-pending-requests 16 --pending-timeout-ms 600000
 
 endlocal

--- a/scripts/run-qwen36-35b-vision.bat
+++ b/scripts/run-qwen36-35b-vision.bat
@@ -18,4 +18,4 @@ if not exist "%MODEL%" (
 
 echo Starting Qwen3.6-35B-A3B Vision at http://127.0.0.1:8080/v1
 echo Safe RTX 3090 profile: one request, 32K context, vision enabled, MTP disabled
-"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 32768 --kv-capacity 32768 --max-concurrency 1 --max-pending-requests 8 --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 512 --vision --no-thinking --temperature 0.2
+"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 32768 --kv-capacity 32768 --max-concurrency 1 --max-pending-requests 8 --pending-timeout-ms 600000 --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 512 --vision --no-thinking --temperature 0.2

--- a/scripts/run-qwen36-35b-vision.sh
+++ b/scripts/run-qwen36-35b-vision.sh
@@ -24,6 +24,6 @@ printf '%s\n' 'Safe RTX 3090 profile: one request, 32K context, vision enabled, 
 exec "$server" "$model" \
   --host 127.0.0.1 --port 8080 \
   --max-context 32768 --kv-capacity 32768 \
-  --max-concurrency 1 --max-pending-requests 8 \
+  --max-concurrency 1 --max-pending-requests 8 --pending-timeout-ms 600000 \
   --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 512 \
   --vision --no-thinking --temperature 0.2

--- a/scripts/run-qwen38-c1.bat
+++ b/scripts/run-qwen38-c1.bat
@@ -18,4 +18,4 @@ if not exist "%MODEL%" (
 
 echo Starting Qwen3.8-27B at http://127.0.0.1:8080/v1
 echo Profile: one request, 64K context, MTP3, ReplaySSM
-"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 65536 --kv-capacity 65536 --max-concurrency 1 --max-pending-requests 16 --prefill-chunk 1024 --kv-dtype int8 --spec mtp --draft-tokens 3 --lm-head-draft
+"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 65536 --kv-capacity 65536 --max-concurrency 1 --max-pending-requests 16 --pending-timeout-ms 600000 --prefill-chunk 1024 --kv-dtype int8 --spec mtp --draft-tokens 3 --lm-head-draft

--- a/scripts/run-qwen38-c1.sh
+++ b/scripts/run-qwen38-c1.sh
@@ -24,6 +24,6 @@ printf '%s\n' 'Profile: one request, 64K context, MTP3, ReplaySSM'
 exec "$server" "$model" \
   --host 127.0.0.1 --port 8080 \
   --max-context 65536 --kv-capacity 65536 \
-  --max-concurrency 1 --max-pending-requests 16 \
+  --max-concurrency 1 --max-pending-requests 16 --pending-timeout-ms 600000 \
   --prefill-chunk 1024 --kv-dtype int8 \
   --spec mtp --draft-tokens 3 --lm-head-draft

--- a/scripts/run-qwen38-c8.bat
+++ b/scripts/run-qwen38-c8.bat
@@ -18,4 +18,4 @@ if not exist "%MODEL%" (
 
 echo Starting Qwen3.8-27B at http://127.0.0.1:8080/v1
 echo Profile: up to eight requests, 8K context, MTP3, ReplaySSM
-"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 8192 --kv-capacity 16384 --max-concurrency 8 --max-pending-requests 32 --prefill-chunk 1024 --kv-dtype int8 --spec mtp --draft-tokens 3 --lm-head-draft
+"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 8192 --kv-capacity 16384 --max-concurrency 8 --max-pending-requests 32 --pending-timeout-ms 600000 --prefill-chunk 512 --kv-dtype int8 --spec mtp --draft-tokens 3 --lm-head-draft

--- a/scripts/run-qwen38-c8.sh
+++ b/scripts/run-qwen38-c8.sh
@@ -24,6 +24,6 @@ printf '%s\n' 'Profile: up to eight requests, 8K context, MTP3, ReplaySSM'
 exec "$server" "$model" \
   --host 127.0.0.1 --port 8080 \
   --max-context 8192 --kv-capacity 16384 \
-  --max-concurrency 8 --max-pending-requests 32 \
-  --prefill-chunk 1024 --kv-dtype int8 \
+  --max-concurrency 8 --max-pending-requests 32 --pending-timeout-ms 600000 \
+  --prefill-chunk 512 --kv-dtype int8 \
   --spec mtp --draft-tokens 3 --lm-head-draft

--- a/scripts/run-qwen38-vision.bat
+++ b/scripts/run-qwen38-vision.bat
@@ -18,4 +18,4 @@ if not exist "%MODEL%" (
 
 echo Starting Qwen3.8-27B Vision at http://127.0.0.1:8080/v1
 echo Tested RTX 3090 profile: one request, 32K context, ReplaySSM and MTP3
-"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 32768 --kv-capacity 32768 --max-concurrency 1 --max-pending-requests 8 --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 1024 --vision --spec mtp --draft-tokens 3 --lm-head-draft
+"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 32768 --kv-capacity 32768 --max-concurrency 1 --max-pending-requests 8 --pending-timeout-ms 600000 --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 1024 --vision --spec mtp --draft-tokens 3 --lm-head-draft

--- a/scripts/run-qwen38-vision.sh
+++ b/scripts/run-qwen38-vision.sh
@@ -24,6 +24,6 @@ printf '%s\n' 'Tested RTX 3090 profile: one request, 32K context, ReplaySSM and 
 exec "$server" "$model" \
   --host 127.0.0.1 --port 8080 \
   --max-context 32768 --kv-capacity 32768 \
-  --max-concurrency 1 --max-pending-requests 8 \
+  --max-concurrency 1 --max-pending-requests 8 --pending-timeout-ms 600000 \
   --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 1024 \
   --vision --spec mtp --draft-tokens 3 --lm-head-draft

--- a/src/ops/attn_input_proj/q4_q5/q4_q5_attn_input_gemm_mma.cu
+++ b/src/ops/attn_input_proj/q4_q5/q4_q5_attn_input_gemm_mma.cu
@@ -82,16 +82,19 @@ void launch(const Tensor& x, const Weight& query_key_weight, const Weight& gate_
     });
 }
 
-using MmaR16C64S3 = GemmCfg<16, 64, 64, 16, 16, 3, 1, false, true, true>;
+// The pair tile pads every column group to its full width, so a 64-wide tile does twice the
+// MMA work a 32-column decode round needs. The 32-wide tile covers every decode extent; the
+// 64-wide tile stays for prefill chunks.
+using MmaR32C32S4 = GemmCfg<32, 32, 64, 16, 16, 4, 1, false, true, true>;
 using MmaR32C64S4 = GemmCfg<32, 64, 64, 16, 16, 4, 1, false, true, true>;
 
 } // namespace
 
-void q4_q5_attn_input_grouped_mma_r16_c64_s3_launch(const Tensor& x, const Weight& query_key_weight,
+void q4_q5_attn_input_grouped_mma_r32_c32_s4_launch(const Tensor& x, const Weight& query_key_weight,
                                                     const Weight& gate_value_weight, Tensor& q,
                                                     Tensor& gate, Tensor& k, Tensor& v,
                                                     cudaStream_t stream) {
-    launch<MmaR16C64S3>(x, query_key_weight, gate_value_weight, q, gate, k, v, stream);
+    launch<MmaR32C32S4>(x, query_key_weight, gate_value_weight, q, gate, k, v, stream);
 }
 
 void q4_q5_attn_input_grouped_mma_r32_c64_s4_launch(const Tensor& x, const Weight& query_key_weight,

--- a/src/ops/attn_input_proj/q4_q5/q4_q5_attn_input_kernels.h
+++ b/src/ops/attn_input_proj/q4_q5/q4_q5_attn_input_kernels.h
@@ -10,7 +10,7 @@ void q4_q5_attn_input_small_t_launch(const Tensor& x, const Weight& query_key_we
                                      const Weight& gate_value_weight, Tensor& q, Tensor& gate,
                                      Tensor& k, Tensor& v, cudaStream_t stream);
 
-void q4_q5_attn_input_grouped_mma_r16_c64_s3_launch(const Tensor& x, const Weight& query_key_weight,
+void q4_q5_attn_input_grouped_mma_r32_c32_s4_launch(const Tensor& x, const Weight& query_key_weight,
                                                     const Weight& gate_value_weight, Tensor& q,
                                                     Tensor& gate, Tensor& k, Tensor& v,
                                                     cudaStream_t stream);

--- a/src/ops/attn_input_proj/q4_q5/q4_q5_attn_input_plan.cpp
+++ b/src/ops/attn_input_proj/q4_q5/q4_q5_attn_input_plan.cpp
@@ -25,9 +25,9 @@ struct RouteSpec {
 };
 
 constexpr std::array<RouteSpec, 3> kRoutes{{
-    {{1, 16}, Q4Q5AttnInputScheduleId::ParentSplitFixed},
-    {{17, 20}, Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR16C64S3},
-    {{21, kAnyCols}, Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR32C64S4},
+    {{1, 8}, Q4Q5AttnInputScheduleId::ParentSplitFixed},
+    {{9, 32}, Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR32C32S4},
+    {{33, kAnyCols}, Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR32C64S4},
 }};
 
 constexpr bool catalog_is_closed() noexcept {
@@ -48,8 +48,8 @@ const char* q4_q5_attn_input_schedule_name(Q4Q5AttnInputScheduleId schedule) noe
     switch (schedule) {
     case Q4Q5AttnInputScheduleId::ParentSplitFixed:
         return "attn_input_proj.q4_q5.parent_split_fixed";
-    case Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR16C64S3:
-        return "attn_input_proj.q4_q5.grouped_homogeneous_pair.mma.r16.c64.s3";
+    case Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR32C32S4:
+        return "attn_input_proj.q4_q5.grouped_homogeneous_pair.mma.r32.c32.s4";
     case Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR32C64S4:
         return "attn_input_proj.q4_q5.grouped_homogeneous_pair.mma.r32.c64.s4";
     }
@@ -89,8 +89,8 @@ void q4_q5_attn_input_execute_plan(const Q4Q5AttnInputPlan& plan, const Tensor& 
         q4_q5_attn_input_small_t_launch(x, query_key_weight, gate_value_weight, q, gate, k, v,
                                         stream);
         return;
-    case Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR16C64S3:
-        q4_q5_attn_input_grouped_mma_r16_c64_s3_launch(x, query_key_weight, gate_value_weight, q,
+    case Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR32C32S4:
+        q4_q5_attn_input_grouped_mma_r32_c32_s4_launch(x, query_key_weight, gate_value_weight, q,
                                                        gate, k, v, stream);
         return;
     case Q4Q5AttnInputScheduleId::GroupedHomogeneousPairMmaR32C64S4:

--- a/src/ops/attn_input_proj/q4_q5/q4_q5_attn_input_plan.h
+++ b/src/ops/attn_input_proj/q4_q5/q4_q5_attn_input_plan.h
@@ -11,7 +11,7 @@ namespace ninfer::ops::detail {
 
 enum class Q4Q5AttnInputScheduleId {
     ParentSplitFixed,
-    GroupedHomogeneousPairMmaR16C64S3,
+    GroupedHomogeneousPairMmaR32C32S4,
     GroupedHomogeneousPairMmaR32C64S4,
 };
 

--- a/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_gemm_mma.cu
+++ b/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_gemm_mma.cu
@@ -33,10 +33,19 @@ RowSplitGroupedMmaJob make_job(const Weight& weight, std::int32_t weight_row_off
     };
 }
 
+// A block tile pads every column group to its full width, so the issued MMA work is set by
+// BN, not by the live token count. On sm_86 the 128-wide tile is issue-bound well before it
+// is bandwidth-bound, and a decode round never fills it: C8 with MTP3 is 32 columns. The
+// narrow tiles cut the padded work proportionally over the extents a decode round uses,
+// while the 128-wide tile stays the throughput anchor for prefill chunks.
+using GdnInputC32Schedule  = GemmCfg<64, 32, 64, 16, 8, 2, 2, false, true, true>;
+using GdnInputC64Schedule  = GemmCfg<64, 64, 64, 16, 16, 2, 2, false, true, true>;
+using GdnInputC128Schedule = GemmCfg<64, 128, 64, 64, 16, 2, 1, false, true, true>;
+
+template <class Schedule>
 void launch_slice(bool full, const Tensor& x, const Weight& qk_weight, const Weight& value_z_weight,
                   Tensor& qkv, Tensor& z, cudaStream_t stream) {
     constexpr std::int32_t kValueRows = 6144;
-    using Schedule                    = GemmCfg<64, 128, 64, 64, 16, 2, 1, false, true, true>;
     const RowSplitGroupedMmaJob qk    = make_job(qk_weight, 0, qk_weight.n, qkv, 0);
     const RowSplitGroupedMmaJob value = make_job(value_z_weight, 0, kValueRows, qkv, qk_weight.n);
     const RowSplitGroupedMmaJob output_gate =
@@ -62,19 +71,38 @@ void launch_slice(bool full, const Tensor& x, const Weight& qk_weight, const Wei
     CUDA_CHECK(cudaGetLastError());
 }
 
-} // namespace
-
-void q4_q5_gdn_input_grouped_mma_launch(const Tensor& x, const Weight& qk_weight,
-                                        const Weight& value_z_weight, Tensor& qkv, Tensor& z,
-                                        cudaStream_t stream) {
-    constexpr std::int32_t kTileCols = 128;
+template <class Schedule>
+void launch_route(const Tensor& x, const Weight& qk_weight, const Weight& value_z_weight,
+                  Tensor& qkv, Tensor& z, cudaStream_t stream) {
+    constexpr std::int32_t kTileCols = Schedule::BN;
     const bool full                  = (x.ne[1] % kTileCols) == 0;
     for_each_token_slice(x.ne[1], kTileCols, [&](std::int32_t offset, std::int32_t count) {
         const Tensor x_slice = x.slice(1, offset, count);
         Tensor qkv_slice     = qkv.slice(1, offset, count);
         Tensor z_slice       = z.slice(1, offset, count);
-        launch_slice(full, x_slice, qk_weight, value_z_weight, qkv_slice, z_slice, stream);
+        launch_slice<Schedule>(full, x_slice, qk_weight, value_z_weight, qkv_slice, z_slice,
+                               stream);
     });
+}
+
+} // namespace
+
+void q4_q5_gdn_input_grouped_mma_c32_launch(const Tensor& x, const Weight& qk_weight,
+                                            const Weight& value_z_weight, Tensor& qkv, Tensor& z,
+                                            cudaStream_t stream) {
+    launch_route<GdnInputC32Schedule>(x, qk_weight, value_z_weight, qkv, z, stream);
+}
+
+void q4_q5_gdn_input_grouped_mma_c64_launch(const Tensor& x, const Weight& qk_weight,
+                                            const Weight& value_z_weight, Tensor& qkv, Tensor& z,
+                                            cudaStream_t stream) {
+    launch_route<GdnInputC64Schedule>(x, qk_weight, value_z_weight, qkv, z, stream);
+}
+
+void q4_q5_gdn_input_grouped_mma_launch(const Tensor& x, const Weight& qk_weight,
+                                        const Weight& value_z_weight, Tensor& qkv, Tensor& z,
+                                        cudaStream_t stream) {
+    launch_route<GdnInputC128Schedule>(x, qk_weight, value_z_weight, qkv, z, stream);
 }
 
 } // namespace ninfer::ops::detail

--- a/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_kernels.h
+++ b/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_kernels.h
@@ -10,6 +10,14 @@ void q4_q5_gdn_input_independent_launch(const Tensor& x, const Weight& qk_weight
                                         const Weight& value_z_weight, Tensor& qk, Tensor& value,
                                         Tensor& z, cudaStream_t stream);
 
+void q4_q5_gdn_input_grouped_mma_c32_launch(const Tensor& x, const Weight& qk_weight,
+                                            const Weight& value_z_weight, Tensor& qkv, Tensor& z,
+                                            cudaStream_t stream);
+
+void q4_q5_gdn_input_grouped_mma_c64_launch(const Tensor& x, const Weight& qk_weight,
+                                            const Weight& value_z_weight, Tensor& qkv, Tensor& z,
+                                            cudaStream_t stream);
+
 void q4_q5_gdn_input_grouped_mma_launch(const Tensor& x, const Weight& qk_weight,
                                         const Weight& value_z_weight, Tensor& qkv, Tensor& z,
                                         cudaStream_t stream);

--- a/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.cpp
+++ b/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.cpp
@@ -25,14 +25,25 @@ struct RouteSpec {
     Q4Q5GdnInputScheduleId schedule;
 };
 
-constexpr std::array<RouteSpec, 2> kRoutes{{
-    {{1, 16}, Q4Q5GdnInputScheduleId::IndependentDirectFixed},
-    {{17, kAnyCols}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C128},
+// Above the direct route the cost of a grouped MMA tile is set by its padded column width,
+// not by the live token count, so the tile is chosen to be the narrowest one that still
+// covers the extent in a single pass. Decode extents (C8 with MTP3 is 32) get the 32-wide
+// tile; the 128-wide tile remains the prefill-chunk anchor.
+constexpr std::array<RouteSpec, 4> kRoutes{{
+    {{1, 6}, Q4Q5GdnInputScheduleId::IndependentDirectFixed},
+    {{7, 32}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C32},
+    {{33, 64}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C64},
+    {{65, kAnyCols}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C128},
 }};
 
 constexpr bool catalog_is_closed() noexcept {
-    return kRoutes[0].cols.first == 1 && kRoutes[0].cols.last + 1 == kRoutes[1].cols.first &&
-           kRoutes[1].cols.last == kAnyCols;
+    std::int64_t expected = 1;
+    for (const RouteSpec& route : kRoutes) {
+        if (route.cols.first != expected || route.cols.last < route.cols.first) { return false; }
+        expected = static_cast<std::int64_t>(route.cols.last) + 1;
+    }
+    return kRoutes.back().cols.last == kAnyCols &&
+           expected == static_cast<std::int64_t>(kAnyCols) + 1;
 }
 
 static_assert(catalog_is_closed(), "GDN input routes must be exact and closed");
@@ -48,6 +59,10 @@ const char* q4_q5_gdn_input_schedule_name(Q4Q5GdnInputScheduleId schedule) noexc
     switch (schedule) {
     case Q4Q5GdnInputScheduleId::IndependentDirectFixed:
         return "gdn_input_proj.q4_q5.independent_direct_fixed";
+    case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C32:
+        return "gdn_input_proj.q4_q5.grouped_mixed.mma.r64.c32";
+    case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C64:
+        return "gdn_input_proj.q4_q5.grouped_mixed.mma.r64.c64";
     case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C128:
         return "gdn_input_proj.q4_q5.grouped_mixed.mma.r64.c128";
     }
@@ -118,6 +133,12 @@ void q4_q5_gdn_input_execute_plan(const Q4Q5GdnInputPlan& plan, const Tensor& x,
         q4_q5_gdn_input_independent_launch(x, qk_weight, value_z_weight, qk, value, z, stream);
         return;
     }
+    case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C32:
+        q4_q5_gdn_input_grouped_mma_c32_launch(x, qk_weight, value_z_weight, qkv, z, stream);
+        return;
+    case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C64:
+        q4_q5_gdn_input_grouped_mma_c64_launch(x, qk_weight, value_z_weight, qkv, z, stream);
+        return;
     case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C128:
         q4_q5_gdn_input_grouped_mma_launch(x, qk_weight, value_z_weight, qkv, z, stream);
         return;

--- a/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.h
+++ b/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.h
@@ -11,6 +11,8 @@ namespace ninfer::ops::detail {
 
 enum class Q4Q5GdnInputScheduleId {
     IndependentDirectFixed,
+    GroupedMixedMmaR64C32,
+    GroupedMixedMmaR64C64,
     GroupedMixedMmaR64C128,
 };
 

--- a/src/ops/linear/w8/w8_dispatch.cpp
+++ b/src/ops/linear/w8/w8_dispatch.cpp
@@ -32,7 +32,10 @@ W8Launch select_w8_a16_launch(std::int32_t n, std::int32_t k, std::int32_t t) {
             if (t <= 48) { return launch_w8_mma_r64x16_c48_k128_a1; }
             return launch_w8_mma_r64_c128;
         case 248320:
-            if (t <= 33) { return launch_w8_small_t; }
+            // The exact-T kernel's cost grows with T while the 48-wide MMA tile is flat
+            // across the extents it covers, so the vocabulary crossover sits at 26 on
+            // sm_86, not at the top of the exact-T family.
+            if (t <= 26) { return launch_w8_small_t; }
             if (t <= 48) { return launch_w8_mma_r64x16_c48_k128_a1; }
             if (t <= 64) { return launch_w8_mma_r32_c64; }
             return launch_w8_mma_r64_c128;

--- a/src/ops/linear_add/q5/q5_linear_add_gemm_mma.cu
+++ b/src/ops/linear_add/q5/q5_linear_add_gemm_mma.cu
@@ -15,6 +15,11 @@ namespace {
 using MmaR64C16Schedule =
     Q5RowSplitMmaGemmSchedule<64, 16, 64, 16, 8, 2, 3, Q5FragmentPipeline::Serial, Cache::cg,
                               Cache::cg, Q5ScaleLoad::Pair32>;
+// A tile narrower than the live extent costs a full weight pass per column slice: at the 32
+// columns a C8 MTP3 round produces, the 16-wide tile reads the whole projection twice.
+using MmaR64C32Schedule =
+    Q5RowSplitMmaGemmSchedule<64, 32, 64, 16, 8, 2, 2, Q5FragmentPipeline::Serial, Cache::cg,
+                              Cache::cg, Q5ScaleLoad::Pair32>;
 using MmaR64C24Schedule =
     Q5RowSplitMmaGemmSchedule<64, 24, 64, 16, 8, 2, 2, Q5FragmentPipeline::Serial, Cache::cg,
                               Cache::cg, Q5ScaleLoad::Pair32>;
@@ -66,6 +71,11 @@ void launch_route(const Tensor& x, const Weight& w, Tensor& residual_out, cudaSt
 void q5_linear_add_mma_r64_c16_launch(const Tensor& x, const Weight& w, Tensor& residual_out,
                                       cudaStream_t stream) {
     launch_route<MmaR64C16Schedule>(x, w, residual_out, stream);
+}
+
+void q5_linear_add_mma_r64_c32_launch(const Tensor& x, const Weight& w, Tensor& residual_out,
+                                      cudaStream_t stream) {
+    launch_route<MmaR64C32Schedule>(x, w, residual_out, stream);
 }
 
 void q5_linear_add_mma_r64_c24_launch(const Tensor& x, const Weight& w, Tensor& residual_out,

--- a/src/ops/linear_add/q5/q5_linear_add_kernels.h
+++ b/src/ops/linear_add/q5/q5_linear_add_kernels.h
@@ -14,6 +14,8 @@ void q5_linear_add_mma_r64_c16_launch(const Tensor& x, const Weight& w, Tensor& 
                                       cudaStream_t stream);
 void q5_linear_add_mma_r64_c24_launch(const Tensor& x, const Weight& w, Tensor& residual_out,
                                       cudaStream_t stream);
+void q5_linear_add_mma_r64_c32_launch(const Tensor& x, const Weight& w, Tensor& residual_out,
+                                      cudaStream_t stream);
 void q5_linear_add_mma_r64_c64_launch(const Tensor& x, const Weight& w, Tensor& residual_out,
                                       cudaStream_t stream);
 void q5_linear_add_mma_r64_c128_launch(const Tensor& x, const Weight& w, Tensor& residual_out,

--- a/src/ops/linear_add/q5/q5_linear_add_plan.cpp
+++ b/src/ops/linear_add/q5/q5_linear_add_plan.cpp
@@ -36,10 +36,13 @@ constexpr std::array<SupportSpec, 2> kSupports{{
     {5120, 17408, 17408},
 }};
 
-constexpr std::array<RouteSpec, 6> kK6144Routes{{
+// A tile narrower than the live extent repeats the whole weight pass per column slice, so
+// above 16 columns the 32-wide tile covers a decode round in one pass instead of two.
+constexpr std::array<RouteSpec, 7> kK6144Routes{{
     {{1, 1}, Q5LinearAddScheduleId::GemvResidual},
-    {{2, 13}, Q5LinearAddScheduleId::Split2ExactResidual},
-    {{14, 32}, Q5LinearAddScheduleId::MmaResidualR64C16},
+    {{2, 10}, Q5LinearAddScheduleId::Split2ExactResidual},
+    {{11, 16}, Q5LinearAddScheduleId::MmaResidualR64C16},
+    {{17, 32}, Q5LinearAddScheduleId::MmaResidualR64C32},
     {{33, 48}, Q5LinearAddScheduleId::MmaResidualR64C24},
     {{49, 128}, Q5LinearAddScheduleId::MmaResidualR64C64},
     {{129, kAnyCols}, Q5LinearAddScheduleId::MmaResidualR64C128},
@@ -47,8 +50,8 @@ constexpr std::array<RouteSpec, 6> kK6144Routes{{
 
 constexpr std::array<RouteSpec, 6> kK17408Routes{{
     {{1, 1}, Q5LinearAddScheduleId::GemvResidual},
-    {{2, 16}, Q5LinearAddScheduleId::Split2ExactResidual},
-    {{17, 32}, Q5LinearAddScheduleId::MmaResidualR64C16},
+    {{2, 10}, Q5LinearAddScheduleId::Split2ExactResidual},
+    {{11, 32}, Q5LinearAddScheduleId::MmaResidualR64C32},
     {{33, 48}, Q5LinearAddScheduleId::MmaResidualR64C24},
     {{49, 128}, Q5LinearAddScheduleId::MmaResidualR64C64},
     {{129, kAnyCols}, Q5LinearAddScheduleId::MmaResidualR64C128},
@@ -90,6 +93,8 @@ const char* q5_linear_add_schedule_name(Q5LinearAddScheduleId schedule) noexcept
         return "linear_add.q5.mma.r64.c16.cta_collective_residual";
     case Q5LinearAddScheduleId::MmaResidualR64C24:
         return "linear_add.q5.mma.r64.c24.cta_collective_residual";
+    case Q5LinearAddScheduleId::MmaResidualR64C32:
+        return "linear_add.q5.mma.r64.c32.cta_collective_residual";
     case Q5LinearAddScheduleId::MmaResidualR64C64:
         return "linear_add.q5.mma.r64.c64.cta_collective_residual";
     case Q5LinearAddScheduleId::MmaResidualR64C128:
@@ -149,6 +154,9 @@ void q5_linear_add_execute_plan(const Q5LinearAddPlan& plan, const Tensor& x, co
         return;
     case Q5LinearAddScheduleId::MmaResidualR64C24:
         q5_linear_add_mma_r64_c24_launch(x, w, residual_out, stream);
+        return;
+    case Q5LinearAddScheduleId::MmaResidualR64C32:
+        q5_linear_add_mma_r64_c32_launch(x, w, residual_out, stream);
         return;
     case Q5LinearAddScheduleId::MmaResidualR64C64:
         q5_linear_add_mma_r64_c64_launch(x, w, residual_out, stream);

--- a/src/ops/linear_add/q5/q5_linear_add_plan.h
+++ b/src/ops/linear_add/q5/q5_linear_add_plan.h
@@ -14,6 +14,7 @@ enum class Q5LinearAddScheduleId {
     Split2ExactResidual,
     MmaResidualR64C16,
     MmaResidualR64C24,
+    MmaResidualR64C32,
     MmaResidualR64C64,
     MmaResidualR64C128,
 };

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
@@ -33,8 +33,13 @@ constexpr Q4LinearSwiGluProblem kShape{34816, 17408, 5120, 5120, 1};
 
 constexpr std::array<RouteSpec, 10> kRoutes{{
     {{1, 1}, Q4LinearSwiGluScheduleId::GemvPair},
-    {{2, 32}, Q4LinearSwiGluScheduleId::SmallTExact},
-    {{33, 40}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C40},
+    // The exact-T route's cost rises with T; the 40-wide pair tile's is set by its padded
+    // width and is flat across the extents it covers. On sm_86 they cross at 25, inside the
+    // range a C8 MTP3 decode round uses. Tiles narrower than 40 were measured and are not
+    // worth routing: the split-half-pair kernel is not issue-bound at these widths, so a
+    // 16-wide tile only loses occupancy (+29.9% against the exact route at T=16).
+    {{2, 24}, Q4LinearSwiGluScheduleId::SmallTExact},
+    {{25, 40}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C40},
     {{41, 48}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C48},
     {{49, 128}, Q4LinearSwiGluScheduleId::Materialized},
     {{129, 256}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},

--- a/src/serve/http_server.cpp
+++ b/src/serve/http_server.cpp
@@ -218,11 +218,18 @@ HttpServer::HttpServer(ServeOptions options, std::shared_ptr<spdlog::logger> log
                                                             options_.response_store_max_bytes),
       operational_log_(logger),
       request_jsonl_(options_.request_log_jsonl, options_.artifact_path, std::move(logger)) {
-    const std::size_t queued_requests =
-        static_cast<std::size_t>(options_.max_concurrency) + options_.max_pending_requests;
-    const std::size_t worker_count = queued_requests + 1;
-    server_.new_task_queue         = [queued_requests, worker_count] {
-        return new httplib::ThreadPool(worker_count, worker_count, queued_requests);
+    // cpp-httplib is thread-per-connection: a worker is held for a connection's whole
+    // life, including the idle keep-alive window between requests. Sizing the pool to the
+    // request-lifetime capacity alone lets idle pooled connections occupy every worker, at
+    // which point a C8 server accepts and runs requests strictly one at a time. Base
+    // workers cover the admissible request capacity; the headroom is grown on demand for
+    // connections that are merely open, and those dynamic workers retire once idle.
+    constexpr std::size_t kKeepAliveWorkerHeadroom = 64;
+    const std::size_t request_workers =
+        static_cast<std::size_t>(options_.max_concurrency) + options_.max_pending_requests + 1;
+    const std::size_t worker_limit = request_workers + kKeepAliveWorkerHeadroom;
+    server_.new_task_queue         = [request_workers, worker_limit] {
+        return new httplib::ThreadPool(request_workers, worker_limit, worker_limit);
     };
     server_.set_socket_options(configure_http_server_socket);
     server_.set_payload_max_length(options_.max_request_bytes);

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -31,7 +31,11 @@ struct ServeOptions {
     KvCapacityPolicy kv_capacity       = KvCapacityPolicy::explicit_capacity(8192);
     std::uint32_t max_concurrency      = 1;
     std::uint32_t max_pending_requests = 16;
-    std::uint32_t pending_timeout_ms   = 30000;
+    // Admission waits behind the active set, so the deadline has to cover the generation
+    // time of the requests ahead in the FIFO. One 1K-token response already runs past 15 s
+    // at C1 on an RTX 3090, and a 6.5K-token one past 100 s; a 30 s deadline expired those
+    // callers before they were ever admitted.
+    std::uint32_t pending_timeout_ms   = 600000;
     std::uint32_t prefill_chunk        = 1024;
     std::filesystem::path context_cost_presets;
     std::uint32_t log_stats_interval_ms    = 5000; // 0 disables periodic Engine throughput logs

--- a/tests/ops/linear/test_w8_a16.cpp
+++ b/tests/ops/linear/test_w8_a16.cpp
@@ -16,8 +16,8 @@ int w8_a16_conformance() {
     int failures = 0;
 
     constexpr std::array kN248320K5120{
-        a16(1),  a16(6),  a16(16), a16(17), a16(32), a16(33),
-        a16(34), a16(48), a16(49), a16(64), a16(65),
+        a16(1),  a16(6),  a16(16), a16(17), a16(26), a16(27), a16(32),
+        a16(33), a16(34), a16(48), a16(49), a16(64), a16(65),
     };
     failures += run_shape("W8_A16", ActivationCompute::A16, make_w8g32_f16s_weight,
                           {248320, 5120, 197U, Comparison::Sampled, false, kN248320K5120});

--- a/tests/ops/linear_add/test_q5_a16.cpp
+++ b/tests/ops/linear_add/test_q5_a16.cpp
@@ -12,15 +12,15 @@ using ninfer::test::linear_add::WeightFormat;
 int q5_a16_conformance() {
     // Starts of the registered positive-T regions. run_shape checks b-1/b/b+1 for every start,
     // plus one interior point for every region, through the public Op.
-    constexpr std::array<std::int32_t, 5> kK6144RouteStarts{2, 14, 33, 49, 129};
-    constexpr std::array<std::int32_t, 6> kK6144RouteInteriors{1, 8, 24, 40, 96, 256};
+    constexpr std::array<std::int32_t, 6> kK6144RouteStarts{2, 11, 17, 33, 49, 129};
+    constexpr std::array<std::int32_t, 7> kK6144RouteInteriors{1, 6, 14, 24, 40, 96, 256};
 
     int failures = 0;
     failures += ninfer::test::linear_add::run_shape(
         "Q5_A16 LinearAdd", WeightFormat::Q5G64F16S,
         ShapeCase{5120, 6144, 401U, kK6144RouteStarts, kK6144RouteInteriors});
-    constexpr std::array<std::int32_t, 5> kK17408RouteStarts{2, 17, 33, 49, 129};
-    constexpr std::array<std::int32_t, 6> kK17408RouteInteriors{1, 8, 24, 40, 96, 256};
+    constexpr std::array<std::int32_t, 5> kK17408RouteStarts{2, 11, 33, 49, 129};
+    constexpr std::array<std::int32_t, 6> kK17408RouteInteriors{1, 6, 24, 40, 96, 256};
     failures += ninfer::test::linear_add::run_shape(
         "Q5_A16 LinearAdd", WeightFormat::Q5G64F16S,
         ShapeCase{5120, 17408, 409U, kK17408RouteStarts, kK17408RouteInteriors});

--- a/tests/ops/linear_swiglu/test_q4_a16.cpp
+++ b/tests/ops/linear_swiglu/test_q4_a16.cpp
@@ -11,8 +11,9 @@ int main() {
     try {
         // Public numerical cases straddle each registered Q4 implementation interval. They make
         // no assertion about the private route selected for any T.
-        constexpr std::array<std::int32_t, 18> kTokenCases{
-            1, 2, 32, 33, 40, 41, 48, 49, 128, 129, 256, 257, 384, 385, 512, 513, 640, 641,
+        constexpr std::array<std::int32_t, 20> kTokenCases{
+            1,   2,   24,  25,  32,  33,  40,  41,  48,  49,
+            128, 129, 256, 257, 384, 385, 512, 513, 640, 641,
         };
         const int failures = run_profile(
             "LinearSwiGLU Q4_A16",

--- a/tests/ops/test_attn_input_proj.cpp
+++ b/tests/ops/test_attn_input_proj.cpp
@@ -93,7 +93,9 @@ int run_q4_q5() {
         quantized_weight::make_patterned_weight(QType::Q5G64_F16S, kParent, kHidden, 107U));
 
     int failures = 0;
-    for (const std::int32_t tokens : {1, 2, 16, 17, 21, 48}) {
+    // One exactly-filled and one partially-filled extent per route: parent-split (1, 2, 8),
+    // the 32-wide pair tile (9, 16, 32), and the 64-wide tile that carries prefill (33, 64, 65).
+    for (const std::int32_t tokens : {1, 2, 8, 9, 16, 32, 33, 64, 65}) {
         failures += run_q4_q5_case(query_key, gate_value, tokens);
     }
     return failures;

--- a/tests/ops/test_gdn_input_proj.cpp
+++ b/tests/ops/test_gdn_input_proj.cpp
@@ -77,7 +77,10 @@ int run_q4_q5() {
     DevicePackedWeight value_z_weight(
         quantized_weight::make_patterned_weight(QType::Q5G64_F16S, 12288, kHidden, 419U));
     int failures = 0;
-    for (const std::int32_t tokens : {1, 2, 16, 17}) {
+    // One exactly-filled and one partially-filled extent per route: direct (1, 2, 6),
+    // the 32- and 64-wide grouped MMA tiles (7, 32, 33, 64), and the 128-wide tile
+    // that carries prefill chunks (65, 128).
+    for (const std::int32_t tokens : {1, 2, 6, 7, 16, 32, 33, 64, 65, 128}) {
         failures += run_q4_q5_case(query_key, value_z_weight, tokens);
     }
     return failures;


### PR DESCRIPTION
Verified on the RTX 3090 host against `qwen3.8-27b/groupwise-int`
(`qwen3_8_27b.ninfer`, 16.96 GiB), sm_86, driver 610.88, `build-ninja`.

## Results

| Metric | Before | After | Change |
|---|---:|---:|---:|
| C1 decode tok/s | 78.61 | 78.71 | +0.1% |
| C2 decode tok/s | 90.62 | 96.04 | +6.0% |
| **C4 decode tok/s** | 100.29 | 139.91 | **+39.5%** |
| **C8 decode tok/s** | 180.26 | 250.26 | **+38.8%** |
| Steady round C4 / C8 | 118.2 / 127.3 ms | 82.6 / 93.3 ms | -30% / -27% |
| C8 / C1 scaling | 2.29x | 3.18x | — |
| Prefill tok/s (C1 to C8) | 1168-1174 | 1170-1177 | unchanged |
| TTFT C4 / C8 (1K gen) | 452 / 955 ms | 420 / 866 ms | -7% / -9% |
| Peak VRAM C8 | 20,895 MiB | 20,903 MiB | +8 MiB |

Methodology: 1,024 output tokens per request, 8K per-request context, INT8 KV,
MTP3 with `--lm-head-draft`, greedy, prefix reuse off. Prefill measured
separately with 4,403 fresh input tokens per request.

| Multi-client case | Before | After |
|---|---|---|
| C1 request queued behind a 106 s generation | **503 `request_queue_timeout` at 30.04 s** | 200 at 108.5 s |
| C8: 8 requests behind 40 idle keep-alive sockets | **fully serialized**, 3.32 s, 0.39 s apart | 2.38 s — matches the 0-idle control |
| C8: 60 idle keep-alive sockets | 41 later `/health` failures | 0 |
| C8: 150 idle keep-alive sockets | not run | wave 2.58 s, 0 request failures |
| C8: 4 streams while a 4,904-token prompt ingests | max gap **1,043 ms**, p99 904 ms | 515/513 ms at chunk 512 (now shipped) |

Median decode inter-token gap is 82 ms throughout.

## What changed

**Kernels/routes.** A decode round covers `concurrency x (draft window + 1)`
columns, and above the single-token point these routes cost their *padded tile
width*, not their live column count. Every crossover had been placed for a 5090.
An nsys capture of a steady C8 round (`--cuda-graph-trace=node`, required — the
whole MTP round is otherwise one opaque graph entry) put 73.7% of a 122.97 ms
round in three ops: the gate/up SwiGLU at 26.6%, the fused down and output
projections at 25.5%, and the GDN input projection at 21.6%. Each is re-routed
to the narrowest tile that covers the extent in one pass; new tiles are
instantiations of existing schedules, and the superseded attention `r16c64s3`
route is removed. Operator medians at T=32 fall 47.5% / 43.6% / 29.4% / 21.0% /
16.9%, and at T=16 by 55.2% / 41.6% / 45.7%.

**Serving.** `--pending-timeout-ms` now defaults to 600,000 ms: admission waits
out the generations ahead of it with no preemption, so the deadline must cover
generation time rather than connection time. The HTTP pool was constructed with
`max == base` threads, disabling the dynamic-worker growth cpp-httplib 0.54.1
provides, so idle pooled sockets occupied every worker; base workers now cover
the admissible request capacity with 64 grown on demand and retired when idle.
The concurrent launcher moves to `--prefill-chunk 512`, which halves the
worst-case stall for a 0.5% ingestion loss.

## Verification

- All 16 affected operator tests pass against their independent FP32/FP64
  oracles, with route-boundary coverage added at every new crossover.
- Full suite: 110/110 pass (6 pre-existing skips needing real artifacts).
- End-to-end C1/C2/C4/C8 decode and prefill re-measured; per-kernel attribution
  re-profiled and confirms every new route is live.

## Deliberately not changed

- Narrow 16/24-wide SwiGLU pair tiles were built and measured, then removed:
  that kernel is not issue-bound at those widths and lost 29.9% to the exact
  route at T=16.
- Plain q4/q5 linear dispatch: absent from the C8 decode profile (the decode
  path is entirely fused ops); its 128-wide tile is correct for prefill.
- MTP draft window stays at 3 — measured C1 69.67/78.71/72.81 and C8
  221.79/250.26/209.86 for k=2/3/4.
- No attempt to fuse decode rows into prefill units; the measured cost of the
  current alternation is reported instead.

## Known gaps

- A C1 nsys capture could not be obtained: two attempts produced a valid report
  with no CUDA kernel data, while the identical script works at C8. C1
  attribution rests on the operator sweeps, which match profiled production
  kernel times within ~2%.
- No `linear_add` k=6144 baseline sweep was captured before the change; the
  k=17408 shape exercises the same route change and the end-to-end numbers
  cover both.
