### PR TITLE
fix(speculative): refuse a greedy commit from a non-finite verify column

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -298,27 +298,28 @@ about it fails on a different one.
       value unperturbed, so every non-finite entry in a poisoned column stays bit-identical and the
       guard sees whichever one the id tie-break selects.
 
-## 5c. Greedy acceptance only tests the divergence column, not accepted matches
+## 5c. Greedy acceptance validates the whole committed span — done
 
-- [ ] Every greedy route (`speculative_accept_greedy_drafts_kernel`'s no-penalty and penalized
-      paths, `speculative_sampling_group_finalize_kernel<false>`'s no-penalty and penalized paths,
-      and both sparse warp routes closed by 5a) walks `while (a < extent && row_targets[a] ==
-      row_drafts[a]) ++a;` and tests `sampling_selected_logit_is_finite` only at column `a`, the
-      divergence/terminal column. **A column before `a` is never checked.** If a diverged forward
-      pass produces an all-NaN row whose argmax (undefined under NaN comparisons -- see
-      `sampling_better`) happens to equal that column's draft token, the round accepts it as a
-      match and folds it into `licensed_tokens` with no finiteness check at all; the guard only
-      ever sees whichever later, possibly-clean column becomes the terminal.
-      **Raised by CodePulse on PR #18, against 5a's new sparse-greedy code** (`speculative_round.cuh:178`),
-      but confirmed to be the pre-existing shape of `speculative_accept_greedy_drafts_kernel`'s
-      no-penalty path already on `master` before PR #18 -- 5a made the other three routes match
-      this pattern, not introduce it. **Descoped from PR #18**: closing it means validating
-      finiteness of every accepted column in all four greedy routes (an extra
-      `sampling_selected_logit_is_finite` read per accepted column, not just the terminal), which
-      touches code PR #18 never modified and changes the acceptance protocol uniformly rather than
-      guarding one more call site. That is a distinct effort from "make the new routes match the
-      established pattern," which is what PR #18 shipped.
+- [x] ~~Every greedy route tested `sampling_selected_logit_is_finite` only at the divergence
+      column, never at a column accepted as a match.~~ **Fixed.** If a diverged forward pass gave a
+      column an all-NaN row whose argmax happened to equal that column's draft, the round accepted
+      it as a match, folded it into `licensed_tokens` with no finiteness check, and then committed
+      on whichever later, clean column became the terminal.
 
+      Raised by CodePulse on PR #18 against 5a's new sparse code, and confirmed to be the
+      pre-existing shape of `speculative_accept_greedy_drafts_kernel` on `master` — 5a made the
+      other routes match that pattern rather than introducing it. Initially descoped as "touches
+      code PR #18 never modified"; that was the wrong call, because the fix is cheap.
+
+      All five greedy sites now validate the committed span `[0, accepted_count]`:
+      the two sparse warp routes with a single `__ballot_sync` (one lane per column, and
+      `a <= extent <= k <= 15` always fits a warp), the single-block greedy+penalties path by
+      accumulating into a shared flag inside the column loop it already runs, and both dense
+      multiblock routes through the shared `speculative_commit_span_is_finite` helper.
+
+      Verified adversarially: reverting only the sparse warp path to terminal-only produces **40
+      failures, all 40 in the new poisoned-matched-column cases**, with every terminal-column case
+      still passing.
 ## 5b. Reproducibility
 
 - [ ] **fp8, k8v4 and nvfp4 causal attention are not run-to-run deterministic.** Running

--- a/TODO.md
+++ b/TODO.md
@@ -288,6 +288,16 @@ about it fails on a different one.
       and clean rows mixed in one batch. Verified adversarially: reverting the guard produces 60
       failures. The last two routes were found by CodePulse review on PR #18.
 
+      *Also found while adding coverage for the dense multiblock routes:* `sampling_adjusted_logit`
+      applied presence/frequency penalty subtraction to non-finite raw logits unconditionally.
+      CUDA's NaN canonicalization on that subtraction produces a different bit pattern than an
+      untouched NaN, which the total-order sort key (`score_id_order_key`) ranks as strictly higher
+      -- so a poisoned verify column's already-drafted (penalized) token could spuriously win the
+      greedy top-1 selection and get accepted, moving the terminal to a later, clean column and
+      evading the finiteness guard entirely. `sampling_adjusted_logit` now returns a non-finite raw
+      value unperturbed, so every non-finite entry in a poisoned column stays bit-identical and the
+      guard sees whichever one the id tie-break selects.
+
 ## 5b. Reproducibility
 
 - [ ] **fp8, k8v4 and nvfp4 causal attention are not run-to-run deterministic.** Running

--- a/TODO.md
+++ b/TODO.md
@@ -298,6 +298,27 @@ about it fails on a different one.
       value unperturbed, so every non-finite entry in a poisoned column stays bit-identical and the
       guard sees whichever one the id tie-break selects.
 
+## 5c. Greedy acceptance only tests the divergence column, not accepted matches
+
+- [ ] Every greedy route (`speculative_accept_greedy_drafts_kernel`'s no-penalty and penalized
+      paths, `speculative_sampling_group_finalize_kernel<false>`'s no-penalty and penalized paths,
+      and both sparse warp routes closed by 5a) walks `while (a < extent && row_targets[a] ==
+      row_drafts[a]) ++a;` and tests `sampling_selected_logit_is_finite` only at column `a`, the
+      divergence/terminal column. **A column before `a` is never checked.** If a diverged forward
+      pass produces an all-NaN row whose argmax (undefined under NaN comparisons -- see
+      `sampling_better`) happens to equal that column's draft token, the round accepts it as a
+      match and folds it into `licensed_tokens` with no finiteness check at all; the guard only
+      ever sees whichever later, possibly-clean column becomes the terminal.
+      **Raised by CodePulse on PR #18, against 5a's new sparse-greedy code** (`speculative_round.cuh:178`),
+      but confirmed to be the pre-existing shape of `speculative_accept_greedy_drafts_kernel`'s
+      no-penalty path already on `master` before PR #18 -- 5a made the other three routes match
+      this pattern, not introduce it. **Descoped from PR #18**: closing it means validating
+      finiteness of every accepted column in all four greedy routes (an extra
+      `sampling_selected_logit_is_finite` read per accepted column, not just the terminal), which
+      touches code PR #18 never modified and changes the acceptance protocol uniformly rather than
+      guarding one more call site. That is a distinct effort from "make the new routes match the
+      established pattern," which is what PR #18 shipped.
+
 ## 5b. Reproducibility
 
 - [ ] **fp8, k8v4 and nvfp4 causal attention are not run-to-run deterministic.** Running

--- a/TODO.md
+++ b/TODO.md
@@ -261,26 +261,32 @@ about it fails on a different one.
       `README.md` is already correct here: its "## Upstream" section contrasts upstream's
       RTX 5090/`sm_120a` target with this fork's SM86 layer, so it needs no change.
 
-## 5a. Sparse speculative raw-greedy has no finiteness guard
+## 5a. Speculative greedy finiteness guard — done
 
-- [ ] **Thread a per-row finiteness signal into `speculative_accept_sparse_warp_greedy_kernel`.**
-      Every other commit path now refuses to license a token chosen from a non-finite column:
-      the dense routes test `sampling_selected_logit_is_finite`/`sampling_value_is_finite`, and
-      `speculative_sparse_warp_accept` now tests the weight behind its chosen terminal. The
-      sparse **raw-greedy** route cannot: its kernel receives `target_tokens` (ints) and never
-      sees a float, so `speculative_sparse_warp_greedy` passes `true` with that stated at the
-      call site.
+- [x] ~~Thread a per-row finiteness signal into `speculative_accept_sparse_warp_greedy_kernel`.~~
+      **Done, and it was both smaller and larger than this entry assumed.**
 
