### PR TITLE
Accept the request shapes agent CLIs send: hosted tools and parallel_tool_calls=false

### DIFF
--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -346,6 +346,7 @@ PreparedRequest GenerationService::prepare_impl(const GenerationRequest& request
     prepared.thinking_budget            = request_options.execution.thinking.budget;
     prepared.effective_reasoning_effort = semantics.effective_reasoning_effort;
     prepared.preserve_thinking          = semantics.preserve_thinking;
+    prepared.parallel_tool_calls        = request.parallel_tool_calls;
     const bool request_has_media        = request.media_item_count() != 0;
     if (request_has_media && !options_.enable_vision) {
         const std::invalid_argument error("Vision is disabled for this server");
@@ -498,6 +499,13 @@ GenerationOutcome GenerationService::run(PreparedRequest& prepared, const Stream
 
     outcome.tool_calls      = std::move(result.tool_calls);
     outcome.tool_call_parse = result.tool_call_parse;
+    // parallel_tool_calls=false promises the caller at most one tool call per assistant turn.
+    // Decoding is not constrained, so enforce it here: keep the first call and drop the rest. The
+    // model can ask for the next one on the following turn, which is how a sequential executor
+    // consumes them anyway.
+    if (!prepared.parallel_tool_calls && outcome.tool_calls.size() > 1) {
+        outcome.tool_calls.resize(1);
+    }
     return outcome;
 }
 

--- a/src/serve/generation_service.h
+++ b/src/serve/generation_service.h
@@ -96,6 +96,8 @@ struct PreparedRequest {
     std::optional<std::uint32_t> thinking_budget;
     std::optional<ninfer::ReasoningEffort> effective_reasoning_effort;
     bool preserve_thinking = false;
+    // False trims the finished response to a single tool call. See GenerationRequest.
+    bool parallel_tool_calls = true;
     std::shared_ptr<RequestLifetime> lifetime;
 };
 

--- a/src/serve/openai_chat_request.cpp
+++ b/src/serve/openai_chat_request.cpp
@@ -597,6 +597,11 @@ void parse_tools(const Json& body, GenerationRequest& output) {
         }
         const std::string type = item.at("type").get<std::string>();
         if (type != "function") {
+            // A hosted tool would have been executed by the server. NInfer cannot, and the client
+            // is not waiting on it either, so drop it and carry on: the model is never told the
+            // tool exists. Agent harnesses declare web_search unconditionally, and failing the
+            // whole request over one entry they cannot remove locked them out entirely.
+            if (is_hosted_openai_tool_type(type)) { continue; }
             bad_request(
                 "tool type '" + type +
                     "' requires a non-function output contract that NInfer does not provide",
@@ -737,19 +742,18 @@ void parse_tool_choice(const Json& body, GenerationRequest& output) {
     }
 }
 
-void parse_parallel_tool_calls(const Json& body, const GenerationRequest& output) {
+void parse_parallel_tool_calls(const Json& body, GenerationRequest& output) {
     if (!body.contains("parallel_tool_calls") || body.at("parallel_tool_calls").is_null()) {
         return;
     }
     if (!body.at("parallel_tool_calls").is_boolean()) {
         bad_request("parallel_tool_calls must be a boolean", "parallel_tool_calls");
     }
-    if (!body.at("parallel_tool_calls").get<bool>() && output.uses_tools()) {
-        bad_request(
-            "parallel_tool_calls=false requires the model to emit at most one tool call, which "
-            "NInfer cannot guarantee while tools are enabled",
-            "parallel_tool_calls", "parallel_tool_calls_not_supported");
-    }
+    // Honoured by keeping the first tool call and dropping the rest, rather than refused. The
+    // guarantee a client depends on is what the response contains, and that much is enforceable
+    // even though decoding itself is not constrained. Refusing instead broke agent harnesses that
+    // send parallel_tool_calls=false whenever any tool is available.
+    output.parallel_tool_calls = body.at("parallel_tool_calls").get<bool>();
 }
 
 void parse_stop(const Json& body, GenerationRequest& output) {

--- a/src/serve/openai_common.cpp
+++ b/src/serve/openai_common.cpp
@@ -38,6 +38,21 @@ std::string responses_identifier(std::string_view prefix) {
 
 using Json = nlohmann::json;
 
+bool is_hosted_openai_tool_type(std::string_view type) noexcept {
+    // OpenAI versions some of these with a dated suffix (web_search_preview_2025_03_11), so match
+    // the family by prefix rather than pinning every spelling.
+    static constexpr std::string_view kHostedPrefixes[] = {
+        "web_search", "code_interpreter", "file_search",
+        "image_generation", "computer_use", "mcp",
+    };
+    for (const std::string_view prefix : kHostedPrefixes) {
+        if (type.size() >= prefix.size() && type.substr(0, prefix.size()) == prefix) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool parse_openai_prompt_cache_breakpoint(const RequestJson& value, std::string_view param) {
     if (!value.contains("prompt_cache_breakpoint") ||
         value.at("prompt_cache_breakpoint").is_null()) {

--- a/src/serve/openai_common.h
+++ b/src/serve/openai_common.h
@@ -28,6 +28,15 @@ struct OpenAIPromptCachePolicy {
 [[nodiscard]] OpenAIPromptCachePolicy parse_openai_prompt_cache_policy(const RequestJson& body);
 void apply_openai_prompt_cache_policy(GenerationRequest& request, OpenAIPromptCachePolicy policy);
 
+// True for OpenAI tool types the *server* would have executed - hosted search, hosted code
+// execution, hosted file search and the like. NInfer has no executor for any of them, and a client
+// never waits on one itself, so declaring one is silently dropped rather than failing the request:
+// the model is simply never told the tool exists, which is the same outcome as not declaring it.
+//
+// Client-executed types stay rejected. Dropping one of those would leave the caller waiting for a
+// call that can never arrive, which is worse than a clear error.
+[[nodiscard]] bool is_hosted_openai_tool_type(std::string_view type) noexcept;
+
 std::string make_models_list(const std::string& model_id, std::int64_t created,
                              std::uint32_t max_model_len);
 std::string make_model_object(const std::string& model_id, std::int64_t created,

--- a/src/serve/openai_responses_request.cpp
+++ b/src/serve/openai_responses_request.cpp
@@ -800,6 +800,10 @@ void parse_tools(const Json& body, ParsedPromptFields& out) {
             continue;
         }
         if (type != "namespace") {
+            // Hosted tools are the server's to execute, and NInfer has no executor for any of
+            // them. Drop the declaration instead of failing the request: the model is never told
+            // the tool exists, and the client was never going to run it either.
+            if (is_hosted_openai_tool_type(type)) { continue; }
             bad_request("tool type '" + type +
                             "' requires an executor that NInfer does not provide",
                         "tools", "tool_type_not_supported");
@@ -1051,11 +1055,8 @@ ParsedPromptFields parse_prompt_fields(const Json& body, const RequestLimits& li
     parse_tools(body, out);
     parse_tool_choice(body, out);
     out.parallel_tool_calls = optional_bool(body, "parallel_tool_calls", true);
-    if (!out.parallel_tool_calls && out.prompt.generation.uses_tools()) {
-        bad_request("parallel_tool_calls=false cannot be guaranteed when callable tools are "
-                    "present",
-                    "parallel_tool_calls", "parallel_tool_calls_not_supported");
-    }
+    // Honoured by trimming the response to one tool call rather than refused; see the chat parser.
+    out.prompt.generation.parallel_tool_calls = out.parallel_tool_calls;
     parse_reasoning(body, out.prompt);
     parse_text(body);
     parse_truncation(body);

--- a/src/serve/request.h
+++ b/src/serve/request.h
@@ -186,6 +186,10 @@ struct GenerationRequest {
     ninfer::PromptContinuationMode continuation = ninfer::PromptContinuationMode::NewAssistantTurn;
     bool private_cache_boundary_at_prompt_end   = false;
     bool allow_engine_automatic_shared_prefixes = true;
+    // False asks for at most one tool call per assistant turn. Decoding is not constrained; the
+    // serving layer keeps the first call and drops the rest, which is the part of the contract a
+    // client can actually observe.
+    bool parallel_tool_calls = true;
     SamplingParams sampling;
 
     [[nodiscard]] bool uses_tools() const noexcept {

--- a/tests/test_openai_responses.cpp
+++ b/tests/test_openai_responses.cpp
@@ -698,6 +698,26 @@ int test_namespace_tools() {
                       }) == "tool_type_not_supported",
                       "namespace custom tools remain explicitly unsupported");
 
+    // Hosted tools are dropped rather than rejected on this endpoint too.
+    Json hosted           = body;
+    hosted["tool_choice"] = "auto";
+    hosted["tools"]       = Json::array({Json{{"type", "web_search"}},
+                                         Json{{"type", "function"}, {"name", "weather"}}});
+    const auto hosted_parsed = parse_openai_responses_create_request(hosted, limits());
+    failures += check(hosted_parsed.prompt.generation.tools.size() == 1 &&
+                          hosted_parsed.prompt.generation.tools[0].name == "weather",
+                      "responses drops a hosted tool and keeps the function tool");
+
+    // parallel_tool_calls=false parses and is carried down to the generation request, which trims
+    // the finished response to a single call.
+    Json sequential                        = body;
+    sequential["tool_choice"]              = "auto";
+    sequential["parallel_tool_calls"]      = false;
+    const auto sequential_parsed           = parse_openai_responses_create_request(sequential, limits());
+    failures += check(!sequential_parsed.parallel_tool_calls &&
+                          !sequential_parsed.prompt.generation.parallel_tool_calls,
+                      "responses accepts parallel_tool_calls=false and propagates it");
+
     Json oversized           = body;
     oversized["tool_choice"] = "auto";
     oversized["tools"] =

--- a/tests/test_openai_schema.cpp
+++ b/tests/test_openai_schema.cpp
@@ -296,12 +296,33 @@ int test_tools() {
     failures += check(api_error([&] { (void)parse(body); }).code == "tool_type_not_supported",
                       "custom tools rejected");
 
+    // A hosted tool is the server's to run. NInfer has no executor, and the caller is not waiting
+    // on one either, so the declaration is dropped instead of failing a request the client cannot
+    // change: agent harnesses declare web_search unconditionally.
+    body          = base_request();
+    body["tools"] = Json::array({Json{{"type", "web_search"}}, function_tool()});
+    const GenerationRequest hosted = parse(body).generation;
+    failures += check(hosted.tools.size() == 1 && hosted.tools[0].name == "weather",
+                      "hosted web_search is dropped and the function tool survives");
+    body["tools"] = Json::array({Json{{"type", "web_search_preview_2025_03_11"}}});
+    failures += check(parse(body).generation.tools.empty(),
+                      "dated hosted tool spellings are dropped by family");
+    body["tools"] = Json::array({Json{{"type", "web_search"}}});
+    failures += check(!parse(body).generation.uses_tools(),
+                      "a request whose only tool is hosted still parses, with no callable tools");
+
+    // parallel_tool_calls=false is honoured by trimming the response to one call rather than
+    // refused; the request must survive parsing for that to be possible.
     body                        = base_request();
     body["tools"]               = Json::array({function_tool()});
     body["parallel_tool_calls"] = false;
-    failures +=
-        check(api_error([&] { (void)parse(body); }).code == "parallel_tool_calls_not_supported",
-              "parallel_tool_calls=false rejected when tools exist");
+    const GenerationRequest sequential = parse(body).generation;
+    failures += check(!sequential.parallel_tool_calls && sequential.uses_tools(),
+                      "parallel_tool_calls=false is accepted alongside tools");
+    body["parallel_tool_calls"] = true;
+    failures += check(parse(body).generation.parallel_tool_calls,
+                      "parallel_tool_calls=true is the default contract");
+    body["parallel_tool_calls"] = false;
     body.erase("tools");
     failures += check(parse(body).generation.tools.empty(),
                       "parallel_tool_calls=false is neutral without tools");


### PR DESCRIPTION
Two rejections that stopped codex-cli connecting at all. Neither was enforcing anything the client could act on, and both were reported from a real agentic run.

## 1. A declared `web_search` tool failed the whole request

codex-cli puts `{"type": "web_search"}` in `tools` on every request, regardless of whether search is wanted. Strict validation rejected the entire request over that one entry, and the client has no way to drop it — the reported workaround was `-c web_search="disabled"`.

A **hosted** tool is the *server's* to execute. NInfer has no executor for one, and the caller is not waiting on it either, so the declaration is now dropped: the model is simply never told the tool exists, which is the same outcome as not declaring it. No silent wrong behaviour — the tool cannot be called because it was never offered.

**Client-executed types stay rejected.** Dropping a `custom` tool would leave the caller waiting for a call that can never arrive, which is worse than a clear error. The line is "would the server have run it", not "do we recognise the name".

Matching is by family prefix (`web_search`, `code_interpreter`, `file_search`, `image_generation`, `computer_use`, `mcp`) so dated spellings like `web_search_preview_2025_03_11` are covered without pinning every variant. Applies to `/v1/chat/completions` and `/v1/responses`.

## 2. `parallel_tool_calls=false` was refused whenever tools existed

codex-cli has no built-in metadata for a custom local model, falls back to conservative defaults, and that path sends `parallel_tool_calls=false` whenever any tool is available — which, in an agentic run with a shell executor, is always.

The old error claimed the guarantee could not be met while tools were enabled. That is true of *decoding*, which is still unconstrained, but the part of the contract a client can observe is what the response contains, and that much is enforceable: keep the first tool call and drop the rest.

Verified against a live server, same prompt and seed, with a tool the model wants to call twice:

| | tool calls | finish |
|---|---|---|
| `parallel_tool_calls=true` (default) | **2** — `pwd`, `whoami` | `tool_calls` |
| `parallel_tool_calls=false` | **1** — `pwd` | `tool_calls` |

The call kept is the first, so a sequential executor runs it and the model asks for the next on the following turn. That is how OpenAI's own semantics behave and how a sequential client consumes them anyway.

## Verification

All four shapes now return 200 where 1–3 previously 400'd:

```
200  web_search declared alongside a real tool
200  parallel_tool_calls=false with a tool available
200  both together (what codex-cli actually sends)
200  control: plain request, no tools
```

`ctest` **110/110**.

## Note on the tests

`test_openai_schema.cpp` and `test_openai_responses.cpp` asserted both rejections explicitly, so this changes intent rather than fixing an oversight. Those assertions now cover the new behaviour: a hosted tool is dropped while a sibling function tool survives, dated spellings are matched by family, `custom` is still rejected, and `parallel_tool_calls=false` parses and propagates.

## Not changed

`web_search_options` still returns `web_search_not_supported`. That field is an explicit request for hosted search with citations, not a passive declaration the client cannot remove, so failing loudly is the honest answer there.
