### PR TITLE
Automatic shared-prefix reuse: fix OpenAI candidate suppression, add --auto-prefix-grid

### DIFF
--- a/docs/maintainer/resource-scheduling-and-context-cache.md
+++ b/docs/maintainer/resource-scheduling-and-context-cache.md
@@ -483,6 +483,18 @@ Shared prefix 的三个状态不能混为一谈：
 candidates：全部 tools 之后、连续 leading System/Developer 之后，以及 full prompt。相同 frontier 合并，
 因此每个请求最多七个 prepared candidates。这个固定上限不是启动配置。
 
+这三个 Engine candidates 由 `ContextCacheHints::allow_engine_automatic_shared_prefixes` 控制，默认开启。
+自带写入策略的协议（例如显式请求了 Anthropic 顶层 `cache_control` 的请求）可以关闭它们，但只应在该协议
+确实会把 marker 放在别的请求也能匹配的位置时关闭：协议的 automatic marker 通常落在自己 prompt 的末尾，
+任何内容不同的请求都无法匹配，因此关掉结构性 candidates 会让共享前缀永远不被发布。
+
+`ContextCacheHints::allow_engine_prefix_grid`（`ninfer-serve --auto-prefix-grid`，默认关闭）额外在与内容
+无关的 token 栅格上提供 candidates：步长从 256 tokens 起按 2 倍增长，直到栅格点不超过八个，frontier 取
+步长的绝对倍数而不是从 prompt 末尾倒推，因此长度不同的两个 prompt 在仍然一致的位置上会给出同一个
+frontier。栅格 candidate 只带 `EngineObserved`，既不是 declared 也不是 surplus，所以永远不会被投机性地
+占用空闲 shared slot；只有当两个独立 reuse domain 都提出同一个 key 时才会发布。开启后单请求最多十五个
+prepared candidates。
+
 Shared catalog 是 Engine-wide 公共容量，不是每条 lineage 的配额。启用 context cache 时，默认 logical
 capacity 同时覆盖 active concurrency 下限和单请求最多四个显式 markers，即
 `max(max_concurrency, kMaximumExplicitPromptCacheMarkers)`；显式配置仍完整覆盖默认值。这个下限允许较早的

--- a/docs/maintainer/resource-scheduling-and-context-cache.md
+++ b/docs/maintainer/resource-scheduling-and-context-cache.md
@@ -507,9 +507,17 @@ Candidate 保存 evidence flags。策略含义为：
 |---|---|
 | `ExplicitBoundary` | 可以参与 pressure，但仍须有严格正净收益 |
 | `RequestedAutomatic` | 可以参与 pressure，但仍须有严格正净收益 |
-| `DefaultAutomatic` | 只能使用不降低现有 owner 的空余终态 |
+| `DefaultAutomatic` | 至少两个独立 reuse domains 观测到相同 key 后才可创建 |
 | `EngineStructural` | 只能使用不降低现有 owner 的空余终态 |
 | `EngineObserved` | 至少两个独立 reuse domains 观测到相同 key 后才可创建 |