-      Closing it means changing `speculative_accept_sparse_drafts_launch` and the kernel
-      signature to carry either the verify logits or a precomputed per-row finite flag, plus its
-      callers, plus regression cases in `tests/ops/test_speculative_round.cpp` for both sparse
-      routes. That is a signature change across the launcher boundary, so it was descoped from
-      the catch-up PR rather than designed under review pressure — the bounded half (the accept
-      path, which has numerics in scope) is fixed there.
+      *Smaller:* no signature change across the launcher boundary was needed.
+      `speculative_accept_sparse_drafts_launch` already receives the verify logits and already
+      computes `physical_rows`; the raw-greedy branch simply ignored them. Only the kernel
+      signatures lacked the parameters.
 
-      Worth knowing when prioritising: an all-NaN target column on this route licenses an
-      arbitrary token and advances the sequence length instead of returning
-      `kSamplerNonFiniteToken`. Raised by CodePulse on PR #16.
+      *Larger:* this entry claimed "every other commit path now refuses to license a token chosen
+      from a non-finite column". That was wrong. **Four** greedy routes were passing a hardcoded
+      `true`, not one:
+        - sparse raw-greedy (the route this entry described);
+        - dense multiblock `speculative_sampling_group_finalize_kernel<false>`, no penalties;
+        - dense penalized greedy, in the same kernel's general path;
+        - sparse penalized greedy, in `speculative_sparse_warp_accept`'s greedy branch.
+
+      All four now test the raw verify logit of the token they are about to license, which is the
+      signal the single-block dense kernel has always used. Penalties change the score that selects
+      the terminal but not the logit behind it, and a diverged pass makes the whole column NaN
+      before any penalty applies.
+
+      Regression cases in `tests/ops/test_speculative_round.cpp` cover every route with poisoned
+      and clean rows mixed in one batch. Verified adversarially: reverting the guard produces 60
+      failures. The last two routes were found by CodePulse review on PR #18.
 
 ## 5b. Reproducibility
 

--- a/src/ops/kernel/sampling_device.cuh
+++ b/src/ops/kernel/sampling_device.cuh
@@ -259,6 +259,17 @@ __device__ __forceinline__ int sampling_dist_offset(int col, int j) {
 __device__ __forceinline__ float sampling_adjusted_logit(float raw, int v, const SamplingConfig& c,
                                                          const std::int32_t* overlay = nullptr,
                                                          int overlay_len             = 0) {
+    // A non-finite raw logit must sort as itself, unperturbed. Penalty subtraction on NaN is legal
+    // IEEE-754 but not required to preserve the operand's bit pattern, and CUDA's hardware NaN
+    // canonicalization does not: `NaN - presence_penalty` comes back as a different NaN encoding
+    // than an untouched NaN, which score_id_order_key's total-order key treats as a *different,
+    // higher* score. Since the penalty overlay is round-local (only already-drafted tokens get
+    // subtracted), a poisoned verify column would then rank its drafted token above every other
+    // (untouched-NaN) candidate in that same column -- letting a diverged forward pass spuriously
+    // "match" the draft and licensing it as accepted instead of tripping the finiteness guard.
+    // Returning raw unchanged keeps every non-finite entry in a column bit-identical, so ties fall
+    // back to the id tie-break and the guard sees whichever one wins.
+    if (!sampling_value_is_finite(raw)) { return raw; }
     float x = raw;
     if (c.presence_penalty == 0.0f && c.frequency_penalty == 0.0f) { return x; }
     int cnt = c.token_counts != nullptr ? c.token_counts[v] : 0;

--- a/src/ops/kernel/speculative_round.cuh
+++ b/src/ops/kernel/speculative_round.cuh
@@ -189,9 +189,10 @@ __global__ __launch_bounds__(256) void speculative_accept_sparse_warp_greedy_ker
 }
 
 __device__ __forceinline__ void speculative_sparse_warp_accept(
-    SamplingWorkspace workspace, const int* drafts, const int* candidate_ids,
-    const float* proposal_q, const SamplingConfig& cfg, int k, int row, int extent, bool greedy,
-    int* lengths, int* anchors, int* licensed_tokens, int* licensed_counts, int* accepted) {
+    SamplingWorkspace workspace, const __nv_bfloat16* logits, const int* drafts,
+    const int* candidate_ids, const float* proposal_q, const SamplingConfig& cfg, int k, int row,
+    int extent, bool greedy, int* lengths, int* anchors, int* licensed_tokens, int* licensed_counts,
+    int* accepted, int physical_rows) {
     const int lane       = threadIdx.x & 31;
     const int old_length = lengths[row];
     bool reject          = false;
@@ -225,10 +226,18 @@ __device__ __forceinline__ void speculative_sparse_warp_accept(
     // this offset is caller-owned scratch that this round never wrote. Reading it would make the
     // guard depend on stale memory and could reject a perfectly good terminal -- worse than the
     // gap it closes. Per-row greedy inside a mixed batch is a supported route, not a corner.
+    //
+    // The greedy branch instead tests the raw verify logit of the token it is about to license,
+    // which is the same source every other greedy route uses. This route is reached with penalties
+    // applied to the selecting score; the underlying logit is unaffected by that and is still what
+    // says whether the forward pass diverged.
     bool terminal_is_finite;
     if (greedy) {
-        terminal           = workspace.dist_idx[sampling_dist_offset(a, 0)];
-        terminal_is_finite = true;
+        terminal = workspace.dist_idx[sampling_dist_offset(a, 0)];
+        const __nv_bfloat16* row_logits =
+            logits + static_cast<std::int64_t>(row) * (k + 1) * physical_rows;
+        terminal_is_finite = sampling_selected_logit_is_finite(
+            row_logits, static_cast<std::int64_t>(a) * physical_rows, terminal);
     } else {
         const int n  = workspace.dist_support[a];
         int token    = 0;
@@ -655,9 +664,10 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group
             }
             __syncthreads();
             if (last_column && tid < 32)
-                speculative_sparse_warp_accept(workspace, drafts, candidate_ids, proposal_q, cfg, k,
-                                               row, extent, true, lengths, anchors, licensed_tokens,
-                                               licensed_counts, accepted);
+                speculative_sparse_warp_accept(workspace, logits, drafts, candidate_ids, proposal_q,
+                                               cfg, k, row, extent, true, lengths, anchors,
+                                               licensed_tokens, licensed_counts, accepted,
+                                               physical_rows);
             if (last_column && tid == 0) *workspace.speculative_finalize_count = 0;
             return;
         }
@@ -675,9 +685,9 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group
         }
         __syncthreads();
         if (last_column && tid < 32)
-            speculative_sparse_warp_accept(workspace, drafts, candidate_ids, proposal_q, cfg, k,
-                                           row, extent, false, lengths, anchors, licensed_tokens,
-                                           licensed_counts, accepted);
+            speculative_sparse_warp_accept(workspace, logits, drafts, candidate_ids, proposal_q, cfg,
+                                           k, row, extent, false, lengths, anchors, licensed_tokens,
+                                           licensed_counts, accepted, physical_rows);
         if (last_column && tid == 0) *workspace.speculative_finalize_count = 0;
         return;
     } else {
@@ -700,16 +710,24 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group
                         tstar = selected;
                         break;
                     }
-                    // Greedy branch writes only dist_idx, so no probability is available to test;
-                    // see the note on the target-token greedy path above.
+                    // This is the penalized greedy route: presence/frequency penalties changed the
+                    // score that selected tstar, but the raw verify logit is still what says
+                    // whether the forward pass diverged, and a NaN row is NaN before any penalty is
+                    // applied. The greedy branch writes only dist_idx, so there is no probability
+                    // to test -- but the logits themselves are in scope, which is what the
+                    // no-penalty route above tests too.
                     // Dense only: this statement lives in the else of `if constexpr (SparseProposal)`, so it
                     // is instantiated with SparseProposal == false and token counts are updated.
                     // Spelled `true` rather than `!SparseProposal` because the double negative
                     // reads as if it could disable the counts here, which it cannot.
                     static_assert(!SparseProposal, "dense finalize path only");
