### PR TITLE
fix(release): make the build scripts able to cut a release

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -19,6 +19,7 @@
 #   .\scripts\build.ps1                  configure + build into build-ninja
 #   .\scripts\build.ps1 -Test            ... then run the test suite
 #   .\scripts\build.ps1 -Package v080    ... then build the release archive
+#   .\scripts\build.ps1 -Benchmarks      ... include bench\ (implied by -Package)
 #   .\scripts\build.ps1 -Clean           delete the build directory first
 #   .\scripts\build.ps1 -Target ninfer-serve
 [CmdletBinding()]
@@ -26,6 +27,7 @@ param(
     [switch]$Test,
     [string]$Package,
     [switch]$Clean,
+    [switch]$Benchmarks,
     [string]$Target,
     [string]$BuildDir,
     [ValidateSet('86', '89')][string]$Arch = '86'
@@ -35,6 +37,13 @@ $ErrorActionPreference = 'Stop'
 
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 if (-not $BuildDir) { $BuildDir = Join-Path $RepoRoot 'build-ninja' }
+
+# Every packaging script ships bench\ninfer_bench.exe alongside the CLI and the server, but
+# benchmarks are an opt-in subdirectory (NINFER_BUILD_BENCHMARKS defaults to OFF). Configuring
+# without them and then packaging fails late, after the whole tree has been built, with
+# "Missing release product: ...\bench\ninfer_bench.exe" - so make -Package imply the option rather
+# than leaving the two settings to be kept consistent by hand.
+$BuildBenchmarks = $Benchmarks -or [bool]$Package
 
 # --- locate the toolchain ---------------------------------------------------------------------
 
@@ -90,7 +99,9 @@ Push-Location $RepoRoot
 try {
     # Quote the -D arguments: PowerShell does not reliably expand a variable inside a bare token
     # that begins with "-D", and cmake then sees the literal "$Arch".
-    cmake -S . -B $BuildDir -G Ninja '-DCMAKE_BUILD_TYPE=Release' "-DCMAKE_CUDA_ARCHITECTURES=$Arch"
+    $BenchmarksOption = if ($BuildBenchmarks) { 'ON' } else { 'OFF' }
+    cmake -S . -B $BuildDir -G Ninja '-DCMAKE_BUILD_TYPE=Release' "-DCMAKE_CUDA_ARCHITECTURES=$Arch" `
+          "-DNINFER_BUILD_BENCHMARKS=$BenchmarksOption"
     if ($LASTEXITCODE -ne 0) { throw "configure failed ($LASTEXITCODE)" }
 
     $buildArgs = @('--build', $BuildDir)
@@ -108,8 +119,16 @@ try {
     if ($Package) {
         $packager = Join-Path $PSScriptRoot "package-release-$Package.ps1"
         if (-not (Test-Path -LiteralPath $packager)) { throw "No packaging script: $packager" }
-        & $packager
-        if ($LASTEXITCODE -ne 0) { throw "packaging failed ($LASTEXITCODE)" }
+        # The packagers default to build-ninja\; point them at the tree we actually built, so
+        # -BuildDir and -Package agree. build.sh already does this for the Linux packagers.
+        $PreviousBuildRoot = $env:NINFER_BUILD_ROOT
+        $env:NINFER_BUILD_ROOT = $BuildDir
+        try {
+            & $packager
+            if ($LASTEXITCODE -ne 0) { throw "packaging failed ($LASTEXITCODE)" }
+        } finally {
+            $env:NINFER_BUILD_ROOT = $PreviousBuildRoot
+        }
     }
 } finally {
     Pop-Location

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,6 +9,7 @@
 #   ./scripts/build.sh                 configure + build into build-linux
 #   ./scripts/build.sh --test          ... then run the test suite
 #   ./scripts/build.sh --package v080  ... then build the release archive
+#   ./scripts/build.sh --benchmarks    ... include bench/ (implied by --package)
 #   ./scripts/build.sh --clean         delete the build directory first
 #   ./scripts/build.sh --target ninfer-serve
 #
@@ -24,19 +25,31 @@ run_tests=0
 clean=0
 package=''
 target=''
+benchmarks=0
 
 while (( $# )); do
   case "$1" in
     --test) run_tests=1; shift ;;
     --clean) clean=1; shift ;;
+    --benchmarks) benchmarks=1; shift ;;
     --package) package="${2:-}"; shift 2 ;;
     --target) target="${2:-}"; shift 2 ;;
     --build-dir) build_dir="${2:-}"; shift 2 ;;
     --arch) arch="${2:-}"; shift 2 ;;
-    -h|--help) sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    # Print the header comment block, stopping at the first line that is not a comment. A pinned
+    # line range drifts every time the block grows: it was '2,20p' against a block ending at 17,
+    # so --help trailed `set -euo pipefail` and a blank line.
+    -h|--help) sed -n '2,${/^#/!q;p;}' "${BASH_SOURCE[0]}"; exit 0 ;;
     *) printf 'Unknown argument: %s\n' "$1" >&2; exit 2 ;;
   esac
 done
+
+# Every packaging script ships bench/ninfer_bench alongside the CLI and the server, but benchmarks
+# are an opt-in subdirectory (NINFER_BUILD_BENCHMARKS defaults to OFF). Configuring without them and
+# then packaging fails late, after the whole tree has been built, with "Missing release product:
+# .../bench/ninfer_bench" - so make --package imply the option rather than leaving the two settings
+# to be kept consistent by hand.
+if [[ -n "$package" ]]; then benchmarks=1; fi
 
 case "$arch" in 86|89) ;; *) printf 'CUDA arch must be 86 or 89, got %s\n' "$arch" >&2; exit 2 ;; esac
 
@@ -74,7 +87,11 @@ if (( clean )) && [[ -d "$build_dir" ]]; then
 fi
 
 cd -- "$repo_root"
-cmake -S . -B "$build_dir" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES="$arch"
+benchmarks_option=OFF
+if (( benchmarks )); then benchmarks_option=ON; fi
+
+cmake -S . -B "$build_dir" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES="$arch" \
+      -DNINFER_BUILD_BENCHMARKS="$benchmarks_option"
 if [[ -n "$target" ]]; then
   cmake --build "$build_dir" --target "$target"
 else


### PR DESCRIPTION
## What

Neither `scripts/build.sh` nor `scripts/build.ps1` could actually produce a release package.

Both configure with `NINFER_BUILD_BENCHMARKS` at its `OFF` default, so `bench/` is never added to
the build — but every `package-release-*` script ships `bench/ninfer_bench` alongside the CLI and
the server. The failure lands *after* the entire tree has compiled:

```
ninja: error: unknown target 'ninfer_bench'
Missing release product: .../bench/ninfer_bench
```

This was hit while cutting **v0.9.0**, whose Linux binaries had to be built by reconfiguring the
tree by hand.

## Changes

- `--package` / `-Package` now implies benchmarks, and `--benchmarks` / `-Benchmarks` exposes it
  on its own. Leaving the two settings to be kept consistent by hand is what failed.
- `build.ps1` never set `NINFER_BUILD_ROOT` for the packager, which defaults to `build-ninja\`.
  `-BuildDir` together with `-Package` therefore packaged whichever tree happened to sit in the
  default location rather than the one just built. `build.sh` already did this correctly.
- `build.sh --help` printed a pinned line range (`2,20p`) against a header block ending at line 17,
  so it trailed `set -euo pipefail` and a blank line. It now stops at the first non-comment line
  and cannot drift again.

## Verification

Fresh configures, checking `CMakeCache.txt` and the generated target list:

| invocation | `NINFER_BUILD_BENCHMARKS` | `ninfer_bench` target |
|---|---|---|
| (no flags) | `OFF` | absent |
| `--benchmarks` | `ON` | present |
| `--package v090` | `ON` | present |

`build.ps1` parses clean and its option computation was checked across all four
`-Package`/`-Benchmarks` combinations. `bash -n` clean; `--help` output verified at 17 lines,
ending on the last comment line.