+
+`EngineStructural` 标记的是 prompt 自身结构暴露的 frontier（leading instructions 之后、tools 之后），
+内容不同的请求也可能落在同一位置，因此用空余 slot 做投机是合理的。`DefaultAutomatic` 不是：协议按自己的
+策略放置它，而 OpenAI 与 Anthropic 都放在该请求 prompt 的末尾，每个请求的副本都位于任何内容不同的请求都
+无法匹配的 frontier 上。让它占用空余 slot 会把 shared catalog 填满一次性 checkpoint，并饿死结构性
+candidate——后者只能等到 catalog 没有空位、pressure 生效后才能被提升。实测（八个不同前缀轮询）：十六个
+slot 的 catalog 到第四轮才完全命中（整体 32.8%），反而不如八个 slot；同一请求流在抑制该 automatic marker
+后两种容量都在第二轮完全命中（98.3%）。该 marker 真正被共享时仍会通过 `repeated` 获得 slot。
 
 Marker、evidence 和 shortlist key 都不证明命中；Program 对 read、dedup 和 publication 重新验证完整
 identity。候选创建 source 的顺序为：exact shared owner 直接 dedup；selected exact private reuse base 在

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -489,9 +489,17 @@ struct ContextCacheHints {
     std::optional<std::string> session_key;
     CacheRetentionHint retention = CacheRetentionHint::Default;
     std::vector<PromptCacheMarker> markers;
-    // Protocols with their own automatic/explicit write policy disable the Engine's structural
-    // candidates. Exact reads from already-published shared prefixes remain enabled.
+    // Structural shared candidates the Engine derives from the prompt's own shape: after the
+    // leading System/Developer block, after the tool definitions, and at the full prompt frontier.
+    // A protocol that carries its own write policy still wants these, because its policy only
+    // governs where *its* marker goes; turning them off leaves a request whose only candidate sits
+    // at the end of its own prompt, which no differing request can ever match.
     bool allow_engine_automatic_shared_prefixes = true;
+    // Propose additional shared candidates on a content-independent token grid so two prompts that
+    // merely start alike converge on the same frontier. Grid candidates carry EngineObserved
+    // evidence only, so they are never speculatively materialized: a grid frontier is published
+    // solely once two distinct reuse domains have both asked for it.
+    bool allow_engine_prefix_grid = false;
     // Advance the named session lineage when session_key is present. This does not require an
     // anonymous content-matched source to be retained.
     bool update_session_index = true;

--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
@@ -74,6 +74,41 @@ rem acceptance rather than costing any. Note the spread in absolute terms: 320 t
 rem against 188 on mixed prose, because code is far more predictable. Any single decode figure for
 rem this model is really a statement about the text being generated.
 rem
+rem CONTEXT CACHE: the catalog defaults are too small and it does not show up as an error, only as
+rem prefill you keep paying. A checkpoint is a KV prefix plus a StateImage, and on this model the
+rem StateImage is 61.4 MiB *flat* regardless of prefix length -- 30 GDN layers of 128x128x32 FP32
+rem recurrent state plus conv. Unlike KV pages, which several checkpoints of one conversation share,
+rem it cannot be shared between two frontiers at all: the recurrent state at token N is a function
+rem of every token before it. That fixed cost is why the shipped catalog is small.
+rem
+rem Measured, eight distinct ~1430-token preambles round-robined four times, reuse after round one:
+rem
+rem   --max-shared-prefixes    reuse    what happens
+rem   ------------------------------------------------------------------------------------
+rem   4  (the old default)      8.4%    only one preamble ever stays cached; constant thrash
+rem   8                        98.3%    all eight stay; prefill 0.317 s -> 0.044 s
+rem   16                       98.3%    no better than 8 once the catalog fits the working set
+rem
+rem Sizing rule: --max-shared-prefixes should match the number of distinct preambles in play, and
+rem --host-state-slots roughly twice (shared + private). Raising them costs pinned HOST memory and
+rem nothing on the device -- measured on this exact profile, both settings resolve the full 114,688
+rem tokens with byte-identical 492.4 MiB free after startup; the only change is host state pinned
+rem 982.6 MiB -> 1.92 GiB and 26 ms more startup.
+rem
+rem --auto-prefix-grid offers shared candidates on a content-independent token grid, so two requests
+rem that merely start alike -- the same pasted document in two different chats, the same few-shot
+rem preamble inside one user message -- converge on the same frontier without any client hint. A
+rem grid point is only ever materialised once two independent callers have both asked for it, so it
+rem cannot waste a slot speculatively. Measured on a prompt with no structural boundary at all:
+rem 0% -> 82.6% reuse, prefill -71%, TTFT -64%, and the cold requests before it warms are unchanged.
+rem
+rem LONG CONVERSATIONS do not need any of the above -- they run on the private turn-closure path,
+rem which is what --max-private-continuations sizes. Measured with a 194-turn coding-agent loop
+rem (tool calls, file pastes, whole history resent each turn) growing to 64,668 tokens: exactly one
+rem cache miss, on turn 1. Computed prefill stayed flat at ~340 tokens per turn no matter how long
+rem the history got, and TTFT went 0.085 s at 3k to 0.177 s at 64k. The limit on turn count is
+rem --max-context, not the cache.
+rem
 rem VISION: on, via --vision-residency overlay (ported from Don-Chad/ninfer-3090#21). Resident
 rem residency cost 261 MiB of the ~450 MiB this profile has free after startup -- too tight to risk.
 rem Overlay keeps the Vision tower host-pinned and streams each image through a borrowed device
@@ -116,6 +151,7 @@ if not exist "%MODEL%" (
 )
 
 echo Qwen3.6-35B-A3B  ^|  C1  ^|  context %CONTEXT%  ^|  rk8v4 KV  ^|  MTP3 + draft head  ^|  Vision (overlay)
+echo Cache: 8 shared / 8 private / 32 host states  ^|  automatic prefix grid on
 echo API: http://%HOST%:%PORT%/v1
 echo.
 
@@ -130,7 +166,8 @@ rem --- Profile A: speculation on. ~240 tok/s decode. ---
   --prefill-chunk 512 ^
   --max-pending-requests 16 --pending-timeout-ms 600000 ^
   --vision --vision-residency overlay ^
-  --max-private-continuations 8 --max-shared-prefixes 4 --host-state-slots 16 --host-kv-mib 8192
+  --max-private-continuations 8 --max-shared-prefixes 8 --host-state-slots 32 --host-kv-mib 8192 ^
+  --auto-prefix-grid
 
 rem --- Profile B: maximum context, no speculation. ~183 tok/s decode. ---
 rem "%SERVER%" "%MODEL%" ^
@@ -140,6 +177,8 @@ rem   --max-context %CONTEXT% ^
 rem   --kv-capacity %CONTEXT% ^
 rem   --kv-dtype rk8v4 ^
 rem   --prefill-chunk 512 ^
-rem   --max-pending-requests 16 --pending-timeout-ms 600000
+rem   --max-pending-requests 16 --pending-timeout-ms 600000 ^
+rem   --max-private-continuations 8 --max-shared-prefixes 8 --host-state-slots 32 ^
+rem   --host-kv-mib 8192 --auto-prefix-grid
 
 endlocal

--- a/src/runtime/engine/resource_manager.h
+++ b/src/runtime/engine/resource_manager.h
@@ -1681,12 +1681,28 @@ private:
                 has_shared_candidate_evidence(opportunity.evidence,
                                               SharedCandidateEvidence::RequestedAutomatic);
             const bool repeated = matching_reuse_domains(*key, provisional_demand) >= 2U;
+            // EngineStructural marks a frontier the prompt's own shape exposes - after the
+            // leading instructions, after the tools - so a differing request can plausibly
+            // land on it, and spending a spare slot speculatively is a reasonable bet.
+            //
+            // DefaultAutomatic is not that. A protocol places it where its own policy says,
+            // which for both OpenAI and Anthropic is the end of the request's own prompt, and
+            // every request's copy sits at a frontier no differing request can match. Letting
+            // it take a spare slot filled the shared catalog with single-use checkpoints and
+            // starved the structural candidate, which then had to wait for the catalog to run
+            // out of vacancies before pressure could promote it. Measured with eight distinct
+            // preambles round-robined: a sixteen-slot catalog reached full reuse only in the
+            // fourth round (32.8% overall) and was beaten by an eight-slot one, while the same
+            // stream with the automatic marker suppressed was fully warm in the second round
+            // (98.3%) at both sizes.
+            //
+            // The marker still earns a slot the moment it is genuinely shared: `repeated` sees
+            // two distinct reuse domains asking for the same key, which is exactly the case
+            // where a conversational endpoint has become a common prefix.
             const bool surplus_candidate =
                 vacant_shared_slots != 0 &&
-                (has_shared_candidate_evidence(opportunity.evidence,
-                                               SharedCandidateEvidence::DefaultAutomatic) ||
-                 has_shared_candidate_evidence(opportunity.evidence,
-                                               SharedCandidateEvidence::EngineStructural));
+                has_shared_candidate_evidence(opportunity.evidence,
+                                              SharedCandidateEvidence::EngineStructural);
             if (!declared && !repeated && !surplus_candidate) { continue; }
             const std::optional<PrefillWork> rebuild =
                 base.shared_candidate_rebuild_work(opportunity.frontier);

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -372,6 +372,8 @@ PreparedRequest GenerationService::prepare_impl(const GenerationRequest& request
         input.context_cache.allow_engine_automatic_shared_prefixes =
             input.context_cache.allow_engine_automatic_shared_prefixes &&
             protocol_allows_engine_automatic;
+        input.context_cache.allow_engine_prefix_grid =
+            input.context_cache.allow_engine_prefix_grid || options_.auto_prefix_grid;
         trim_cache_markers(input.context_cache.markers,
                            engine_->options().context_cache.max_cache_markers_per_request.value());
         prepared.acquisition_seconds =

--- a/src/serve/openai_common.cpp
+++ b/src/serve/openai_common.cpp
@@ -172,9 +172,12 @@ void apply_openai_prompt_cache_policy(GenerationRequest& request, OpenAIPromptCa
             *automatic_target = CacheBoundary{.evidence = evidence};
         }
     }
-    // OpenAI already defines the automatic/explicit write policy for every request. Existing
-    // exact shared residents are still considered by the Engine independently of this switch.
-    request.allow_engine_automatic_shared_prefixes = false;
+    // OpenAI's policy governs one boundary: the automatic marker this function just placed at the
+    // end of the prompt. It says nothing about where a prompt's structure already exposes a
+    // reusable prefix, so the Engine's structural boundaries stay enabled. Disabling them left a
+    // request whose only shared candidate sat at the end of its own prompt, which no differing
+    // request can ever match: ten identical-preamble requests each recomputed their whole prompt.
+    request.allow_engine_automatic_shared_prefixes = true;
 }
 
 std::string make_models_list(const std::string& model_id, std::int64_t created,

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -83,7 +83,7 @@ std::string serve_usage_text(const char* argv0) {
            "[--kv-dtype bf16|int8|fp8|rk8v4|nvfp4|k8v4] [--spec mtp|dflash --draft-tokens N] "
            "[--default-max-tokens N] [--default-thinking-budget N] "
            "[--vision] [--vision-residency resident|overlay] [--vision-max-merged N] "
-           "[--no-cuda-graph] [--no-prefix-reuse] "
+           "[--no-cuda-graph] [--no-prefix-reuse] [--auto-prefix-grid] "
            "[--lm-head-draft] [--no-thinking] [--preserve-thinking] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--min-p F] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
@@ -110,6 +110,9 @@ std::string serve_usage_text(const char* argv0) {
            std::to_string(kDefaultKvCapacityHeadroomBytes / (1024ULL * 1024ULL)) +
            " MiB of sizing headroom\n"
            "       --no-prefix-reuse disables compatible-prefix caching (enabled by default)\n"
+           "       --auto-prefix-grid offers shared candidates on a token grid so unrelated "
+           "callers whose prompts start alike share a cached prefix without any client hint; a grid "
+           "frontier is only published once two callers have both asked for it\n"
            "       context cache defaults: device-state=max-concurrency, private=2x concurrency, "
            "shared=max(max-concurrency,4), anchors=2; Host state=8 slots, Host KV=8192 MiB\n"
            "       --device-state-slots is extra checkpoint capacity beyond active lanes; "
@@ -312,6 +315,8 @@ ServeOptions parse_serve_options(int argc, char** argv) {
             options.use_cuda_graph = false;
         } else if (arg == "--no-prefix-reuse") {
             options.allow_prefix_reuse = false;
+        } else if (arg == "--auto-prefix-grid") {
+            options.auto_prefix_grid = true;
         } else if (arg == "--lm-head-draft") {
             options.speculative.proposal_head = ProposalHead::Optimized;
         } else if (arg == "--no-thinking") {
@@ -356,6 +361,10 @@ ServeOptions parse_serve_options(int argc, char** argv) {
         if (context_capacity_explicit) {
             throw std::invalid_argument(
                 "--no-prefix-reuse cannot be combined with context-cache capacity options");
+        }
+        if (options.auto_prefix_grid) {
+            throw std::invalid_argument(
+                "--no-prefix-reuse cannot be combined with --auto-prefix-grid");
         }
         options.context_cache.enabled                = false;
         options.context_cache.host_state_slots       = 0;

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -54,6 +54,10 @@ struct ServeOptions {
     std::uint32_t vision_max_merged_tokens = 16384;
     bool use_cuda_graph     = true;
     bool allow_prefix_reuse = true;
+    // Offer shared-prefix candidates on a content-independent token grid so unrelated callers whose
+    // prompts merely start alike converge on the same frontier. Off by default: it adds host-side
+    // candidate work to every request and only pays for itself on a multi-tenant preamble.
+    bool auto_prefix_grid = false;
     bool enable_thinking =
         true; // default thinking mode for the generation prompt (--no-thinking opts out)
     bool preserve_thinking = false;

--- a/src/targets/qwen3_6/impl/frontend/frontend.cpp
+++ b/src/targets/qwen3_6/impl/frontend/frontend.cpp
@@ -820,7 +820,7 @@ PreparedContextCache prepare_context_cache(
         }
     }
 
-    out.opportunities.reserve(7U);
+    out.opportunities.reserve(7U + (hints.allow_engine_prefix_grid ? 8U : 0U));
     const auto add_opportunity = [&](PromptCacheMarkerKind kind, SharedCandidateEvidence evidence,
                                      std::uint32_t frontier, std::uint32_t input_order) {
         if (frontier == 0 || !exact_vision_frontier(frontier, vision_items)) { return; }
@@ -868,7 +868,34 @@ PreparedContextCache prepare_context_cache(
         }
         add_opportunity(PromptCacheMarkerKind::SharedStablePrefix,
                         SharedCandidateEvidence::EngineObserved, full_prompt_frontier,
-                        engine_order);
+                        engine_order++);
+    }
+    if (hints.allow_engine_prefix_grid) {
+        // Structural boundaries only expose a prefix where the prompt's own shape happens to put
+        // one. Two requests that merely start with the same long span - the same pasted document,
+        // the same few-shot preamble inside a single user message - share no boundary at all, so
+        // neither ever proposes a frontier the other could match.
+        //
+        // The grid supplies that missing agreement. Frontiers are placed at absolute multiples of a
+        // page-sized stride rather than at positions measured from the end of the prompt, so two
+        // prompts of unrelated lengths still name the same frontier wherever they still agree. The
+        // stride doubles until the grid fits in kPrefixGridCandidates points, which keeps the count
+        // bounded and keeps a coarser grid a subset of a finer one - prompts that pick different
+        // strides still meet on the multiples of the larger.
+        //
+        // Every grid point carries EngineObserved and nothing else. That evidence is neither
+        // "declared" nor "surplus", so the resource manager will not spend a vacant shared slot on
+        // one speculatively; a grid frontier is only ever materialized once two distinct reuse
+        // domains have independently proposed it, which is exactly the signal that two callers
+        // share that prefix.
+        constexpr std::uint32_t kPrefixGridPageTokens = 256;
+        constexpr std::uint32_t kPrefixGridCandidates = 8;
+        std::uint32_t stride                         = kPrefixGridPageTokens;
+        while (full_prompt_frontier / stride > kPrefixGridCandidates) { stride *= 2U; }
+        for (std::uint32_t frontier = stride; frontier <= full_prompt_frontier; frontier += stride) {
+            add_opportunity(PromptCacheMarkerKind::SharedStablePrefix,
+                            SharedCandidateEvidence::EngineObserved, frontier, engine_order++);
+        }
     }
     return out;
 }

--- a/tests/test_serve_options.cpp
+++ b/tests/test_serve_options.cpp
@@ -211,6 +211,18 @@ int main() {
     failures += check(disabled_cache_capacity_rejected,
                       "root-only server mode accepted context-cache capacity options");
 
+    failures += check(!parse({"ninfer-serve", "model.ninfer"}).auto_prefix_grid,
+                      "automatic prefix grid was on without --auto-prefix-grid");
+    failures +=
+        check(parse({"ninfer-serve", "model.ninfer", "--auto-prefix-grid"}).auto_prefix_grid,
+              "--auto-prefix-grid did not reach serving options");
+    bool grid_without_reuse_rejected = false;
+    try {
+        (void)parse({"ninfer-serve", "model.ninfer", "--no-prefix-reuse", "--auto-prefix-grid"});
+    } catch (const std::invalid_argument&) { grid_without_reuse_rejected = true; }
+    failures += check(grid_without_reuse_rejected,
+                      "--auto-prefix-grid was accepted with prefix reuse disabled");
+
     const ServeOptions response_store =
         parse({"ninfer-serve", "model.ninfer", "--response-store-max-records", "42",
                "--response-store-max-mib", "8"});
@@ -325,6 +337,9 @@ int main() {
     failures +=
         check(serve_usage_text("ninfer-serve").find("--no-prefix-reuse") != std::string::npos,
               "serve help omits --no-prefix-reuse");
+    failures +=
+        check(serve_usage_text("ninfer-serve").find("--auto-prefix-grid") != std::string::npos,
+              "serve help omits --auto-prefix-grid");
     failures += check(serve_usage_text("ninfer-serve").find("--host-kv-mib") != std::string::npos,
                       "serve help omits context-cache capacities");
     failures += check(serve_usage_text("ninfer-serve").find("device-state=max-concurrency") !=


### PR DESCRIPTION
Two changes that make shared-prefix reuse work without the client saying anything.

## 1. The fix: OpenAI requests disabled every shared-prefix candidate

`apply_openai_prompt_cache_policy` set `allow_engine_automatic_shared_prefixes = false` on **every** OpenAI request, following the doctrine that a protocol carrying its own write policy should suppress the Engine's structural candidates.

That doctrine does not hold for OpenAI. The only marker the policy places sits at `automatic_target` — the last content part of the last message, i.e. **the end of the request's own prompt**. No request with a different tail can ever match a frontier there. So with the structural candidates suppressed, a fleet of requests sharing a long preamble published nothing and each recomputed its whole prompt. Instrumentation confirmed `EngineStructural` (0x08) never once reached the opportunity list.

One line, plus the comment that explains why the doctrine is wrong here.

Measured on qwen3.6-35b-a3b, 1554-token prompt whose shared span is a leading system message, direct to the bound port, **no client hint of any kind**:

| | before | after |
|---|---|---|
| requests reusing anything | 0 of 10 | req 6 onward |
| prompt tokens reused | 0 | **1529 / 1554 (98.4%)** |

`anthropic_messages_request.cpp:980` suppresses the same flag, but only after `if (!automatic_ttl) return;` — it fires only when the client explicitly asked for Anthropic's policy. That one is deliberate and is left alone.

## 2. The feature: `--auto-prefix-grid`

The fix only helps where the prompt's own shape exposes a boundary. Two callers who merely start with the same long span — the same pasted document, the same few-shot preamble inside a single user message — share no boundary at all.

The read side already does partial matching: an incoming request probes every resident checkpoint frontier against its own token stream (`resource_manager.h:321-325`), and `matching_reuse_domains(key) >= 2` already means "two different callers wanted this prefix". What was missing were candidate **frontiers** to agree on.

`--auto-prefix-grid` (off by default) supplies them. Frontiers sit at absolute multiples of a 256-token stride that doubles until the grid fits in eight points — absolute positions, not measured from the end, so prompts of unrelated lengths still name the same frontier wherever they still agree, and a coarser grid stays a subset of a finer one. Grid points carry `EngineObserved` and nothing else: neither *declared* nor *surplus*, so they can never speculatively consume a vacant shared slot. One is materialized only once two independent reuse domains have proposed it.

Measured on the shape that motivated this — shared span buried inside a single user message, no client hint, twelve requests with differing tails:

| | baseline | `--auto-prefix-grid` |
|---|---|---|
| reuse, steady state (req 6-12) | 0 | **1280 / 1549 (82.6%)** |
| reuse path | `root` | `shared_stable_prefix` |
| prefill, median | 0.322 s | **0.092 s (−71%)** |
| TTFT, median | 0.350 s | **0.127 s (−64%)** |
| total, median | 0.554 s | 0.330 s (−41%) |
| prefill, first 5 (cold) | 0.322 s | 0.323 s |

That last row is the one that matters for the default-off question: the extra host-side candidate work costs nothing measurable before it pays off.

## Testing

- `ctest -j2` **110/110**. (`ninfer_softmax_attention_test` flaked once on an earlier run under parallel GPU load and passes consistently since; it is contention, not a regression.)
- Three new `test_serve_options` cases: default off, flag reaches options, and `--auto-prefix-grid` with `--no-prefix-reuse` is rejected.
- End-to-end harness at `profiles/serve/repro_35b_grid.py` (gitignored) runs the identical request stream against a freshly launched server with the flag off and on.

## Known, not addressed here

The `DefaultAutomatic` marker at end-of-prompt is still surplus-promoted and consumes one of the shared slots per *unique* prompt (`vacant` observed going 4→3→2→1). That is why warm-up costs ~5 requests rather than 2. Fixing it means changing serve-layer marker placement, which belongs in its own change.

## 3. The end-of-prompt marker was taking shared slots

Added after a capacity sweep turned up something backwards: with eight distinct preambles round-robined, a **16-slot** shared catalog reached full reuse a whole round *later* than an **8-slot** one, and reused less than half as much overall.

A shared slot is for a prefix several callers reach. `EngineStructural` marks a frontier the prompt's own shape exposes, so a differing request can plausibly land on it and spending a spare slot speculatively is a reasonable bet. `DefaultAutomatic` is not that: both OpenAI and Anthropic place it at the end of the request's own prompt, so every request's copy sits at a frontier no differing request can ever match. Letting it take a spare slot filled the catalog with single-use checkpoints and starved the structural candidate, which then had to wait for the catalog to run *out* of vacancies before pressure could promote it. A bigger catalog offered more vacancies to waste — hence the inversion.

Demoted `DefaultAutomatic` to the `EngineObserved` rung. It still earns a slot the moment it is genuinely shared, via `repeated` (two distinct reuse domains asking for the same key) — which is exactly the case where a conversational endpoint has become a common prefix.

Eight distinct ~1430-token preambles, four rounds, reuse after round 1:

| config | before | after |
|---|---|---|
| `--max-shared-prefixes 8` | 65.6%, warm from round 3 | **98.3%, round 2** |
| `--max-shared-prefixes 16` | 32.8%, warm from round 4 | **98.3%, round 2** |
| prefill median (16 slots) | 0.305 s | **0.044 s** |

Both sizes now behave identically, and both match a control arm that suppresses the marker client-side with `prompt_cache_options: {mode: "explicit"}` — which is how the cause was isolated before any code changed.

It compounds with the grid: the single-preamble grid case went from warm at request 6 to warm at request **3**, and 48.2% → **68.9%** reuse over the same twelve requests.

## Sizing note for operators

A StateImage on qwen3.6-35b-a3b is **61.4 MiB flat** (30 GDN layers x 128x128x32 FP32 recurrent, plus conv) — the server reports `pinning host state | 3.84 GiB` for 64 slots. It does not shrink with prefix length and, unlike KV pages, cannot be shared between two frontiers, because the recurrent state at token N is a function of every token before it. That fixed cost is what keeps the shared catalog small.

Practical consequence, measured: `--max-shared-prefixes` should match your distinct-preamble working set. Eight preambles against the default four slots reused **8.4%**; against eight slots, **98.3%**. Host is cheap (61.4 MiB/slot pinned, 304 ms to pin 64) — set `--host-state-slots` to roughly twice `shared + private`.


## Evaluated and rejected: BF16 frozen StateImages

Halving the StateImage by storing the frozen recurrent state as BF16 would let roughly twice as many checkpoints stay device-resident instead of being restored over PCIe. Measured the upper bound on that first, by raising `--device-state-slots` until the whole working set fits on the device:

| | device 2 (host restore) | device 10 (resident) | delta |
|---|---|---|---|
| prefill median | 0.0438 s | 0.0433 s | -0.5 ms |
| TTFT median | 0.0805 s | 0.0744 s | -6.1 ms |
| total median | 0.2474 s | 0.2380 s | -9.4 ms |

Removing the restore *entirely* is worth ~6 ms of TTFT, which matches 61.4 MiB at ~12 GB/s. A BF16 checkpoint would capture only part of that while adding a pack kernel, an unpack kernel, a second host layout and a changed transfer cost model, and it would change numerics. Not worth building. Measured at concurrency 2 on ~1430-token prefixes; the conclusion could change if copy-engine contention grows at higher concurrency.