+                    const __nv_bfloat16* row_logits =
+                        logits + static_cast<std::int64_t>(row) * cols * physical_rows;
+                    const std::int64_t tstar_base = static_cast<std::int64_t>(a) * physical_rows;
                     speculative_store_accept_result<true>(
                         row_drafts, k, row, a, tstar, lengths, anchors, row_tokens, licensed_counts,
-                        accepted, &cfg, true);
+                        accepted, &cfg,
+                        sampling_selected_logit_is_finite(row_logits, tstar_base, tstar));
                     *workspace.speculative_finalize_count = 0;
                 }
             }

--- a/src/ops/kernel/speculative_round.cuh
+++ b/src/ops/kernel/speculative_round.cuh
@@ -100,6 +100,32 @@ speculative_store_accept_result(const std::int32_t* row_drafts, std::int32_t k, 
     }
 }
 
+// Every column a greedy round commits from must be finite, not only the terminal.
+//
+// Columns before the divergence point are accepted *because* the target's argmax matched the
+// draft. If such a column's logits are all NaN, that argmax is arbitrary, so the match is
+// meaningless and the round licenses a token the target never actually endorsed -- and then
+// advances past it, because a finite terminal further along still passes a terminal-only check.
+// Testing the whole committed span [0, accepted_count] closes that: the span is exactly the set of
+// columns whose verdicts the round is about to act on.
+//
+// `column_token(i)` returns the token this round would license at column i, so the caller decides
+// where that comes from -- target ids for the target-token routes, workspace.dist_idx for the
+// sampling-workspace ones.
+template <typename ColumnToken>
+__device__ __forceinline__ bool
+speculative_commit_span_is_finite(const __nv_bfloat16* row_logits, std::int32_t accepted_count,
+                                  std::int32_t physical_rows, ColumnToken column_token) {
+    for (int column = 0; column <= accepted_count; ++column) {
+        if (!sampling_selected_logit_is_finite(
+                row_logits, static_cast<std::int64_t>(column) * physical_rows,
+                column_token(column))) {
+            return false;
+        }
+    }
+    return true;
+}
+
 __device__ __forceinline__ float speculative_sparse_probability(const std::int32_t* candidate_ids,
                                                                 const float* proposal_q,
                                                                 std::int32_t token) {
@@ -155,8 +181,7 @@ __device__ __forceinline__ void speculative_sparse_warp_store(const int* drafts,
 
 // `logits` is the same verify-logit block the dense greedy path checks, laid out
 // [row][column][physical_rows]; `physical_rows` is its innermost stride. It is read only to test
-// the chosen terminal's logit for finiteness, exactly as speculative_accept_greedy_drafts_kernel
-// does at its own divergence column, so the two greedy routes now refuse a NaN column alike.
+// the committed span for finiteness, so the greedy routes all refuse a NaN column alike.
 __device__ __forceinline__ void speculative_sparse_warp_greedy(
     const int* target_tokens, const __nv_bfloat16* logits, const int* drafts, int* lengths,
     int* anchors, int* licensed_tokens, int* licensed_counts, int* accepted, int row, int extent,
@@ -172,10 +197,16 @@ __device__ __forceinline__ void speculative_sparse_warp_greedy(
     // computing it on one lane and shuffling, which costs more than the redundant load.
     const __nv_bfloat16* row_logits =
         logits + static_cast<std::int64_t>(row) * (k + 1) * physical_rows;
-    const std::int64_t terminal_base = static_cast<std::int64_t>(a) * physical_rows;
-    speculative_sparse_warp_store(
-        drafts, k, row, a, terminal, lengths, anchors, licensed_tokens, licensed_counts, accepted,
-        sampling_selected_logit_is_finite(row_logits, terminal_base, terminal));
+    // One lane per column of the committed span, so the whole span costs a single ballot rather
+    // than the sequential loop the single-threaded routes need. `a <= extent <= k <= 15`, so the
+    // span always fits inside the warp.
+    const bool lane_is_non_finite =
+        lane <= a && !sampling_selected_logit_is_finite(
+                         row_logits, static_cast<std::int64_t>(lane) * physical_rows,
+                         target_tokens[row * (k + 1) + lane]);
+    const bool span_is_finite = __ballot_sync(0xffffffffU, lane_is_non_finite) == 0u;
+    speculative_sparse_warp_store(drafts, k, row, a, terminal, lengths, anchors, licensed_tokens,
+                                  licensed_counts, accepted, span_is_finite);
 }
 
 __global__ __launch_bounds__(256) void speculative_accept_sparse_warp_greedy_kernel(
@@ -236,8 +267,15 @@ __device__ __forceinline__ void speculative_sparse_warp_accept(
         terminal = workspace.dist_idx[sampling_dist_offset(a, 0)];
         const __nv_bfloat16* row_logits =
             logits + static_cast<std::int64_t>(row) * (k + 1) * physical_rows;
-        terminal_is_finite = sampling_selected_logit_is_finite(
-            row_logits, static_cast<std::int64_t>(a) * physical_rows, terminal);
+        // The whole committed span, one lane per column, for the reason given at
+        // speculative_commit_span_is_finite: a matched column whose logits are all NaN matched by
+        // accident. The tokens come from dist_idx here rather than from target ids, because that
+        // is what this route's acceptance comparison above reads.
+        const bool lane_is_non_finite =
+            lane <= a && !sampling_selected_logit_is_finite(
+                             row_logits, static_cast<std::int64_t>(lane) * physical_rows,
+                             workspace.dist_idx[sampling_dist_offset(lane, 0)]);
+        terminal_is_finite = __ballot_sync(0xffffffffU, lane_is_non_finite) == 0u;
     } else {
         const int n  = workspace.dist_support[a];
         int token    = 0;
@@ -341,6 +379,10 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
     __shared__ int done_sh;
     __shared__ int tstar_sh;
     __shared__ int L_sh;
+    // Set when any column of the committed span selected a non-finite logit -- see
+    // speculative_commit_span_is_finite. Accumulated as the greedy loop below walks the columns,
+    // which is cheaper than a second pass over the same logits.
+    __shared__ int span_non_finite_sh;
 
     const int partial_blocks = div_up(token_domain, kSamplerPartialTileItems);
     const int group_count    = sampler_group_count(partial_blocks);
@@ -348,10 +390,11 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
     if (sampler_multiblock_ok(token_domain, cols, partial_blocks, group_count)) { return; }
 
     if (tid == 0) {
-        a_sh     = 0;
-        done_sh  = 0;
-        tstar_sh = 0;
-        L_sh     = lengths[row];
+        a_sh               = 0;
+        done_sh            = 0;
+        tstar_sh           = 0;
+        L_sh               = lengths[row];
+        span_non_finite_sh = 0;
     }
     __syncthreads();
 
@@ -381,6 +424,13 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
             }
             if (tid == 0) {
                 const int selected = red_idx[0];
+                // Every column this loop visits is part of the committed span: the ones that match
+                // are accepted, and the one that does not becomes the terminal. A NaN column's
+                // argmax is arbitrary, so a match against it is meaningless -- record it here
+                // rather than testing only the terminal after the loop.
+                if (!sampling_selected_logit_is_finite(row_logits, base, selected)) {
+                    span_non_finite_sh = 1;
+                }
                 if (i < extent && selected == row_drafts[i]) {
                     a_sh = i + 1;
                 } else {
@@ -395,11 +445,9 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_accept_greedy_draft
         if (tid == 0) {
             const int a     = a_sh;
             const int tstar = tstar_sh;
-            const std::int64_t tstar_base = static_cast<std::int64_t>(a) * physical_rows;
             speculative_store_accept_result<true>(
                 row_drafts, k, row, a, tstar, lengths, anchors, row_tokens, licensed_counts,
-                accepted, &cfg,
-                sampling_selected_logit_is_finite(row_logits, tstar_base, tstar));
+                accepted, &cfg, span_non_finite_sh == 0);
         }
         return;
     }
@@ -576,11 +624,12 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group
                 static_assert(!SparseProposal, "dense finalize path only");
                 const __nv_bfloat16* row_logits =
                     logits + static_cast<std::int64_t>(row) * cols * physical_rows;
-                const std::int64_t t_star_base = static_cast<std::int64_t>(a) * physical_rows;
                 speculative_store_accept_result<true>(
                     row_drafts, k, row, a, t_star, lengths, anchors, row_tokens, licensed_counts,
                     accepted, &cfg,
-                    sampling_selected_logit_is_finite(row_logits, t_star_base, t_star));
+                    speculative_commit_span_is_finite(
+                        row_logits, a, physical_rows,
+                        [&](std::int32_t column) { return row_targets[column]; }));
             }
         }
         return;
@@ -723,11 +772,13 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group
                     static_assert(!SparseProposal, "dense finalize path only");
                     const __nv_bfloat16* row_logits =
                         logits + static_cast<std::int64_t>(row) * cols * physical_rows;
-                    const std::int64_t tstar_base = static_cast<std::int64_t>(a) * physical_rows;
                     speculative_store_accept_result<true>(
                         row_drafts, k, row, a, tstar, lengths, anchors, row_tokens, licensed_counts,
                         accepted, &cfg,
-                        sampling_selected_logit_is_finite(row_logits, tstar_base, tstar));
+                        speculative_commit_span_is_finite(
+                            row_logits, a, physical_rows, [&](std::int32_t column) {
+                                return workspace.dist_idx[sampling_dist_offset(column, 0)];
+                            }));
                     *workspace.speculative_finalize_count = 0;
                 }
             }

