### PR TITLE
DO NOT MERGE: prefill/decode overlap on a second lane (negative result)

### DIFF
--- a/bench/targets/qwen3_6_27b/target_mtp_round_bench.cpp
+++ b/bench/targets/qwen3_6_27b/target_mtp_round_bench.cpp
@@ -143,6 +143,7 @@ int run(const Options& options) {
     engine.use_cuda_graph            = options.use_cuda_graph;
 
     ninfer::DeviceContext device(options.device);
+    ninfer::DeviceContext prefill_device(options.device, ninfer::StreamPriority::Low);
     ninfer::artifact::Reader reader(options.artifact);
     const auto weights_profile = target::Package::resolve_weights(reader.identity());
     ninfer::artifact::Binder binder(reader);
@@ -160,7 +161,8 @@ int run(const Options& options) {
     auto sequence = std::move(planner).finalize(resolution.main_page_groups);
     const ninfer::StartupObserver startup_observer;
     auto program =
-        target::Package::create_program(*model, std::move(sequence), device, startup_observer);
+        target::Package::create_program(*model, std::move(sequence), device, prefill_device,
+                                        startup_observer);
     ninfer::runtime::ResolvedExecutionOptions execution;
     execution.requested_output_tokens = 1 + measured_rounds * (options.draft_tokens + 1);
     execution.allow_prefix_reuse      = false;

--- a/bench/targets/qwen3_6_35b_a3b/dflash_round_bench.cpp
+++ b/bench/targets/qwen3_6_35b_a3b/dflash_round_bench.cpp
@@ -213,6 +213,7 @@ int run(const Options& options) {
     engine.max_concurrency           = options.batch_size;
 
     ninfer::DeviceContext device(options.device);
+    ninfer::DeviceContext prefill_device(options.device, ninfer::StreamPriority::Low);
     ninfer::artifact::Reader reader(options.artifact);
     const auto weights_profile = target::Package::resolve_weights(reader.identity());
     ninfer::artifact::Binder binder(reader);
@@ -242,7 +243,8 @@ int run(const Options& options) {
     auto frontend = target::Package::make_frontend(*model, engine);
     const ninfer::StartupObserver startup_observer;
     auto program =
-        target::Package::create_program(*model, std::move(sequence), device, startup_observer);
+        target::Package::create_program(*model, std::move(sequence), device, prefill_device,
+                                        startup_observer);
     ninfer::runtime::ResolvedExecutionOptions execution;
     execution.requested_output_tokens = 1 + measured_rounds * (options.draft_tokens + 1);
     execution.allow_prefix_reuse      = false;

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -168,6 +168,10 @@ struct EngineOptions {
     std::uint32_t max_concurrency      = 1;
     std::uint32_t max_pending_requests = 16;
     std::uint32_t pending_timeout_ms   = 30000;
+    // A staged prefill chunk may share a device boundary with a decode round, each on its own
+    // stream and workspace arena. Disable to restore the strictly serial one-unit-per-boundary
+    // order.
+    bool prefill_overlap               = true;
     std::uint32_t prefill_chunk        = 1024;
     KvCacheStorage kv_cache            = KvCacheStorage::BFloat16;
     SpeculativeOptions speculative;

--- a/src/core/device.cu
+++ b/src/core/device.cu
@@ -27,6 +27,20 @@ void destroy_stream(cudaStream_t& stream) noexcept {
     }
 }
 
+// Compute-stream rank for a lane. CUDA orders priorities low-value-is-higher, and the usable
+// range is device-reported rather than fixed, so both ends are queried instead of assumed.
+int stream_priority_value(StreamPriority priority) {
+    if (priority == StreamPriority::Default) { return 0; }
+    int least    = 0;
+    int greatest = 0;
+    const cudaError_t err = cudaDeviceGetStreamPriorityRange(&least, &greatest);
+    if (err != cudaSuccess) {
+        throw std::runtime_error(
+            cuda_error_message("cudaDeviceGetStreamPriorityRange failed", err));
+    }
+    return priority == StreamPriority::High ? greatest : least;
+}
+
 void destroy_event(cudaEvent_t& event) noexcept {
     if (event != nullptr) {
         log_cuda_error("cudaEventDestroy", cudaEventDestroy(event));
@@ -43,7 +57,7 @@ void cuda_check(cudaError_t err, const char* expr, const char* file, int line) {
     std::abort();
 }
 
-DeviceContext::DeviceContext(int device_id) : device(device_id) {
+DeviceContext::DeviceContext(int device_id, StreamPriority priority) : device(device_id) {
     int count       = 0;
     cudaError_t err = cudaGetDeviceCount(&count);
     if (err != cudaSuccess) {
@@ -62,10 +76,13 @@ DeviceContext::DeviceContext(int device_id) : device(device_id) {
     cudaStream_t compute = nullptr;
     cudaStream_t load    = nullptr;
     cudaStream_t vision  = nullptr;
-    err                  = cudaStreamCreateWithFlags(&compute, cudaStreamNonBlocking);
+    // Only the compute stream is ranked. Transfers and vision encodes keep the default rank:
+    // they are already event-ordered against the lanes that consume them.
+    err = cudaStreamCreateWithPriority(&compute, cudaStreamNonBlocking,
+                                       stream_priority_value(priority));
     if (err != cudaSuccess) {
         throw std::runtime_error(
-            cuda_error_message("cudaStreamCreateWithFlags(stream) failed", err));
+            cuda_error_message("cudaStreamCreateWithPriority(stream) failed", err));
     }
 
     err = cudaStreamCreateWithFlags(&load, cudaStreamNonBlocking);

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -18,6 +18,16 @@ struct DeviceExecutionView {
     std::int32_t multiprocessor_count = 0;
 };
 
+// Scheduling rank of a context's compute stream. Two contexts on one device form the decode and
+// prefill execution lanes; when both have runnable kernels the decode lane must win the SMs,
+// because it owns every active stream's inter-token latency while prefill only owns one request's
+// ingestion rate.
+enum class StreamPriority {
+    Default,
+    High,
+    Low,
+};
+
 struct DeviceContext {
     int device                   = 0;
     cudaStream_t stream          = nullptr;
@@ -27,7 +37,7 @@ struct DeviceContext {
     cudaStream_t vision_stream = nullptr;
     cudaDeviceProp props{};
 
-    explicit DeviceContext(int device_id = 0);
+    explicit DeviceContext(int device_id = 0, StreamPriority priority = StreamPriority::Default);
     ~DeviceContext();
 
     DeviceContext(const DeviceContext&)            = delete;

--- a/src/runtime/engine/engine.cpp
+++ b/src/runtime/engine/engine.cpp
@@ -94,9 +94,18 @@ EngineOptions normalize_engine_options(EngineOptions options) {
 
 DeviceContext initialize_device(const EngineOptions& options) {
     StartupPhaseScope phase(options.startup_observer, StartupPhase::CudaInitialize);
-    DeviceContext device(options.device);
+    // Decode owns every active stream's inter-token latency, so its lane outranks prefill's
+    // whenever both have kernels queued.
+    DeviceContext device(options.device, StreamPriority::High);
     phase.complete();
     return device;
+}
+
+// The prefill lane. A second context on the same device is what lets a prefill chunk run beside
+// a decode round: it carries its own compute stream, and the Program gives it its own workspace
+// arena so the two units never share scratch.
+DeviceContext initialize_prefill_device(const EngineOptions& options) {
+    return DeviceContext(options.device, StreamPriority::Low);
 }
 
 runtime::ResolvedRequestOptions resolve_request_options(const ModelSamplingDefaults& defaults,
@@ -227,9 +236,10 @@ public:
 
     explicit Impl(EngineOptions engine_options)
         : options(normalize_engine_options(std::move(engine_options))),
-          device(initialize_device(options)) {
+          device(initialize_device(options)),
+          prefill_device(initialize_prefill_device(options)) {
         nvtx::ScopedRange load_range(nvtx::Name::EngineLoad, nvtx::Category::Runtime);
-        auto constructed  = targets::construct_target(options, device);
+        auto constructed  = targets::construct_target(options, device, prefill_device);
         active            = std::move(constructed.active);
         load              = std::move(constructed.load);
         sampling_defaults = constructed.sampling_defaults;
@@ -266,6 +276,7 @@ public:
 
     EngineOptions options;
     DeviceContext device;
+    DeviceContext prefill_device;
     targets::ActiveTarget active;
     LoadSummary load;
     ModelSamplingDefaults sampling_defaults;

--- a/src/runtime/engine/engine_core.h
+++ b/src/runtime/engine/engine_core.h
@@ -68,6 +68,7 @@ public:
           max_outstanding_(static_cast<std::size_t>(options.max_concurrency) +
                            options.max_pending_requests),
           pending_timeout_(std::chrono::milliseconds(options.pending_timeout_ms)),
+          prefill_overlap_(options.prefill_overlap),
           resources_(max_concurrency_, options.context_cache.max_private_continuations.value(),
                      options.context_cache.max_shared_prefixes.value(),
                      options.context_cache.enabled,
@@ -1790,6 +1791,54 @@ private:
         }
     }
 
+    // One boundary, two device lanes. The decode graph is launched first and the staged prefill
+    // chunk is issued from inside the round's device-busy window, so the chunk shares the device
+    // with the round instead of displacing it. Both units are complete before this returns, which
+    // is what lets every later boundary rule (capture ordering, cancellation sampling, admission)
+    // stay exactly as it is for a single unit.
+    void run_overlapped_round(const RoundMembership& membership,
+                              const std::array<bool, kMaximumConcurrency>& cancelled_at_unit_start) {
+        nvtx::ScopedRange range(nvtx::Name::Decode, nvtx::Category::Decode,
+                                static_cast<std::uint64_t>(membership.size));
+        const auto prefill_lane = scheduler_.prefill_lane();
+        if (!prefill_lane) { throw std::logic_error("no request owns staged prefill"); }
+        const std::uint32_t lane = *prefill_lane;
+        const auto request       = slots_[lane];
+        if (request == nullptr || !request->is_prefilling() || request->capture_pending ||
+            !request->sequence) {
+            throw std::logic_error("staged prefill lane has invalid request state");
+        }
+
+        using DeviceBusyHook =
+            typename std::remove_reference_t<decltype(*instance_.program)>::DeviceBusyHook;
+        std::exception_ptr prefill_error;
+        runtime::ExecutionTiming prefill_failed_timing;
+        // The chunk is both issued and resolved here. The Program carries one pending
+        // transaction at a time, so the prefill's has to be settled before the round claims
+        // its own; doing it inside the window is free, because the device is busy with the
+        // round while this host work runs.
+        DeviceBusyHook hook = [&] {
+            try {
+                auto progress =
+                    instance_.program->advance_prefill(*request->sequence, &prefill_failed_timing);
+                resolve_prefill_progress(request, std::move(progress), cancelled_at_unit_start);
+            } catch (...) {
+                // The round is already in flight; let it finish and commit, then fail the
+                // prefill request alone.
+                prefill_error = std::current_exception();
+            }
+        };
+
+        ProgramCallScope program_call(*this);
+        auto pending = instance_.program->decode(membership.sequence_span(),
+                                                 membership.budget_span(),
+                                                 &program_call.failed_timing(), &hook);
+        program_call.finish(pending.execution_timing());
+        commit_pending(std::move(pending), membership.lane_span(), true, cancelled_at_unit_start);
+        if (prefill_error) { complete_error(request, prefill_error); }
+        publish_runtime_stats();
+    }
+
     void run_decode_round(const RoundMembership& membership,
                           const std::array<bool, kMaximumConcurrency>& cancelled_at_unit_start) {
         nvtx::ScopedRange decode_range(nvtx::Name::Decode, nvtx::Category::Decode,
@@ -1995,8 +2044,9 @@ private:
                         !(slots_[*lane]->sequence &&
                           instance_.program->vision_pending(*slots_[*lane]->sequence));
                 }
-                const ExecutionAction action = scheduler_.choose_execution(
-                    !membership.empty(), prefill_runnable, previous_unit_was_decode);
+                const ExecutionAction action =
+                    scheduler_.choose_execution(!membership.empty(), prefill_runnable,
+                                                previous_unit_was_decode, prefill_overlap_);
                 if (action == ExecutionAction::Prefill) {
                     set_host_work_class(HostWorkClass::Prefill);
                     finish_engine_phase(boundary, EngineHostPhase::Boundary);
@@ -2008,6 +2058,15 @@ private:
                     set_host_work_class(HostWorkClass::Decode, membership.lane_span());
                     finish_engine_phase(boundary, EngineHostPhase::Boundary);
                     run_decode_round(membership, cancelled_at_unit_start);
+                    previous_unit_was_decode = true;
+                    continue;
+                }
+                if (action == ExecutionAction::PrefillAndDecode) {
+                    set_host_work_class(HostWorkClass::Decode, membership.lane_span());
+                    finish_engine_phase(boundary, EngineHostPhase::Boundary);
+                    run_overlapped_round(membership, cancelled_at_unit_start);
+                    // The pair contains a decode round, so admission treats it as one: a prefill
+                    // that shares a boundary with decode has not starved the decode lane.
                     previous_unit_was_decode = true;
                     continue;
                 }
@@ -2035,6 +2094,8 @@ private:
     const std::uint32_t max_concurrency_;
     const std::size_t max_outstanding_;
     const std::chrono::milliseconds pending_timeout_;
+    // Whether a staged prefill chunk may share a boundary with a decode round.
+    const bool prefill_overlap_ = true;
     ResourceManagement resources_;
 
     mutable std::mutex execution_mutex_;

--- a/src/runtime/engine/scheduler.h
+++ b/src/runtime/engine/scheduler.h
@@ -26,6 +26,10 @@ public:
     enum class ExecutionAction : std::uint8_t {
         Prefill,
         Decode,
+        // One decode round and one staged prefill chunk issued together, on separate device
+        // lanes. Both complete before the next boundary, so every rule that holds for a single
+        // unit still holds for the pair.
+        PrefillAndDecode,
         Wait,
     };
 
@@ -237,8 +241,15 @@ public:
                (!have_decode || previous_unit_was_decode);
     }
 
+    // With overlap available the two runnable units no longer compete for the round boundary,
+    // so the 1:1 alternation that used to ration it is unnecessary: issue both. Without it the
+    // alternation stands, because one lane must still take turns.
     [[nodiscard]] ExecutionAction choose_execution(bool have_decode, bool prefill_runnable,
-                                                   bool previous_unit_was_decode) const noexcept {
+                                                   bool previous_unit_was_decode,
+                                                   bool overlap_available) const noexcept {
+        if (prefill_runnable && have_decode && overlap_available) {
+            return ExecutionAction::PrefillAndDecode;
+        }
         if (prefill_runnable) {
             return have_decode && !previous_unit_was_decode ? ExecutionAction::Decode
                                                             : ExecutionAction::Prefill;

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -276,6 +276,7 @@ GenerationService::GenerationService(ServeOptions options, StartupObserver start
     engine_options.max_concurrency          = options_.max_concurrency;
     engine_options.max_pending_requests     = options_.max_pending_requests;
     engine_options.pending_timeout_ms       = options_.pending_timeout_ms;
+    engine_options.prefill_overlap          = options_.prefill_overlap;
     engine_options.prefill_chunk            = options_.prefill_chunk;
     engine_options.kv_cache                 = options_.kv_cache;
     engine_options.enable_vision            = options_.enable_vision;

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -71,6 +71,7 @@ std::string serve_usage_text(const char* argv0) {
            " <model.ninfer> [--host H] [--port N] [--api-key KEY] "
            "[--model-id ID] [--max-context N] [--kv-capacity N|auto] [--max-concurrency N] "
            "[--max-pending-requests N] [--pending-timeout-ms N] "
+           "[--no-prefill-overlap] "
            "[--prefill-chunk N] [--log-stats-interval-ms N] [--device N] "
            "[--context-cost-presets FILE] "
            "[--max-request-mib N] [--media-cache-mib N] [--media-live-mib N] "
@@ -173,6 +174,8 @@ ServeOptions parse_serve_options(int argc, char** argv) {
         } else if (arg == "--max-pending-requests") {
             options.max_pending_requests = static_cast<std::uint32_t>(parse_nonnegative_int(
                 require_value("--max-pending-requests"), "max-pending-requests"));
+        } else if (arg == "--no-prefill-overlap") {
+            options.prefill_overlap = false;
         } else if (arg == "--pending-timeout-ms") {
             options.pending_timeout_ms = static_cast<std::uint32_t>(
                 parse_nonnegative_int(require_value("--pending-timeout-ms"), "pending-timeout-ms"));

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -37,6 +37,10 @@ struct ServeOptions {
     // callers before they were ever admitted.
     std::uint32_t pending_timeout_ms   = 600000;
     std::uint32_t prefill_chunk        = 1024;
+    // A staged prefill chunk may share a device boundary with a decode round, each on its own
+    // stream and workspace arena. Disable to restore the strictly serial one-unit-per-boundary
+    // order.
+    bool prefill_overlap               = true;
     std::filesystem::path context_cost_presets;
     std::uint32_t log_stats_interval_ms    = 5000; // 0 disables periodic Engine throughput logs
     std::size_t max_request_bytes          = kDefaultMaxRequestBytes;

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <array>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <span>
@@ -913,9 +914,15 @@ public:
         const SharedPrefixHandle<Variant>* replacement,
         std::optional<runtime::CheckpointRef> private_replacement, bool permit_shared_publication,
         CapturePressurePlan<Variant>&& pressure, runtime::CancellationFlagView cancellation);
+// Host work to run while a decode round is in flight on the device. The Engine passes the
+// staged prefill chunk here: the decode graph is already launched on the decode stream, so a
+// chunk issued on the prefill lane's own stream and arena overlaps it instead of waiting for
+// the round boundary. Null restores the strictly serial unit order.
+    using DeviceBusyHook = std::function<void()>;
     [[nodiscard]] PendingBatch<Variant> decode(std::span<const SequenceHandle<Variant>> sequences,
                                                std::span<const runtime::RoundBudget> budgets,
-                                               runtime::ExecutionTiming* failed_timing = nullptr);
+                                               runtime::ExecutionTiming* failed_timing = nullptr,
+                                               const DeviceBusyHook* device_busy = nullptr);
     // Advance each live sequence with its exact target-owned token row. This does not sample or
     // advance sampler RNG/occurrence state; callers own output publication and budget accounting.
     // Each optional execution split is relative to its row's forced-token span.
@@ -951,7 +958,8 @@ private:
     template <class V>
     friend std::unique_ptr<Program<V>> create_program(const typename V::ModelView&,
                                                       typename V::WeightsProfile, SequencePlan<V>&&,
-                                                      DeviceContext&, const StartupObserver&);
+                                                      DeviceContext&, DeviceContext&,
+                                                      const StartupObserver&);
 };
 
 namespace detail {
@@ -1116,6 +1124,7 @@ template <class Variant>
 [[nodiscard]] std::unique_ptr<Program<Variant>>
 create_program(const typename Variant::ModelView& model,
                typename Variant::WeightsProfile weights_profile, SequencePlan<Variant>&& plan,
-               DeviceContext& device, const StartupObserver& startup_observer);
+               DeviceContext& device, DeviceContext& prefill_device,
+               const StartupObserver& startup_observer);
 
 } // namespace ninfer::targets::qwen3_6

--- a/src/targets/qwen3_6/impl/runtime/api_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/api_impl.h
@@ -520,8 +520,9 @@ runtime::ContextTransactionReserveStatus Program<Variant>::reserve_active_captur
 template <>
 PendingBatch<Variant> Program<Variant>::decode(std::span<const SequenceHandle<Variant>> sequences,
                                                std::span<const runtime::RoundBudget> budgets,
-                                               runtime::ExecutionTiming* failed_timing) {
-    return impl_->decode(sequences, budgets, failed_timing);
+                                               runtime::ExecutionTiming* failed_timing,
+                                               const DeviceBusyHook* device_busy) {
+    return impl_->decode(sequences, budgets, failed_timing, device_busy);
 }
 
 template <>
@@ -611,6 +612,7 @@ template <>
 std::unique_ptr<Program<Variant>>
 create_program<Variant>(const Variant::ModelView& model, Variant::WeightsProfile weights_profile,
                         SequencePlan<Variant>&& plan, DeviceContext& device,
+                        DeviceContext& prefill_device,
                         const StartupObserver& startup_observer) {
     if (plan.impl_ == nullptr) { throw std::invalid_argument("sequence plan is empty"); }
     if (plan.impl_->weights_profile != weights_profile) {
@@ -618,7 +620,7 @@ create_program<Variant>(const Variant::ModelView& model, Variant::WeightsProfile
             "loaded model weights profile does not match the sequence plan");
     }
     auto impl = std::make_unique<detail::ProgramImpl<Variant>>(model, *plan.impl_, device,
-                                                               startup_observer);
+                                                               prefill_device, startup_observer);
     plan.impl_.reset();
     return std::unique_ptr<Program<Variant>>(new Program<Variant>(std::move(impl)));
 }

--- a/src/targets/qwen3_6/impl/runtime/layouts.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts.h
@@ -66,6 +66,9 @@ struct WorkspacePlan {
     std::size_t dflash_round     = 0;
     std::size_t causal_score     = 0;
     std::size_t general_capacity = 0;
+    // Scratch peak of the units the prefill lane issues. The lane holds its own arena so a
+    // prefill chunk can refill scratch while a captured decode graph is replaying.
+    std::size_t prefill_lane_capacity = 0;
     std::optional<VisionWorkspacePlan> vision;
     // False in overlay residency: the vision encode workspace and handoff are borrowed per
     // window instead of being folded into capacity.

--- a/src/targets/qwen3_6/impl/runtime/layouts_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/layouts_impl.h
@@ -585,6 +585,10 @@ WorkspacePlan build_workspace_plan(const SequencePlanImpl& plan) {
     out.general_capacity =
         std::max({out.text_prefill, out.ordinary_round, out.mtp_prefill, out.mtp_round,
                   out.dflash_context, out.dflash_round, out.causal_score});
+    // Only the units the staged-prefill lane issues; the decode-round peaks stay with the decode
+    // arena. Causal scoring is included because it runs through the same prefill entry point.
+    out.prefill_lane_capacity = std::max({out.text_prefill, out.mtp_prefill, out.dflash_context,
+                                          out.causal_score});
     out.capacity = out.general_capacity;
     if (plan.features.vision) {
         const std::uint32_t merged = static_cast<std::uint32_t>(std::min<std::uint64_t>(
@@ -743,8 +747,12 @@ std::unique_ptr<SequencePlanImpl> build_sequence_candidate(const SequencePlannin
         }
     }
 
+    // Both workspace arenas are resident for the Program's life, so KV sizing has to see them.
+    const std::size_t workspace_resident_bytes =
+        checked_add(impl->workspace.capacity, impl->workspace.prefill_lane_capacity,
+                    "prefill lane workspace");
     impl->device_reservation_bytes = checked_add(
-        checked_add(impl->persistent.bytes, impl->workspace.capacity, "sequence memory plan"),
+        checked_add(impl->persistent.bytes, workspace_resident_bytes, "sequence memory plan"),
         impl->graph_allowance_bytes, "sequence graph allowance");
     return impl;
 }

--- a/src/targets/qwen3_6/impl/runtime/program.h
+++ b/src/targets/qwen3_6/impl/runtime/program.h
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <array>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -524,7 +525,8 @@ public:
     };
 
     ProgramImplCore(const LoadedModelData& model, const SequencePlanImpl& plan,
-                    DeviceContext& device, const StartupObserver& startup_observer);
+                    DeviceContext& device, DeviceContext& prefill_device,
+                    const StartupObserver& startup_observer);
     ~ProgramImplCore() noexcept;
 
     [[nodiscard]] RequestBasePlan plan_request(const PreparedPromptData& prompt,
@@ -595,9 +597,15 @@ public:
         const SharedPrefixHandle* replacement,
         std::optional<runtime::CheckpointRef> private_replacement, bool permit_shared_publication,
         CapturePressureCandidate&& pressure, runtime::CancellationFlagView cancellation);
+    // Host work to run while a decode round is in flight on the device. The Engine passes the
+    // staged prefill chunk here: the decode graph is already launched on the decode stream, so a
+    // chunk issued on the prefill lane's own stream and arena overlaps it instead of waiting for
+    // the round boundary. Null restores the strictly serial unit order.
+    using DeviceBusyHook = std::function<void()>;
     [[nodiscard]] PendingBatch decode(std::span<const SequenceHandle> sequences,
                                       std::span<const runtime::RoundBudget> budgets,
-                                      runtime::ExecutionTiming* failed_timing);
+                                      runtime::ExecutionTiming* failed_timing,
+                                      const DeviceBusyHook* device_busy = nullptr);
     [[nodiscard]] runtime::ExecutionTiming
     append_forced_tokens(std::span<const SequenceHandle> sequences,
                          std::span<const TokenId> row_major_tokens, std::uint32_t row_stride,
@@ -630,6 +638,8 @@ public:
 
     const LoadedModelData& model;
     DeviceContext& device;
+    // The prefill lane's context. Same device, its own compute stream, ranked below decode.
+    DeviceContext& prefill_device;
     const std::uint32_t capacity;
     const std::uint32_t kv_capacity;
     const std::uint32_t max_concurrency;
@@ -656,6 +666,11 @@ public:
     DeviceArena persistent;
     DeviceArena workspace_storage;
     WorkspaceArena work;
+    // Scratch for the prefill lane. A prefill chunk resets and refills its arena while a decode
+    // graph is in flight, and the graph bakes the decode arena's addresses at capture, so the two
+    // lanes cannot share one.
+    DeviceArena prefill_workspace_storage;
+    WorkspaceArena prefill_work;
     std::unique_ptr<qwen3_6::DecoderState> decoder;
     std::unique_ptr<HostKVArena> host_kv_arena;
     std::unique_ptr<LogicalKVPageStore> text_kv_pages;
@@ -1013,7 +1028,7 @@ private:
     advance_prefill_raw(std::uint32_t lane, runtime::ExecutionTiming* failed_timing);
     [[nodiscard]] runtime::BatchedGeneratedRound
     decode_raw(std::span<const std::uint32_t> lanes, std::span<const runtime::RoundBudget> budgets,
-               runtime::ExecutionTiming* failed_timing);
+               runtime::ExecutionTiming* failed_timing, const DeviceBusyHook* device_busy);
     [[nodiscard]] runtime::ExecutionTiming
     resolve_prefill_raw(std::uint32_t lane, bool terminal, runtime::ExecutionTiming* failed_timing);
     [[nodiscard]] runtime::ExecutionTiming resolve_pending_raw(
@@ -1239,15 +1254,18 @@ private:
     [[nodiscard]] runtime::BatchedGeneratedRound
     decode_ordinary_batch(std::span<const std::uint32_t> lanes,
                           std::span<const runtime::RoundBudget> budgets,
-                          runtime::ExecutionTiming* failed_timing);
+                          runtime::ExecutionTiming* failed_timing,
+                          const DeviceBusyHook* device_busy);
     [[nodiscard]] runtime::BatchedGeneratedRound
     decode_mtp_batch(std::span<const std::uint32_t> lanes,
                      std::span<const runtime::RoundBudget> budgets,
-                     runtime::ExecutionTiming* failed_timing);
+                     runtime::ExecutionTiming* failed_timing,
+                     const DeviceBusyHook* device_busy);
     [[nodiscard]] runtime::BatchedGeneratedRound
     decode_dflash_batch(std::span<const std::uint32_t> lanes,
                         std::span<const runtime::RoundBudget> budgets,
-                        runtime::ExecutionTiming* failed_timing);
+                        runtime::ExecutionTiming* failed_timing,
+                        const DeviceBusyHook* device_busy);
     void resize_sequence_kv_entitlement(SequenceState& sequence, std::uint32_t text_pages,
                                         std::uint32_t backend_pages);
     void bind_sequence_kv(SequenceState& sequence);

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -750,8 +750,10 @@ std::unique_ptr<EvictableKVPool> make_kv_arena(DeviceContext& device,
 } // namespace
 
 ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const SequencePlanImpl& plan,
-                                 DeviceContext& device_in, const StartupObserver& startup_observer)
-    : model(model_in), device(device_in), capacity(plan.capacity), kv_capacity(plan.kv_capacity),
+                                 DeviceContext& device_in, DeviceContext& prefill_device_in,
+                                 const StartupObserver& startup_observer)
+    : model(model_in), device(device_in), prefill_device(prefill_device_in),
+      capacity(plan.capacity), kv_capacity(plan.kv_capacity),
       max_concurrency(plan.max_concurrency), context_cache(plan.context_cache),
       continuation_capacity(normalized_private_capacity(plan.context_cache)),
       shared_prefix_capacity(plan.context_cache.max_shared_prefixes.value_or(0)),
@@ -767,6 +769,9 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
       persistent(kv_arena ? DeviceArena(kv_arena->arena()) : DeviceArena(plan.persistent.bytes)),
       workspace_storage(plan.workspace.capacity),
       work(DeviceSpan{workspace_storage.base(), plan.workspace.general_capacity}),
+      prefill_workspace_storage(plan.workspace.prefill_lane_capacity),
+      prefill_work(
+          DeviceSpan{prefill_workspace_storage.base(), plan.workspace.prefill_lane_capacity}),
       continuation_states(continuation_capacity), continuation_slots(continuation_capacity),
       shared_prefix_states(shared_prefix_capacity), shared_prefix_slots(shared_prefix_capacity),
       round_host(sizeof(TokenId)),
@@ -8804,7 +8809,8 @@ ProgramImplCore::progress_active_capture_transaction(runtime::CancellationFlagVi
 
 PendingBatch ProgramImplCore::decode(std::span<const SequenceHandle> members,
                                      std::span<const runtime::RoundBudget> budgets,
-                                     runtime::ExecutionTiming* failed_timing) {
+                                     runtime::ExecutionTiming* failed_timing,
+                                     const DeviceBusyHook* device_busy) {
     if (pending_transaction_ || members.empty() || members.size() > max_concurrency ||
         budgets.size() != members.size()) {
         throw std::invalid_argument("decode membership is invalid");
@@ -8824,7 +8830,8 @@ PendingBatch ProgramImplCore::decode(std::span<const SequenceHandle> members,
     }
     const auto lane_span = std::span<const std::uint32_t>(lanes.data(), members.size());
     try {
-        runtime::BatchedGeneratedRound round = decode_raw(lane_span, budgets, failed_timing);
+        runtime::BatchedGeneratedRound round =
+            decode_raw(lane_span, budgets, failed_timing, device_busy);
         if (failed_timing != nullptr) { *failed_timing += round.timing; }
         return wrap_pending(lane_span, std::move(round));
     } catch (...) {
@@ -11365,9 +11372,12 @@ void ProgramImplCore::copy_tail(SequenceState& sequence, const Tensor& source) {
     sequence.tail_hidden_valid = true;
 }
 
+// The token this reads is produced by the staged prefill, which runs on the prefill lane, so
+// the copy and its wait belong to that stream. Issuing it on the decode stream would queue it
+// behind an overlapped round.
 void ProgramImplCore::copy_round_token() {
     CUDA_CHECK(cudaMemcpyAsync(host_tokens, io.token.data, sizeof(TokenId), cudaMemcpyDeviceToHost,
-                               device.stream));
+                               prefill_device.stream));
 }
 
 void ProgramImplCore::mark_workspace_usage(std::size_t phase_bytes) noexcept {
@@ -11505,7 +11515,7 @@ ProgramImplCore::advance_prefill(SequenceState& sequence, RequestControl& reques
             rewrite_capture_hidden_ptr = &rewrite_capture_hidden;
         }
         schedule::PrefillContext schedule_state{
-            {device, model, work, state_images->linear(),
+            {prefill_device, model, prefill_work, state_images->linear(),
              replay_records ? &*replay_records : nullptr, io, prefill_hidden, prefill_chunk,
              proposal_head},
             text_kv_view(sequence),
@@ -11695,10 +11705,12 @@ ProgramImplCore::advance_prefill(SequenceState& sequence, RequestControl& reques
         if (staged.prepare_mtp && staged.initial_mtp_extent != 0) {
             CUDA_CHECK(cudaMemcpyAsync(initial_drafts.data(), io.mtp->draft_tokens.data,
                                        staged.initial_mtp_extent * sizeof(TokenId),
-                                       cudaMemcpyDeviceToHost, device.stream));
+                                       cudaMemcpyDeviceToHost, prefill_device.stream));
         }
         timing.begin_wait();
-        device.synchronize();
+        // Only this lane's stream: a decode round overlapping this chunk is awaited by its own
+        // caller, and waiting for it here would put the round back in front of the prefill.
+        prefill_device.synchronize();
         timing.end_wait();
         staged.elapsed_seconds += std::chrono::duration<double>(Clock::now() - started).count();
         const double vision_seconds       = staged.vision ? staged.vision->elapsed_seconds() : 0.0;
@@ -11760,6 +11772,9 @@ ProgramImplCore::advance_prefill(SequenceState& sequence, RequestControl& reques
     } catch (...) {
         timing.begin_wait();
         try {
+            // Drain both lanes before tearing the sequence down: the failure may have left
+            // work queued on either, and the decode lane may hold an overlapped round.
+            prefill_device.synchronize();
             device.synchronize();
         } catch (...) {}
         timing.end_wait();
@@ -11772,7 +11787,8 @@ ProgramImplCore::advance_prefill(SequenceState& sequence, RequestControl& reques
 runtime::BatchedGeneratedRound
 ProgramImplCore::decode_ordinary_batch(std::span<const std::uint32_t> lanes,
                                        std::span<const runtime::RoundBudget> budgets,
-                                       runtime::ExecutionTiming* failed_timing) {
+                                       runtime::ExecutionTiming* failed_timing,
+                                       const DeviceBusyHook* device_busy) {
     nvtx::ScopedRange round_range(nvtx::Name::DecodeOrdinaryRound, nvtx::Category::Decode,
                                   static_cast<std::uint64_t>(lanes.size()));
     runtime::ExecutionTimingRecorder timing(runtime::ExecutionTimingPhase::Submit, failed_timing);
@@ -11853,6 +11869,15 @@ ProgramImplCore::decode_ordinary_batch(std::span<const std::uint32_t> lanes,
         schedule::ordinary_decode_batch(schedule_state, static_cast<std::int32_t>(lanes.size()),
                                         envelope, executable);
         submit_range.reset();
+        // The round is launched; the device is busy until the wait below. Overlapped host
+        // work (a staged prefill chunk on the prefill lane) is issued here so it shares the
+        // device with the round instead of following it. Its own stream and arena keep the
+        // two units disjoint; its cost is not part of this round's submit or wait time.
+        if (device_busy != nullptr && *device_busy) {
+            timing.pause();
+            (*device_busy)();
+            timing.resume_submit();
+        }
         timing.begin_wait();
         {
             nvtx::ScopedRange wait_range(nvtx::Name::DecodeOrdinaryWait, nvtx::Category::Control,
@@ -11905,7 +11930,8 @@ ProgramImplCore::decode_ordinary_batch(std::span<const std::uint32_t> lanes,
 runtime::BatchedGeneratedRound
 ProgramImplCore::decode_mtp_batch(std::span<const std::uint32_t> lanes,
                                   std::span<const runtime::RoundBudget> budgets,
-                                  runtime::ExecutionTiming* failed_timing) {
+                                  runtime::ExecutionTiming* failed_timing,
+                                  const DeviceBusyHook* device_busy) {
     nvtx::ScopedRange round_range(nvtx::Name::DecodeMtpRound, nvtx::Category::Mtp,
                                   static_cast<std::uint64_t>(lanes.size()));
     runtime::ExecutionTimingRecorder timing(runtime::ExecutionTimingPhase::Submit, failed_timing);
@@ -12013,6 +12039,15 @@ ProgramImplCore::decode_mtp_batch(std::span<const std::uint32_t> lanes,
         schedule::mtp_decode_batch(schedule_state, static_cast<std::int32_t>(lanes.size()),
                                    draft_window, envelopes, executable);
         submit_range.reset();
+        // The round is launched; the device is busy until the wait below. Overlapped host
+        // work (a staged prefill chunk on the prefill lane) is issued here so it shares the
+        // device with the round instead of following it. Its own stream and arena keep the
+        // two units disjoint; its cost is not part of this round's submit or wait time.
+        if (device_busy != nullptr && *device_busy) {
+            timing.pause();
+            (*device_busy)();
+            timing.resume_submit();
+        }
         timing.begin_wait();
         {
             nvtx::ScopedRange wait_range(nvtx::Name::DecodeMtpWait, nvtx::Category::Control,
@@ -12089,7 +12124,8 @@ ProgramImplCore::decode_mtp_batch(std::span<const std::uint32_t> lanes,
 runtime::BatchedGeneratedRound
 ProgramImplCore::decode_dflash_batch(std::span<const std::uint32_t> lanes,
                                      std::span<const runtime::RoundBudget> budgets,
-                                     runtime::ExecutionTiming* failed_timing) {
+                                     runtime::ExecutionTiming* failed_timing,
+                                     const DeviceBusyHook* device_busy) {
     nvtx::ScopedRange round_range(nvtx::Name::DecodeDFlashRound, nvtx::Category::DFlash,
                                   static_cast<std::uint64_t>(lanes.size()));
     runtime::ExecutionTimingRecorder timing(runtime::ExecutionTimingPhase::Submit, failed_timing);
@@ -12200,6 +12236,15 @@ ProgramImplCore::decode_dflash_batch(std::span<const std::uint32_t> lanes,
         schedule::dflash_decode_batch(schedule_state, static_cast<std::int32_t>(lanes.size()),
                                       draft_window, envelopes, target_envelope, executable);
         submit_range.reset();
+        // The round is launched; the device is busy until the wait below. Overlapped host
+        // work (a staged prefill chunk on the prefill lane) is issued here so it shares the
+        // device with the round instead of following it. Its own stream and arena keep the
+        // two units disjoint; its cost is not part of this round's submit or wait time.
+        if (device_busy != nullptr && *device_busy) {
+            timing.pause();
+            (*device_busy)();
+            timing.resume_submit();
+        }
         timing.begin_wait();
         {
             nvtx::ScopedRange wait_range(nvtx::Name::DecodeDFlashWait, nvtx::Category::Control,
@@ -12275,14 +12320,15 @@ ProgramImplCore::decode_dflash_batch(std::span<const std::uint32_t> lanes,
 runtime::BatchedGeneratedRound
 ProgramImplCore::decode_raw(std::span<const std::uint32_t> lanes,
                             std::span<const runtime::RoundBudget> budgets,
-                            runtime::ExecutionTiming* failed_timing) {
+                            runtime::ExecutionTiming* failed_timing,
+                            const DeviceBusyHook* device_busy) {
     if (speculative_backend == SpeculativeBackend::None) {
-        return decode_ordinary_batch(lanes, budgets, failed_timing);
+        return decode_ordinary_batch(lanes, budgets, failed_timing, device_busy);
     }
     if (speculative_backend == SpeculativeBackend::Mtp) {
-        return decode_mtp_batch(lanes, budgets, failed_timing);
+        return decode_mtp_batch(lanes, budgets, failed_timing, device_busy);
     }
-    return decode_dflash_batch(lanes, budgets, failed_timing);
+    return decode_dflash_batch(lanes, budgets, failed_timing, device_busy);
 }
 
 runtime::ExecutionTiming ProgramImplCore::resolve_non_speculative_pending(

--- a/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
+++ b/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
@@ -138,6 +138,7 @@ struct Package {
                                                                WeightsProfile weights_profile);
     [[nodiscard]] static std::unique_ptr<Program>
     create_program(const LoadedModel& model, SequencePlan&& plan, DeviceContext& device,
+                   DeviceContext& prefill_device,
                    const StartupObserver& startup_observer);
 };
 

--- a/src/targets/qwen3_6_27b/impl/package.cpp
+++ b/src/targets/qwen3_6_27b/impl/package.cpp
@@ -144,11 +144,12 @@ Package::SequencePlanner Package::make_sequence_planner(DeviceContext& device,
 std::unique_ptr<Package::Program> Package::create_program(const LoadedModel& model,
                                                           SequencePlan&& plan,
                                                           DeviceContext& device,
+                                                         DeviceContext& prefill_device,
                                                           const StartupObserver& startup_observer) {
     if (model.impl_ == nullptr) { throw std::invalid_argument("loaded model is empty"); }
     return qwen3_6::create_program<detail::Variant>(model.impl_->data.runtime,
                                                     model.impl_->weights_profile, std::move(plan),
-                                                    device, startup_observer);
+                                                    device, prefill_device, startup_observer);
 }
 
 } // namespace ninfer::targets::qwen3_6_27b

--- a/src/targets/qwen3_6_35b_a3b/export/ninfer/targets/qwen3_6_35b_a3b/package.h
+++ b/src/targets/qwen3_6_35b_a3b/export/ninfer/targets/qwen3_6_35b_a3b/package.h
@@ -133,6 +133,7 @@ struct Package {
                                                                WeightsProfile weights_profile);
     [[nodiscard]] static std::unique_ptr<Program>
     create_program(const LoadedModel& model, SequencePlan&& plan, DeviceContext& device,
+                   DeviceContext& prefill_device,
                    const StartupObserver& startup_observer);
 };
 

--- a/src/targets/qwen3_6_35b_a3b/impl/package.cpp
+++ b/src/targets/qwen3_6_35b_a3b/impl/package.cpp
@@ -116,11 +116,12 @@ Package::SequencePlanner Package::make_sequence_planner(DeviceContext& device,
 std::unique_ptr<Package::Program> Package::create_program(const LoadedModel& model,
                                                           SequencePlan&& plan,
                                                           DeviceContext& device,
+                                                         DeviceContext& prefill_device,
                                                           const StartupObserver& startup_observer) {
     if (model.impl_ == nullptr) { throw std::invalid_argument("loaded model is empty"); }
     return qwen3_6::create_program<detail::Variant>(model.impl_->data.runtime,
                                                     model.impl_->weights_profile, std::move(plan),
-                                                    device, startup_observer);
+                                                    device, prefill_device, startup_observer);
 }
 
 } // namespace ninfer::targets::qwen3_6_35b_a3b

--- a/src/targets/registry.cpp
+++ b/src/targets/registry.cpp
@@ -87,7 +87,8 @@ std::size_t current_free_device_bytes() {
 
 template <class Target, class Loaded, class Instance>
 ConstructedTarget construct_registered(const EngineOptions& options, DeviceContext& device,
-                                       artifact::Reader& reader, Clock::time_point load_start,
+                                       DeviceContext& prefill_device, artifact::Reader& reader,
+                                       Clock::time_point load_start,
                                        std::string_view target_key) {
     StartupPhaseScope target_plan_phase(options.startup_observer, StartupPhase::TargetPlan);
     const auto& identity                          = reader.identity();
@@ -162,8 +163,9 @@ ConstructedTarget construct_registered(const EngineOptions& options, DeviceConte
     StartupPhaseScope program_phase(options.startup_observer, StartupPhase::ProgramInitialize);
     auto instance =
         std::make_unique<Instance>(std::move(loaded), capacity_resolution, std::move(sequence_plan),
-                                   device, options.startup_observer);
+                                   device, prefill_device, options.startup_observer);
     device.synchronize();
+    prefill_device.synchronize();
     program_phase.complete();
     instance->kv_capacity_resolution.available_after_startup_bytes = current_free_device_bytes();
 
@@ -198,12 +200,12 @@ LoadedQwen3_6_27B::~LoadedQwen3_6_27B() = default;
 Qwen3_6_27BInstance::Qwen3_6_27BInstance(std::unique_ptr<LoadedQwen3_6_27B> stable_loaded,
                                          runtime::KvCapacityResolution resolution,
                                          Qwen3_6_27B::SequencePlan sequence_plan,
-                                         DeviceContext& device,
+                                         DeviceContext& device, DeviceContext& prefill_device,
                                          const StartupObserver& startup_observer)
     : loaded(std::move(stable_loaded)), kv_capacity_resolution(resolution),
       capacity(sequence_plan.capacity()),
       program(Qwen3_6_27B::create_program(*loaded->model, std::move(sequence_plan), device,
-                                          startup_observer)) {}
+                                          prefill_device, startup_observer)) {}
 
 Qwen3_6_27BInstance::~Qwen3_6_27BInstance() = default;
 
@@ -217,15 +219,17 @@ Qwen3_6_35BA3BInstance::Qwen3_6_35BA3BInstance(std::unique_ptr<LoadedQwen3_6_35B
                                                runtime::KvCapacityResolution resolution,
                                                Qwen3_6_35BA3B::SequencePlan sequence_plan,
                                                DeviceContext& device,
+                                               DeviceContext& prefill_device,
                                                const StartupObserver& startup_observer)
     : loaded(std::move(stable_loaded)), kv_capacity_resolution(resolution),
       capacity(sequence_plan.capacity()),
       program(Qwen3_6_35BA3B::create_program(*loaded->model, std::move(sequence_plan), device,
-                                             startup_observer)) {}
+                                             prefill_device, startup_observer)) {}
 
 Qwen3_6_35BA3BInstance::~Qwen3_6_35BA3BInstance() = default;
 
-ConstructedTarget construct_target(const EngineOptions& options, DeviceContext& device) {
+ConstructedTarget construct_target(const EngineOptions& options, DeviceContext& device,
+                                   DeviceContext& prefill_device) {
     validate_options(options);
     const auto load_start = Clock::now();
 
@@ -235,15 +239,16 @@ ConstructedTarget construct_target(const EngineOptions& options, DeviceContext& 
     const auto& identity = reader.identity();
     if (identity.model_id == Qwen3_6_27B::model_id) {
         return construct_registered<Qwen3_6_27B, LoadedQwen3_6_27B, Qwen3_6_27BInstance>(
-            options, device, reader, load_start, Qwen3_6_27B::target_key);
+            options, device, prefill_device, reader, load_start, Qwen3_6_27B::target_key);
     }
     if (identity.model_id == Qwen3_6_27B::qwen3_8_model_id) {
         return construct_registered<Qwen3_6_27B, LoadedQwen3_6_27B, Qwen3_6_27BInstance>(
-            options, device, reader, load_start, Qwen3_6_27B::qwen3_8_target_key);
+            options, device, prefill_device, reader, load_start,
+            Qwen3_6_27B::qwen3_8_target_key);
     }
     if (identity.model_id == Qwen3_6_35BA3B::model_id) {
         return construct_registered<Qwen3_6_35BA3B, LoadedQwen3_6_35BA3B, Qwen3_6_35BA3BInstance>(
-            options, device, reader, load_start, Qwen3_6_35BA3B::target_key);
+            options, device, prefill_device, reader, load_start, Qwen3_6_35BA3B::target_key);
     }
     throw std::runtime_error("artifact identity '" + identity.model_id + "/" + identity.weights_id +
                              "' has no registered target for this device");

--- a/src/targets/registry.h
+++ b/src/targets/registry.h
@@ -40,6 +40,7 @@ struct Qwen3_6_27BInstance {
     Qwen3_6_27BInstance(std::unique_ptr<LoadedQwen3_6_27B> stable_loaded,
                         runtime::KvCapacityResolution resolution,
                         Qwen3_6_27B::SequencePlan sequence_plan, DeviceContext& device,
+                        DeviceContext& prefill_device,
                         const StartupObserver& startup_observer);
     ~Qwen3_6_27BInstance();
 
@@ -70,6 +71,7 @@ struct Qwen3_6_35BA3BInstance {
     Qwen3_6_35BA3BInstance(std::unique_ptr<LoadedQwen3_6_35BA3B> stable_loaded,
                            runtime::KvCapacityResolution resolution,
                            Qwen3_6_35BA3B::SequencePlan sequence_plan, DeviceContext& device,
+                           DeviceContext& prefill_device,
                            const StartupObserver& startup_observer);
     ~Qwen3_6_35BA3BInstance();
 
@@ -88,7 +90,8 @@ struct ConstructedTarget {
 };
 
 [[nodiscard]] ConstructedTarget construct_target(const EngineOptions& options,
-                                                 DeviceContext& device);
+                                                 DeviceContext& device,
+                                                 DeviceContext& prefill_device);
 
 } // namespace targets
 } // namespace ninfer

--- a/tests/targets/qwen3_6_27b/test_load_plan.cpp
+++ b/tests/targets/qwen3_6_27b/test_load_plan.cpp
@@ -175,6 +175,7 @@ int verify_rejection() {
 
 int verify_profile_mismatch_rejection() {
     ninfer::DeviceContext device(0);
+    ninfer::DeviceContext prefill_device(0, ninfer::StreamPriority::Low);
     ninfer::EngineOptions options;
     options.max_context                      = 128;
     options.kv_capacity                      = ninfer::KvCapacityPolicy::explicit_capacity(128);
@@ -189,7 +190,7 @@ int verify_profile_mismatch_rejection() {
     try {
         (void)ninfer::targets::qwen3_6::create_program<Variant>(
             empty_model, WeightsProfile::Qwen36Nvfp4, std::move(sequence), device,
-            ninfer::StartupObserver{});
+            prefill_device, ninfer::StartupObserver{});
     } catch (const std::invalid_argument& error) {
         if (std::string(error.what()).find("weights profile") != std::string::npos) { return 0; }
     }

--- a/tests/test_admission_policy.cpp
+++ b/tests/test_admission_policy.cpp
@@ -178,14 +178,27 @@ int main() {
                           !scheduler.should_attempt_admission(true, true, true, false, false) &&
                           scheduler.should_attempt_admission(true, true, true, true, false) &&
                           !scheduler.should_attempt_admission(true, true, false, false, true) &&
-                          scheduler.choose_execution(true, false, false) == ExecutionAction::Decode,
+                          scheduler.choose_execution(true, false, false, false) ==
+                              ExecutionAction::Decode &&
+                          scheduler.choose_execution(true, false, false, true) ==
+                              ExecutionAction::Decode,
                       "admission and GPU-unit fairness gates changed");
     scheduler.set_prefill_lane(0);
     failures +=
         check(!scheduler.should_attempt_admission(true, true, true, true, false) &&
-                  scheduler.choose_execution(true, true, false) == ExecutionAction::Decode &&
-                  scheduler.choose_execution(true, true, true) == ExecutionAction::Prefill,
+                  scheduler.choose_execution(true, true, false, false) == ExecutionAction::Decode &&
+                  scheduler.choose_execution(true, true, true, false) == ExecutionAction::Prefill,
               "prefill/decode alternation changed");
+    // With overlap the pair replaces the alternation, and a lone runnable unit is unaffected.
+    failures += check(scheduler.choose_execution(true, true, false, true) ==
+                              ExecutionAction::PrefillAndDecode &&
+                          scheduler.choose_execution(true, true, true, true) ==
+                              ExecutionAction::PrefillAndDecode &&
+                          scheduler.choose_execution(false, true, true, true) ==
+                              ExecutionAction::Prefill &&
+                          scheduler.choose_execution(true, false, true, true) ==
+                              ExecutionAction::Decode,
+                      "overlapped prefill/decode selection changed");
     scheduler.clear_prefill_lane(0);
 
     std::array<std::shared_ptr<SchedulerRequest>, ninfer::kMaximumConcurrency> slots{};


### PR DESCRIPTION
> **DO NOT MERGE.** This is a complete, working implementation that **does not achieve its
> goal**. It is kept as a draft so the measurement, the audit and the plumbing are available
> if we pick the problem up again. The overlap default is deliberately left **on** so the
> table below reproduces from this commit; it must be flipped before any merge.

Measured on the RTX 3090 host, `qwen3.8-27b/groupwise-int`, sm_86, `build-ninja`.

## The result

Four streaming clients generating 512 tokens each; a fresh 4,904-token prompt injected five
seconds in. Serial against overlapped, on one build, per prefill chunk:

| chunk | mode | median gap | p99 gap | max gap | injected TTFT | injected prefill tok/s |
|---:|---|---:|---:|---:|---:|---:|
| 1024 | serial | 80.7 ms | 887.5 ms | 1021.2 ms | 4,805 ms | 1157.2 |
| 1024 | **overlap** | 81.2 ms | 885.8 ms | **1031.9 ms** | 4,843 ms | **1029.5** |
| 512 | serial | 81.6 ms | 508.5 ms | 510.0 ms | 5,193 ms | 1147.7 |
| 512 | **overlap** | 81.7 ms | 502.2 ms | **512.2 ms** | 5,288 ms | **950.1** |
| 256 | serial | 83.0 ms | 308.1 ms | 312.9 ms | 6,191 ms | 1115.7 |
| 256 | **overlap** | 83.3 ms | 298.7 ms | **300.3 ms** | 6,103 ms | **823.8** |
| 128 | serial | 81.8 ms | 223.9 ms | 224.2 ms | 8,788 ms | 883.7 |
| 128 | **overlap** | 82.1 ms | 210.0 ms | **220.3 ms** | 8,327 ms | **598.3** |

**The stall does not move at any chunk size, and prefill loses 11-32%.** The target was
"decoders keep close to normal cadence, prefill drops no more than ~20%"; this delivers the
cost without the benefit.

Steady state, no prefill: C8 decode 246.70 tok/s against a 250.26 baseline, round 91.98 ms
against 89.93 ms, peak VRAM 21,038 MiB against 20,903 MiB.

## Why it fails, and it is structural rather than a defect

A stream still receives **one decode round per worker boundary** either way. Serial, a
boundary costs `chunk + round`. Overlapped it costs `max(chunk, round)`. At chunk 512 that
is 533 ms against about 440 ms, a ceiling of roughly 17%, and SM contention returns it:
decode outranks prefill, prefill yields, and the streams observe nothing.

Shrinking the chunk does not rescue it. The gap simply tracks the chunk time, which is why
chunk 128 is 224 ms serial and 220 ms overlapped.

**What would actually work:** the prefill must be asynchronous *across* boundaries so about
five decode rounds run while one chunk proceeds, rather than sharing a single boundary with
one round. Concretely: `TextContext::prefill_impl` records an event instead of its terminal
`ctx_.synchronize()`, and the worker polls for completion the way it already polls context
transactions. The lanes, arena, hook and scheduler action in this branch are the
prerequisites for that and are unaffected by the negative result.

## Buffer audit (the reusable part)

Traced every use site rather than trusting the constructor signatures. `ExecutionCore`
bundles `{device, work, io, prefill_hidden}`, which makes four resources *look* shared.
Three are not:

| Resource | Shared? | Evidence |
|---|---|---|
| `work` (`WorkspaceArena`) | **yes** | `prefill_impl` calls `work_.reset()` per sub-chunk while the decode graph has arena addresses baked in at capture |
| compute stream | **yes** | everything resolves `ctx_.stream` |
| `prefill_hidden` | no | used at exactly two lines, both inside `TextContext::prefill_impl`; the decode body only passes it |
| `io` scalars (`pos`, `rope_pos`, `text_kv_table_row`) | no | `attn_mix` prefers `active_*`, which batched decode always sets; `io_.*` is the single-sequence fallback |
| `io.mtp`, `io.logits`, `io.token`, `io.rope_delta` | no | prefill and bridge only; batched decode uses `io.mtp_decode` / `io.ordinary` / `io.dflash_decode` |
| KV pages, GDN state slots, conv history, ReplaySSM records | no | per sequence; the scheduler never puts the prefilling lane in the decode membership |

So a second `RoundState` and a second `prefill_hidden` are **not needed** — the assumption
that they were is what made this look like a `PersistentLayout` refactor.

Two hazards found that were not in the original list:

- `copy_round_token()` and the initial-draft readback were issued on the decode stream but
  read prefill-lane output. Moved to the prefill lane.
- `advance_prefill` stages a pending transaction and `decode`'s `wrap_pending` claims the
  same slot, so the pair failed every request with *"Program already owns a pending
  transaction"*. Fixed by resolving the prefill inside the hook, which is also where that
  host work is free.

Ordering invariant that carried everything: both units complete before the worker returns to
the boundary, so context-cache captures, cancellation sampling and admission need no new
events.

## VRAM

The whole workspace arena is 152.6 MiB. The second arena moved the sequence plan's device
reservation from 3,844.2 to 3,996.8 MiB — **+152.6 MiB exactly**. The brief's concern that
C8 near 22-23 GiB might block this is not true on this build: C8 peaks at 20.9 GiB of 24.5.

## What is in the branch

Second `DeviceContext` on the same device, ranked with `cudaStreamCreateWithPriority`
(decode High, prefill Low); `WorkspacePlan::prefill_lane_capacity` and a second
`WorkspaceArena`, both counted in `device_reservation_bytes` so `--kv-capacity auto` still
holds; the staged prefill's `ExecutionCore`, readbacks and stream waits on that lane;
`Scheduler::ExecutionAction::PrefillAndDecode`; a `DeviceBusyHook` on `decode()` threaded to
all three backends; and `--no-prefill-overlap`.

Verification: clean build, **110/110 tests pass**, generations complete normally, and
`--no-prefill-overlap` restores the serial order exactly. Not run, because the result made
them moot: `compute-sanitizer --tool racecheck` and the greedy byte-identity comparison.

Docs are untouched — `engine-architecture.md` 5.3 still describes the serial contract, which
is what ships on `master`.

## If we resume

1. Flip the default to overlap-off, or revert.
2. Do the deferred-completion split of `prefill_impl` and poll across boundaries.
3. Then run racecheck and the greedy byte-identity check, which this branch skipped.

Raw logs and harnesses are under `profiles/` (gitignored): `profiles/serve/phase3/` for the
table, `profiles/serve/phase1_b/` for the serial baseline, `profiles/serve/reservation/` for
the VRAM probe.

**In the meantime**, the serial column already carries a usable win: `--prefill-chunk 256`
cuts the worst-case stall from 1021 ms to 313 ms for a 3.6% ingestion loss, one line in the
C8 launcher, no concurrency work required.