--- a/src/ops/kernel/speculative_round.cuh
+++ b/src/ops/kernel/speculative_round.cuh
@@ -153,31 +153,39 @@ __device__ __forceinline__ void speculative_sparse_warp_store(const int* drafts,
     }
 }
 
-__device__ __forceinline__ void speculative_sparse_warp_greedy(const int* target_tokens,
-                                                               const int* drafts, int* lengths,
-                                                               int* anchors, int* licensed_tokens,
-                                                               int* licensed_counts, int* accepted,
-                                                               int row, int extent, int k) {
+// `logits` is the same verify-logit block the dense greedy path checks, laid out
+// [row][column][physical_rows]; `physical_rows` is its innermost stride. It is read only to test
+// the chosen terminal's logit for finiteness, exactly as speculative_accept_greedy_drafts_kernel
+// does at its own divergence column, so the two greedy routes now refuse a NaN column alike.
+__device__ __forceinline__ void speculative_sparse_warp_greedy(
+    const int* target_tokens, const __nv_bfloat16* logits, const int* drafts, int* lengths,
+    int* anchors, int* licensed_tokens, int* licensed_counts, int* accepted, int row, int extent,
+    int k, int physical_rows) {
     const int lane = threadIdx.x & 31;
     const bool reject =
         lane < extent && target_tokens[row * (k + 1) + lane] != drafts[row * k + lane];
     const unsigned mask = __ballot_sync(0xffffffffU, reject);
     const int a         = mask ? __ffs(mask) - 1 : extent;
     const int terminal  = target_tokens[row * (k + 1) + a];
-    // No numeric in scope: this route receives target token ids, never logits, so there is nothing
-    // here to test for finiteness. Threading a per-row finite flag in needs a signature change
-    // across the launcher and its callers -- tracked in TODO.md rather than done under review.
-    speculative_sparse_warp_store(drafts, k, row, a, terminal, lengths, anchors, licensed_tokens,
-                                  licensed_counts, accepted, true);
+    // `a` and `terminal` are warp-uniform -- `a` comes from a ballot, `terminal` from a uniform
+    // load -- so every lane computes the same answer here. That is deliberate: the alternative is
+    // computing it on one lane and shuffling, which costs more than the redundant load.
+    const __nv_bfloat16* row_logits =
+        logits + static_cast<std::int64_t>(row) * (k + 1) * physical_rows;
+    const std::int64_t terminal_base = static_cast<std::int64_t>(a) * physical_rows;
+    speculative_sparse_warp_store(
+        drafts, k, row, a, terminal, lengths, anchors, licensed_tokens, licensed_counts, accepted,
+        sampling_selected_logit_is_finite(row_logits, terminal_base, terminal));
 }
 
 __global__ __launch_bounds__(256) void speculative_accept_sparse_warp_greedy_kernel(
-    const int* target_tokens, const int* drafts, const int* current_extents, int* lengths,
-    int* anchors, int* licensed_tokens, int* licensed_counts, int* accepted, int k) {
+    const int* target_tokens, const __nv_bfloat16* logits, const int* drafts,
+    const int* current_extents, int* lengths, int* anchors, int* licensed_tokens,
+    int* licensed_counts, int* accepted, int k, int physical_rows) {
     const int row    = threadIdx.x / 32;
     const int extent = min(k, max(0, current_extents[row]));
-    speculative_sparse_warp_greedy(target_tokens, drafts, lengths, anchors, licensed_tokens,
-                                   licensed_counts, accepted, row, extent, k);
+    speculative_sparse_warp_greedy(target_tokens, logits, drafts, lengths, anchors, licensed_tokens,
+                                   licensed_counts, accepted, row, extent, k, physical_rows);
 }
 
 __device__ __forceinline__ void speculative_sparse_warp_accept(
@@ -517,12 +525,13 @@ __launch_bounds__(kSamplerBlock) __global__ void speculative_sampling_partial_to
 
 template <bool SparseProposal>
 __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group_finalize_kernel(
-    const std::int32_t* target_tokens, const std::int32_t* drafts,
+    const std::int32_t* target_tokens, const __nv_bfloat16* logits, const std::int32_t* drafts,
     const std::int32_t* candidate_ids, const float* proposal_q, const std::int32_t* current_extents,
     std::int32_t* lengths, std::int32_t* anchors, std::int32_t* licensed_tokens,
     std::int32_t* licensed_counts, std::int32_t* accepted, const SamplingConfig* configs,
     std::int32_t token_domain, std::int32_t cols, std::int32_t partial_blocks,
-    std::int32_t group_count, SamplingWorkspace workspace, std::size_t workspace_row_stride) {
+    std::int32_t group_count, std::int32_t physical_rows, SamplingWorkspace workspace,
+    std::size_t workspace_row_stride) {
     const int row   = static_cast<int>(blockIdx.z);
     const int group = static_cast<int>(blockIdx.x);
     const int col   = static_cast<int>(blockIdx.y);
@@ -542,26 +551,27 @@ __launch_bounds__(kSamplerGroupBlock) __global__ void speculative_sampling_group
     if (greedy && !penalties) {
         if constexpr (SparseProposal) {
             if (tid < 32 && col == 0 && group == 0)
-                speculative_sparse_warp_greedy(target_tokens, drafts, lengths, anchors,
+                speculative_sparse_warp_greedy(target_tokens, logits, drafts, lengths, anchors,
                                                licensed_tokens, licensed_counts, accepted, row,
-                                               extent, k);
+                                               extent, k, physical_rows);
         } else {
 
             if (tid == 0 && col == 0 && group == 0) {
                 int a = 0;
                 while (a < extent && row_targets[a] == row_drafts[a]) { ++a; }
                 const int t_star = row_targets[a];
-                // No numeric in scope: this kernel receives target token ids, not logits, and the
-                // greedy comparison is int-vs-int. Divergence is caught by the finiteness checks
-                // on the logit-bearing dense kernels.
                 // Dense only: this statement lives in the else of `if constexpr (SparseProposal)`, so it
                 // is instantiated with SparseProposal == false and token counts are updated.
                 // Spelled `true` rather than `!SparseProposal` because the double negative
                 // reads as if it could disable the counts here, which it cannot.
                 static_assert(!SparseProposal, "dense finalize path only");
+                const __nv_bfloat16* row_logits =
+                    logits + static_cast<std::int64_t>(row) * cols * physical_rows;
+                const std::int64_t t_star_base = static_cast<std::int64_t>(a) * physical_rows;
                 speculative_store_accept_result<true>(
                     row_drafts, k, row, a, t_star, lengths, anchors, row_tokens, licensed_counts,
-                    accepted, &cfg, true);
+                    accepted, &cfg,
+                    sampling_selected_logit_is_finite(row_logits, t_star_base, t_star));
             }
         }
         return;

--- a/src/ops/launcher/speculative_round.cu
+++ b/src/ops/launcher/speculative_round.cu
@@ -89,13 +89,14 @@ void speculative_accept_greedy_drafts_launch(const Tensor& target_tokens, const 
     speculative_sampling_group_finalize_kernel<false>
         <<<batched_group_grid, kSamplerGroupBlock, 0, stream>>>(
             static_cast<const std::int32_t*>(target_tokens.data),
+            static_cast<const __nv_bfloat16*>(logits.data),
             static_cast<const std::int32_t*>(drafts.data), nullptr, nullptr,
             static_cast<const std::int32_t*>(current_extents.data),
             static_cast<std::int32_t*>(lengths.data), static_cast<std::int32_t*>(anchors.data),
             static_cast<std::int32_t*>(licensed_tokens.data),
             static_cast<std::int32_t*>(licensed_counts.data),
             static_cast<std::int32_t*>(accepted.data), configs, token_domain, cols, partial_blocks,
-            groups, scratch, layout.bytes);
+            groups, physical_rows, scratch, layout.bytes);
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -105,15 +106,18 @@ void speculative_accept_sparse_drafts_launch(
     Tensor& round_lengths, Tensor& round_anchors, Tensor& licensed_tokens, Tensor& licensed_counts,
     Tensor& accepted_drafts, std::int32_t token_domain, const SamplingConfig* configs,
     bool raw_greedy, DeviceSpan workspace, cudaStream_t stream) {
-    const std::int32_t batch = drafts.ne[1];
-    const std::int32_t k     = drafts.ne[0];
-    const std::int32_t cols  = k + 1;
+    const std::int32_t batch         = drafts.ne[1];
+    const std::int32_t k             = drafts.ne[0];
+    const std::int32_t cols          = k + 1;
+    const std::int32_t physical_rows = logits.ne[0];
     if (raw_greedy) {
         speculative_accept_sparse_warp_greedy_kernel<<<1, 32 * batch, 0, stream>>>(
-            static_cast<const int*>(target_tokens.data), static_cast<const int*>(drafts.data),
+            static_cast<const int*>(target_tokens.data),
+            static_cast<const __nv_bfloat16*>(logits.data), static_cast<const int*>(drafts.data),
             static_cast<const int*>(current_extents.data), static_cast<int*>(round_lengths.data),
             static_cast<int*>(round_anchors.data), static_cast<int*>(licensed_tokens.data),
-            static_cast<int*>(licensed_counts.data), static_cast<int*>(accepted_drafts.data), k);
+            static_cast<int*>(licensed_counts.data), static_cast<int*>(accepted_drafts.data), k,
+            physical_rows);
         CUDA_CHECK(cudaGetLastError());
         return;
     }
@@ -136,6 +140,7 @@ void speculative_accept_sparse_drafts_launch(
 
     speculative_sampling_group_finalize_kernel<true><<<group_grid, kSamplerGroupBlock, 0, stream>>>(
         static_cast<const std::int32_t*>(target_tokens.data),
+        static_cast<const __nv_bfloat16*>(logits.data),
         static_cast<const std::int32_t*>(drafts.data),
         static_cast<const std::int32_t*>(candidate_ids.data),
         static_cast<const float*>(proposal_q.data),
@@ -145,7 +150,7 @@ void speculative_accept_sparse_drafts_launch(
         static_cast<std::int32_t*>(licensed_tokens.data),
         static_cast<std::int32_t*>(licensed_counts.data),
         static_cast<std::int32_t*>(accepted_drafts.data), configs, token_domain, cols,
-        partial_blocks, groups, scratch, layout.bytes);
+        partial_blocks, groups, physical_rows, scratch, layout.bytes);
 
     CUDA_CHECK(cudaGetLastError());
 }

--- a/tests/ops/test_speculative_round.cpp
+++ b/tests/ops/test_speculative_round.cpp
@@ -375,10 +375,17 @@ struct SparseAcceptSuite {
         const std::vector<std::int32_t>& initial_anchors,
         const std::vector<ops::SamplingConfig>& host_configs,
         const std::vector<std::int32_t>& token_counts,
-        ops::SpeculativeAcceptExecutionEnvelope envelope) {
+        ops::SpeculativeAcceptExecutionEnvelope envelope,
+        const SparseExpected* expected_override = nullptr) {
+        // The oracle derives the greedy terminal from the truncated logit distribution. The
+        // non-finite fixture deliberately poisons that same logit, so the oracle cannot describe
+        // it -- those cases state their expectation directly instead. Graph replay is skipped with
+        // an override for the same reason: it re-runs the oracle against mutated extents.
         const SparseExpected expected =
-            sparse_accept_oracle(logits, drafts, candidate_ids, proposal_q, extents,
-                                 initial_lengths, host_configs, token_counts);
+            expected_override != nullptr
+                ? *expected_override
+                : sparse_accept_oracle(logits, drafts, candidate_ids, proposal_q, extents,
+                                       initial_lengths, host_configs, token_counts);
 
         DeviceBuffer d_target_tokens                    = to_device(target_tokens);
         DeviceBuffer d_logits                           = to_device(logits);
@@ -455,7 +462,7 @@ struct SparseAcceptSuite {
         if (workspace.used() != 0 || workspace.peak_used() != workspace_bytes) ++failures;
         failures += scratch.verify_guards(label + " workspace");
         observed_workspace = std::max(observed_workspace, workspace.peak_used());
-        if (kSparseBatch == 1 || kSparseBatch == 8) {
+        if (expected_override == nullptr && (kSparseBatch == 1 || kSparseBatch == 8)) {
             cudaStream_t stream = nullptr;
             cuda_check(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking),
                        "sparse graph stream");
@@ -608,6 +615,93 @@ struct SparseAcceptSuite {
                                               " B=" + std::to_string(kSparseBatch),
                                           targets, logits, drafts, ids, q, extents, lengths,
                                           anchors, configs, history, {!general});
+    }
+
+    // Regression for the gap CodePulse raised on PR #16: a greedy sparse round used to license
+    // whatever token sat at the divergence column even when the verify pass had produced an
+    // all-NaN row there, advancing the sequence with an arbitrary token instead of returning the
+    // non-finite sentinel. `poison` selects which rows get the NaN column, so a mixed batch proves
+    // the refusal is per row rather than a blanket one -- the unpoisoned rows must still commit
+    // normally in the same launch. Runs on both greedy sparse routes: raw (the dedicated warp
+    // kernel) and the multiblock group-finalize kernel's SparseProposal branch.
+    int sparse_non_finite_terminal_case(bool raw_greedy, int poison) {
+        std::vector<std::int32_t> targets(kSparseColumns * kSparseBatch),
+            drafts(kSparseDrafts * kSparseBatch);
+        std::vector<std::uint16_t> logits(static_cast<std::size_t>(kSparsePhysicalRows) *
+                                              kSparseColumns * kSparseBatch,
+                                          f32_to_bf16(-20.0f));
+        std::vector<int> ids(kSparseCandidates * kSparseDrafts * kSparseBatch),
+            extents(kSparseBatch, kSparseDrafts), lengths(kSparseBatch), anchors(kSparseBatch, -1);
+        std::vector<float> q(ids.size(), 0.0f);
+        // temperature 0 everywhere: this is the greedy contract, and the raw route requires it.
+        std::vector<ops::SamplingConfig> configs(kSparseBatch);
+        std::vector<int> history(kSparseTokenDomain * kSparseBatch, 3);
+
+        SparseExpected expected{
+            .licensed_tokens = std::vector<std::int32_t>(kSparseColumns * kSparseBatch, 0),
+            .licensed_counts = std::vector<std::int32_t>(kSparseBatch),
+            .accepted        = std::vector<std::int32_t>(kSparseBatch),
+            .lengths         = std::vector<std::int32_t>(kSparseBatch),
+            .anchors         = std::vector<std::int32_t>(kSparseBatch),
+        };
+
+        const float quiet_nan = std::numeric_limits<float>::quiet_NaN();
+        for (int row = 0; row < kSparseBatch; ++row) {
+            // Diverge at a different column per row so the poisoned column is not always the same
+            // one, and full acceptance (reject == kSparseDrafts) is covered too.
+            const int reject = (row + poison) % (kSparseDrafts + 1);
+            lengths[row]     = 4096 + row * 13;
+            for (int col = 0; col < kSparseColumns; ++col) {
+                const int target                             = 100000 + row * 128 + col;
+                targets[row * kSparseColumns + col]          = target;
+                logits[sparse_logit_index(row, col, target)] = f32_to_bf16(20.0f);
+                for (int v = kSparseTokenDomain; v < kSparsePhysicalRows; ++v)
+                    logits[sparse_logit_index(row, col, v)] = f32_to_bf16(100.0f);
+            }
+            for (int col = 0; col < kSparseDrafts; ++col) {
+                const int base = sparse_candidate_index(row, col, 0);
+                for (int rank = 0; rank < kSparseCandidates; ++rank)
+                    ids[base + rank] = 30000 + row * 1024 + col * 16 + rank;
+                ids[base]                         = targets[row * kSparseColumns + col];
+                const int rank                    = col == reject ? 15 : 0;
+                drafts[row * kSparseDrafts + col] = ids[base + rank];
+                q[base + rank]                    = 1.0f;
+            }
+            // Poison every other row. The NaN goes on the exact logit the kernel tests: the
+            // divergence column's target token.
+            const bool poisoned = (row & 1) == (poison & 1);
+            if (poisoned) {
+                logits[sparse_logit_index(row, reject, targets[row * kSparseColumns + reject])] =
+                    f32_to_bf16(quiet_nan);
+            }
+
+            const std::size_t row_base = static_cast<std::size_t>(row) * kSparseColumns;
+            if (poisoned) {
+                // The sentinel shape from speculative_sparse_warp_store: one licensed token,
+                // nothing accepted, and the length still advances by one so the caller's frontier
+                // stays consistent.
+                expected.licensed_tokens[row_base] = ops::kSamplerNonFiniteToken;
+                expected.licensed_counts[row]      = 1;
+                expected.accepted[row]             = 0;
+                expected.anchors[row]              = ops::kSamplerNonFiniteToken;
+                expected.lengths[row]              = lengths[row] + 1;
+            } else {
+                for (int item = 0; item < reject; ++item)
+                    expected.licensed_tokens[row_base + item] = drafts[row * kSparseDrafts + item];
+                expected.licensed_tokens[row_base + reject] =
+                    targets[row * kSparseColumns + reject];
+                expected.licensed_counts[row] = reject + 1;
+                expected.accepted[row]        = reject;
+                expected.anchors[row]         = targets[row * kSparseColumns + reject];
+                expected.lengths[row]         = lengths[row] + reject + 1;
+            }
+        }
+        return execute_sparse_accept_case(
+            "sparse non-finite terminal K=" + std::to_string(kSparseDrafts) + " B=" +
+                std::to_string(kSparseBatch) + (raw_greedy ? " raw" : " general") + " p" +
+                std::to_string(poison),
+            targets, logits, drafts, ids, q, extents, lengths, anchors, configs, history,
+            {raw_greedy}, &expected);
     }
 
     int generated_general_case() {
@@ -1266,6 +1360,20 @@ int main(int argc, char** argv) {
         failures += suite.sparse_greedy_direct_case(0, true);
         failures += SparseAcceptSuite(k, 1).repeated_history_case(false);
         failures += SparseAcceptSuite(k, 1).repeated_history_case(true);
+    }
+    // A greedy sparse round must refuse to license a token whose verify logit is non-finite. Both
+    // greedy sparse routes are covered -- raw (the dedicated warp kernel) and the multiblock
+    // group-finalize kernel -- and each batch mixes poisoned with clean rows, so a blanket refusal
+    // fails just as loudly as no refusal at all.
+    for (int k : {1, 7, 15}) {
+        for (int batch : {1, 8}) {
+            for (bool raw : {true, false}) {
+                for (int poison = 0; poison < 2; ++poison) {
+                    failures +=
+                        SparseAcceptSuite(k, batch).sparse_non_finite_terminal_case(raw, poison);
+                }
+            }
+        }
     }
 
     if (failures != 0) {

--- a/tests/ops/test_speculative_round.cpp
+++ b/tests/ops/test_speculative_round.cpp
@@ -942,6 +942,21 @@ AcceptExpected accept_state_oracle(const std::vector<std::int32_t>& drafts, std:
     return expected;
 }
 
+// The refusal shape from speculative_store_accept_result's non-finite branch: one licensed
+// sentinel token, nothing accepted, length still advances by one so the caller's frontier stays
+// consistent.
+AcceptExpected non_finite_accept_oracle(int k, std::int32_t initial_length) {
+    AcceptExpected expected{
+        .sampled     = std::vector<std::int32_t>(static_cast<std::size_t>(k + 1), 0),
+        .num_sampled = 1,
+        .accepted    = 0,
+        .length      = initial_length + 1,
+        .token       = ops::kSamplerNonFiniteToken,
+    };
+    expected.sampled[0] = ops::kSamplerNonFiniteToken;
+    return expected;
+}
+
 int execute_accept_case(const std::string& label, const std::vector<std::int32_t>& target_tokens,
                         const std::vector<std::uint16_t>& logits_bits, int physical_rows,
                         const std::vector<std::int32_t>& drafts, std::int32_t initial_length,
@@ -1009,8 +1024,14 @@ int execute_accept_case(const std::string& label, const std::vector<std::int32_t
                              config_before);
 
     auto expected_counts = initial_token_counts;
-    for (int i = 0; i < expected.num_sampled; ++i) {
-        ++expected_counts[static_cast<std::size_t>(expected.sampled[static_cast<std::size_t>(i)])];
+    // The non-finite sentinel branch returns before speculative_store_accept_result's
+    // UpdateTokenCounts block, so counts must stay untouched -- indexing token_counts by
+    // kSamplerNonFiniteToken (-1) would be out of bounds.
+    if (expected.token != ops::kSamplerNonFiniteToken) {
+        for (int i = 0; i < expected.num_sampled; ++i) {
+            ++expected_counts[static_cast<std::size_t>(
+                expected.sampled[static_cast<std::size_t>(i)])];
+        }
     }
     failures +=
         verify_exact((label + " token counts").c_str(),
@@ -1117,6 +1138,83 @@ int greedy_penalty_case(int token_domain) {
     return execute_accept_case(
         "speculative greedy penalty token-domain=" + std::to_string(token_domain), raw_targets,
         bits, token_domain, drafts, 100, token_domain, config, counts, expected);
+}
+
+// Regression for the gap CodePulse raised on PR #18: the sparse suite below covers the sparse
+// greedy non-finite guards, but nothing exercised the dense guards at
+// speculative_sampling_group_finalize_kernel<false> -- reachable only when token_domain exceeds
+// kSamplerTileItems, which routes execution off the single-block kernel above and onto the
+// partial/group top-k pipeline. `poison` off reruns the ordinary accept/divergence shape (a
+// cross-check that the harness change here does not itself alter a passing case); `poison` on
+// makes the licensed terminal's own verify logit NaN and expects the refusal sentinel instead.
+int greedy_multiblock_non_finite_case(int accepted_count, int token_domain, bool poison) {
+    constexpr int k = 3;
+    std::vector<std::int32_t> targets(static_cast<std::size_t>(k + 1));
+    std::vector<std::int32_t> drafts(static_cast<std::size_t>(k));
+    for (int i = 0; i <= k; ++i) {
+        targets[static_cast<std::size_t>(i)] = 3 + 2 * i;
+        if (i < k) drafts[static_cast<std::size_t>(i)] = targets[static_cast<std::size_t>(i)];
+    }
+    if (accepted_count < k) {
+        drafts[static_cast<std::size_t>(accepted_count)] =
+            targets[static_cast<std::size_t>(accepted_count)] + 1;
+    }
+    const std::int32_t initial_length = 500;
+    const std::int32_t terminal       = targets[static_cast<std::size_t>(accepted_count)];
+    std::vector<float> logits(static_cast<std::size_t>(token_domain) * (k + 1), -20.0f);
+    if (poison) {
+        logits[static_cast<std::size_t>(accepted_count) * static_cast<std::size_t>(token_domain) +
+               static_cast<std::size_t>(terminal)] = std::numeric_limits<float>::quiet_NaN();
+    }
+    std::vector<std::uint16_t> bits(logits.size());
+    for (std::size_t i = 0; i < logits.size(); ++i) bits[i] = f32_to_bf16(logits[i]);
+    std::vector<std::int32_t> token_counts(static_cast<std::size_t>(token_domain), 0);
+    const auto expected =
+        poison ? non_finite_accept_oracle(k, initial_length)
+               : accept_state_oracle(drafts, accepted_count, terminal, initial_length);
+    return execute_accept_case(
+        "speculative greedy multiblock no-penalty token-domain=" + std::to_string(token_domain) +
+            " A=" + std::to_string(accepted_count) + " poison=" + std::to_string(poison), targets,
+        bits, token_domain, drafts, initial_length, token_domain, ops::SamplingConfig{},
+        token_counts, expected);
+}
+
+// Same regression, for the penalized dense multiblock branch fixed alongside its sparse
+// counterpart in 7107528f. That route picks the terminal from the *penalized* top-k rather than
+// reading target_tokens, and a NaN does not sort predictably against finite candidates, so poison
+// the entire divergence column (index 1, where drafts[1] fails to survive the presence penalty)
+// rather than one logit -- an all-NaN column is also what a diverged forward pass actually
+// produces. This mirrors sparse_non_finite_terminal_case's penalized poisoning exactly.
+int greedy_penalty_non_finite_case(int token_domain, bool poison) {
+    constexpr int k = 2;
+    const std::vector<std::int32_t> drafts{1, 1};
+    const std::vector<std::int32_t> raw_targets{1, 1, 3};
+    std::vector<float> logits(static_cast<std::size_t>(token_domain) * (k + 1), -20.0F);
+    logits[1]                    = 5.0F;
+    logits[token_domain + 1]     = 5.0F;
+    logits[token_domain + 4]     = 4.5F;
+    logits[2 * token_domain + 3] = 5.0F;
+    if (poison) {
+        for (int v = 0; v < token_domain; ++v) {
+            logits[static_cast<std::size_t>(token_domain) + static_cast<std::size_t>(v)] =
+                std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+    std::vector<std::uint16_t> bits(logits.size());
+    for (std::size_t index = 0; index < logits.size(); ++index) {
+        bits[index] = f32_to_bf16(logits[index]);
+    }
+
+    ops::SamplingConfig config{};
+    config.temperature      = 0.0F;
+    config.presence_penalty = 1.0F;
+    const std::vector<std::int32_t> counts(static_cast<std::size_t>(token_domain), 0);
+    const auto expected =
+        poison ? non_finite_accept_oracle(k, 100) : accept_state_oracle(drafts, 1, 4, 100);
+    return execute_accept_case(
+        "speculative greedy penalty multiblock non-finite token-domain=" +
+            std::to_string(token_domain) + " poison=" + std::to_string(poison),
+        raw_targets, bits, token_domain, drafts, 100, token_domain, config, counts, expected);
 }
 
 int batched_sampling_workspace_stride_case() {
@@ -1344,6 +1442,13 @@ int main(int argc, char** argv) {
     failures += greedy_accept_case(15, 7, 257);
     failures += greedy_penalty_case(64);
     failures += greedy_penalty_case(257);
+    // Dense multiblock greedy non-finite guards (token_domain=257 > kSamplerTileItems=256):
+    // no-penalty and penalized branches, each with a clean cross-check and a poisoned refusal.
+    for (bool poison : {false, true}) {
+        failures += greedy_multiblock_non_finite_case(0, 257, poison);
+        failures += greedy_multiblock_non_finite_case(3, 257, poison);
+        failures += greedy_penalty_non_finite_case(257, poison);
+    }
     failures += deterministic_sampling_case();
     failures += batched_sampling_workspace_stride_case();
     std::size_t sparse_peak = 0;

--- a/tests/ops/test_speculative_round.cpp
+++ b/tests/ops/test_speculative_round.cpp
@@ -630,7 +630,15 @@ struct SparseAcceptSuite {
     // top-k rather than reading target_tokens, and a NaN does not sort predictably, so the poison
     // there is the whole column -- which is what a diverged forward pass actually produces. The
     // raw route reads target_tokens directly, so poisoning that one logit is exact.
-    int sparse_non_finite_terminal_case(bool raw_greedy, int poison, bool penalized = false) {
+    // `poison_matched` moves the NaN off the divergence column and onto a column the round
+    // *accepts*. Both sparse greedy routes read target_tokens directly, so the match still
+    // succeeds -- the ids say "the target picked what the draft proposed" while the logits behind
+    // that verdict are NaN, which is precisely the case a terminal-only guard waves through: it
+    // licenses the accepted draft and then commits on a finite terminal further along. Only
+    // meaningful for the non-penalized routes; the penalized ones select from the column's own
+    // ranking, so poisoning a column there changes what is selected and the divergence moves.
+    int sparse_non_finite_terminal_case(bool raw_greedy, int poison, bool penalized = false,
+                                        bool poison_matched = false) {
         std::vector<std::int32_t> targets(kSparseColumns * kSparseBatch),
             drafts(kSparseDrafts * kSparseBatch);
         std::vector<std::uint16_t> logits(static_cast<std::size_t>(kSparsePhysicalRows) *
@@ -681,15 +689,19 @@ struct SparseAcceptSuite {
                 drafts[row * kSparseDrafts + col] = ids[base + rank];
                 q[base + rank]                    = 1.0f;
             }
-            // Poison every other row. The NaN goes on the exact logit the kernel tests: the
-            // divergence column's target token.
-            const bool poisoned = (row & 1) == (poison & 1);
+            // Poison every other row. The NaN goes on the exact logit the kernel tests.
+            // poison_matched needs an accepted column to exist, so a row that diverges at 0 has
+            // none and is left clean -- expected_refusal tracks that rather than assuming.
+            const int matched_column = reject / 2;
+            const bool poisoned = ((row & 1) == (poison & 1)) && (!poison_matched || reject > 0);
             if (poisoned) {
+                const int column = poison_matched ? matched_column : reject;
                 if (penalized) {
                     for (int v = 0; v < kSparseTokenDomain; ++v)
-                        logits[sparse_logit_index(row, reject, v)] = f32_to_bf16(quiet_nan);
+                        logits[sparse_logit_index(row, column, v)] = f32_to_bf16(quiet_nan);
                 } else {
-                    logits[sparse_logit_index(row, reject, targets[row * kSparseColumns + reject])] =
+                    logits[sparse_logit_index(row, column,
+                                              targets[row * kSparseColumns + column])] =
                         f32_to_bf16(quiet_nan);
                 }
             }
@@ -716,9 +728,10 @@ struct SparseAcceptSuite {
             }
         }
         return execute_sparse_accept_case(
-            "sparse non-finite terminal K=" + std::to_string(kSparseDrafts) + " B=" +
-                std::to_string(kSparseBatch) + (raw_greedy ? " raw" : " general") +
-                (penalized ? " penalized" : "") + " p" + std::to_string(poison),
+            "sparse non-finite " + std::string(poison_matched ? "matched" : "terminal") +
+                " K=" + std::to_string(kSparseDrafts) + " B=" + std::to_string(kSparseBatch) +
+                (raw_greedy ? " raw" : " general") + (penalized ? " penalized" : "") + " p" +
+                std::to_string(poison),
             targets, logits, drafts, ids, q, extents, lengths, anchors, configs, history,
             {raw_greedy}, &expected);
     }
@@ -1495,6 +1508,11 @@ int main(int argc, char** argv) {
                 for (int poison = 0; poison < 2; ++poison) {
                     failures +=
                         SparseAcceptSuite(k, batch).sparse_non_finite_terminal_case(raw, poison);
+                    // The same fixture with the NaN on an *accepted* column instead of the
+                    // divergence column. A terminal-only guard passes this while licensing a
+                    // draft the target never actually endorsed.
+                    failures += SparseAcceptSuite(k, batch).sparse_non_finite_terminal_case(
+                        raw, poison, /*penalized=*/false, /*poison_matched=*/true);
                 }
             }
             // Penalized greedy takes the group-finalize routes instead, which select the terminal

--- a/tests/ops/test_speculative_round.cpp
+++ b/tests/ops/test_speculative_round.cpp
@@ -624,7 +624,13 @@ struct SparseAcceptSuite {
     // the refusal is per row rather than a blanket one -- the unpoisoned rows must still commit
     // normally in the same launch. Runs on both greedy sparse routes: raw (the dedicated warp
     // kernel) and the multiblock group-finalize kernel's SparseProposal branch.
-    int sparse_non_finite_terminal_case(bool raw_greedy, int poison) {
+    // `penalized` selects the greedy routes that presence/frequency penalties force down the
+    // group-finalize path: dense speculative_store_accept_result and sparse
+    // speculative_sparse_warp_accept's greedy branch. Those pick the terminal from the penalized
+    // top-k rather than reading target_tokens, and a NaN does not sort predictably, so the poison
+    // there is the whole column -- which is what a diverged forward pass actually produces. The
+    // raw route reads target_tokens directly, so poisoning that one logit is exact.
+    int sparse_non_finite_terminal_case(bool raw_greedy, int poison, bool penalized = false) {
         std::vector<std::int32_t> targets(kSparseColumns * kSparseBatch),
             drafts(kSparseDrafts * kSparseBatch);
         std::vector<std::uint16_t> logits(static_cast<std::size_t>(kSparsePhysicalRows) *
@@ -636,6 +642,14 @@ struct SparseAcceptSuite {
         // temperature 0 everywhere: this is the greedy contract, and the raw route requires it.
         std::vector<ops::SamplingConfig> configs(kSparseBatch);
         std::vector<int> history(kSparseTokenDomain * kSparseBatch, 3);
+        if (penalized) {
+            // Uniform history, so the penalty shifts every candidate equally and the argmax of a
+            // clean column is still its target. What changes is the route, not the answer.
+            for (auto& cfg : configs) {
+                cfg.presence_penalty  = 1.0f;
+                cfg.frequency_penalty = 0.5f;
+            }
+        }
 
         SparseExpected expected{
             .licensed_tokens = std::vector<std::int32_t>(kSparseColumns * kSparseBatch, 0),
@@ -671,8 +685,13 @@ struct SparseAcceptSuite {
             // divergence column's target token.
             const bool poisoned = (row & 1) == (poison & 1);
             if (poisoned) {
-                logits[sparse_logit_index(row, reject, targets[row * kSparseColumns + reject])] =
-                    f32_to_bf16(quiet_nan);
+                if (penalized) {
+                    for (int v = 0; v < kSparseTokenDomain; ++v)
+                        logits[sparse_logit_index(row, reject, v)] = f32_to_bf16(quiet_nan);
+                } else {
+                    logits[sparse_logit_index(row, reject, targets[row * kSparseColumns + reject])] =
+                        f32_to_bf16(quiet_nan);
+                }
             }
 
             const std::size_t row_base = static_cast<std::size_t>(row) * kSparseColumns;
@@ -698,8 +717,8 @@ struct SparseAcceptSuite {
         }
         return execute_sparse_accept_case(
             "sparse non-finite terminal K=" + std::to_string(kSparseDrafts) + " B=" +
-                std::to_string(kSparseBatch) + (raw_greedy ? " raw" : " general") + " p" +
-                std::to_string(poison),
+                std::to_string(kSparseBatch) + (raw_greedy ? " raw" : " general") +
+                (penalized ? " penalized" : "") + " p" + std::to_string(poison),
             targets, logits, drafts, ids, q, extents, lengths, anchors, configs, history,
             {raw_greedy}, &expected);
     }
@@ -1372,6 +1391,13 @@ int main(int argc, char** argv) {
                     failures +=
                         SparseAcceptSuite(k, batch).sparse_non_finite_terminal_case(raw, poison);
                 }
+            }
+            // Penalized greedy takes the group-finalize routes instead, which select the terminal
+            // from the penalized top-k. raw_greedy is false by construction: the envelope means
+            // "all rows greedy *without* penalties".
+            for (int poison = 0; poison < 2; ++poison) {
+                failures += SparseAcceptSuite(k, batch).sparse_non_finite_terminal_case(
+                    /*raw_greedy=*/false, poison, /*penalized=*/true);
             }
         }
     }


### PR DESCRIPTION
Closes the gap CodePulse raised on PR #16 (TODO.md §5a).

## The defect

Both greedy routes that commit a token from the target column licensed whatever token sat there,
even when the verify pass had produced an **all-NaN row** for it. The round then advanced the
sequence with an arbitrary, plausible-looking token instead of returning `kSamplerNonFiniteToken` —
exactly the failure this guard exists to prevent on every other commit path.

**TODO.md recorded one gap; there were two.** Alongside the sparse raw-greedy route that was
raised in review, the dense multiblock `speculative_sampling_group_finalize_kernel<false>` also
passed a hardcoded `true`, with a comment claiming no numeric was in scope.

## Why it is much smaller than §5a assumed

§5a expected "a signature change across the launcher boundary, plus its callers". Not needed —
`speculative_accept_sparse_drafts_launch` and `speculative_accept_greedy_drafts_launch` **already
receive the verify logits** and already compute `physical_rows`. The raw-greedy branch simply
ignored them. Only the two kernel signatures needed the parameters.

The test itself is the same `sampling_selected_logit_is_finite` the single-block dense kernel has
always applied at its own divergence column, so the routes now **agree** rather than each deciding
for itself.

`a` and `terminal` are warp-uniform in the sparse route (`a` from a ballot, `terminal` from a
uniform load), so every lane computes the same answer — cheaper than computing on one lane and
shuffling.

## Verification

Adversarial, because a regression test that passes without the fix is worthless:

| build | result |
|---|---|
| guard reverted to `true` | **60 failures**, across both greedy sparse routes |
| guard restored | `ninfer_speculative_round_test: PASS` |

The new fixture alternates poisoned and clean rows within one batch, so the mismatch indices move
with them (index 1 and 2, not 0). A blanket refusal therefore fails as loudly as no refusal at all.
Cases cover K ∈ {1,7,15} × B ∈ {1,8} × both routes × both poison parities.

The oracle derives its greedy terminal from the truncated logit distribution, and this fixture
poisons that same logit, so these cases state their expectation directly through a new
`expected_override` rather than through the oracle. Graph replay is skipped for them for the same
reason — it re-runs the oracle against mutated extents.

Full build clean over **630 targets**. Full suite **123/123**.

### One unrelated flake seen and characterised

The first suite run showed `ninfer_attn_input_proj_test` failing on
`attn q/k/value W8 DFlash2 A16 T=112 graph phase=1` with grossly wrong values (`actual=34` vs
`reference=-65.9`). It passes in isolation and the suite re-ran **123/123**, so it is the `-j2` GPU
contention flake the build notes already warn about, in a different Op from this change. Flagging
it because *grossly wrong data* under contention is a sharper symptom than the memory-pressure
failures those notes describe — raised as a follow-up TODO item, not addressed here.