### PR TITLE
perf(linear_pair): retune the k=2048 table, up to 52.8% at T=192

### DIFF
--- a/bench/ops/w8_pair_schedule_bench.cu
+++ b/bench/ops/w8_pair_schedule_bench.cu
@@ -82,16 +82,134 @@ void sweep_for_k(std::int32_t k, const ninfer::bench::SweepOptions& base) {
     std::printf("\n");
 }
 
+// --- k=2048, the 35B DFlash pair ---------------------------------------------------------------
+//
+// Two things make this table different from k=5120 and both dictate the shape of this sweep.
+//
+// First, w8_pair_execute_schedule calls require_dflash_row_views whenever k == 2048: the two
+// weights must be exact adjacent row views into one 6144-row parent at rows 4096 and 5120, not
+// standalone 1024-row matrices. make_row_split_weight already lays the parent out the way that
+// check wants -- W8G32_F16S has no high plane, so the scale plane starts exactly at
+// 6144*2048 -- so the views are pointer arithmetic rather than a second allocation.
+//
+// Second, and the reason this table is smaller than it looks on sm_86: under NINFER_SM8X_COMPAT
+// w8_pair_splitk_medium_launch discards its schedule argument entirely and loops
+// w8_pair_splitk_exact_t over <=32-column chunks. All twelve DualSplitKMediumC* schedules are
+// therefore the same code here, and the ten route bands between {33,48} and {161,192} cannot
+// differ. Four of them are swept anyway, to show that rather than assert it.
+
+constexpr std::int32_t kDFlashParentRows = 6144;
+constexpr std::int32_t kDFlashHidden     = 2048;
+constexpr std::int32_t kDFlashViewRows   = 1024;
+constexpr std::int32_t kDFlashFirstRow   = 4096;
+constexpr std::int32_t kDFlashSecondRow  = 5120;
+
+ninfer::Weight dflash_row_view(const ninfer::bench::PackedQuantizedWeight& parent,
+                               std::int32_t row) {
+    constexpr std::uint64_t kCodeBytes =
+        static_cast<std::uint64_t>(kDFlashParentRows) * kDFlashHidden;
+    constexpr std::uint64_t kScaleRowBytes = (kDFlashHidden / 32) * 2;
+
+    const auto* base  = static_cast<const std::uint8_t*>(parent.storage.p);
+    ninfer::Weight view = parent.weight;
+    view.qdata          = base + static_cast<std::uint64_t>(row) * kDFlashHidden;
+    view.scales         = base + kCodeBytes + static_cast<std::uint64_t>(row) * kScaleRowBytes;
+    view.n              = kDFlashViewRows;
+    view.shape[0]       = kDFlashViewRows;
+    view.padded_shape[0] = kDFlashViewRows;
+    return view;
+}
+
+void sweep_k2048(const ninfer::bench::SweepOptions& base) {
+    const std::int32_t max_tokens = *std::max_element(base.tokens.begin(), base.tokens.end());
+    ninfer::bench::PackedQuantizedWeight parent = ninfer::bench::make_row_split_weight(
+        QType::W8G32_F16S, kDFlashParentRows, kDFlashHidden, kDFlashHidden, {0x31, 0x00, 0x3c00});
+    const ninfer::Weight first  = dflash_row_view(parent, kDFlashFirstRow);
+    const ninfer::Weight second = dflash_row_view(parent, kDFlashSecondRow);
+
+    ninfer::DeviceBuffer input(static_cast<std::size_t>(kDFlashHidden) * max_tokens * 2);
+    ninfer::DeviceBuffer first_out(static_cast<std::size_t>(kDFlashViewRows) * max_tokens * 2);
+    ninfer::DeviceBuffer second_out(static_cast<std::size_t>(kDFlashViewRows) * max_tokens * 2);
+
+    const auto make = [&](detail::W8PairScheduleId schedule) {
+        return [&, schedule](std::int32_t tokens, cudaStream_t stream) {
+            Tensor x(input.p, DType::BF16, {kDFlashHidden, tokens});
+            Tensor a(first_out.p, DType::BF16, {kDFlashViewRows, tokens});
+            Tensor b(second_out.p, DType::BF16, {kDFlashViewRows, tokens});
+            detail::w8_pair_execute_schedule(schedule, x, first, second, a, b, stream);
+        };
+    };
+
+    // Domains, all of them enforced by a throw rather than by luck, so the harness reports "n/a"
+    // below a schedule's minimum instead of faulting:
+    //   DualDecodeR4        one column at a time; capped so the sweep does not spend minutes
+    //                       proving a decode kernel is slow at T=2048.
+    //   DualSplitKMmaExactT throws outside T=2..32 (kFirstExactT..kLastExactT).
+    //   DualSplitKMedium*   throws below T=33; unbounded above.
+    //   Concat*             tiled by launch_tiled, so defined at every width.
+    using Id = detail::W8PairScheduleId;
+    std::vector<ninfer::bench::SweepEntry> schedules{
+        {"dual_decode_r4", make(Id::DualDecodeR4), 32},
+        {"dual_splitk_exact_t", make(Id::DualSplitKMmaExactT), 32},
+        {"medium_c48", make(Id::DualSplitKMediumC48), 0},
+        {"medium_c64", make(Id::DualSplitKMediumC64), 0},
+        {"medium_c128", make(Id::DualSplitKMediumC128), 0},
+        {"medium_c192", make(Id::DualSplitKMediumC192), 0},
+        {"concat_r32_c64", make(Id::ConcatMmaR32C64), 0},
+        {"concat_r32_c96", make(Id::ConcatMmaR32C96), 0},
+        {"concat_r32_c128", make(Id::ConcatMmaR32C128), 0},
+        {"concat_r48_c96", make(Id::ConcatMmaR48C96), 0},
+        {"concat_r48_c112", make(Id::ConcatMmaR48C112), 0},
+        {"concat_r48_c128", make(Id::ConcatMmaR48C128), 0},
+        {"concat_r64_c96", make(Id::ConcatMmaR64C96), 0},
+        {"concat_r64_c128", make(Id::ConcatMmaR64C128), 0},
+        {"concat_r96_c64", make(Id::ConcatMmaR96C64), 0},
+        {"concat_r96_c96", make(Id::ConcatMmaR96C96), 0},
+        {"concat_r128_c64", make(Id::ConcatMmaR128C64), 0},
+        {"concat_r128_c80", make(Id::ConcatMmaR128C80), 0},
+    };
+
+    ninfer::bench::SweepOptions options = base;
+    options.title                       = "w8 linear_pair k=2048 (35B DFlash pair)";
+    std::string routed;
+    options.routed_name = [&routed](std::int32_t tokens) -> const char* {
+        const detail::W8PairProblem problem{kDFlashViewRows, kDFlashHidden, kDFlashHidden, tokens};
+        routed = detail::w8_pair_schedule_name(detail::w8_pair_resolve_plan(problem).schedule);
+        return routed.c_str();
+    };
+    options.public_op = [&](std::int32_t tokens, cudaStream_t stream) {
+        Tensor x(input.p, DType::BF16, {kDFlashHidden, tokens});
+        Tensor a(first_out.p, DType::BF16, {kDFlashViewRows, tokens});
+        Tensor b(second_out.p, DType::BF16, {kDFlashViewRows, tokens});
+        detail::w8_pair_dispatch(x, first, second, a, b, stream);
+    };
+    ninfer::bench::run_sweep(options, schedules);
+    std::printf("\n");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
     ninfer::bench::SweepOptions options;
-    options.tokens = {1,  2,   4,   8,   16,  24,  32,  48,  56,  64,  80,  85,  86,
-                      96, 112, 128, 160, 192, 256, 384, 512, 768, 960, 961, 1024};
+    const bool k2048 = argc > 1 && std::string(argv[1]) == "--k2048";
+    if (k2048) { --argc; ++argv; }
+
+    options.tokens =
+        k2048 ? std::vector<std::int32_t>{1,   2,   8,   16,  32,  33,  48,  49,  64,   80,  96,
+                                          112, 128, 160, 192, 193, 256, 384, 385, 480,  481, 512,
+                                          640, 641, 672, 768, 896, 960, 976, 1024, 1280, 1536, 2048}
+              : std::vector<std::int32_t>{1,  2,   4,   8,   16,  24,  32,  48,  56,  64,  80,  85,
+                                          86, 96,  112, 128, 160, 192, 256, 384, 512, 768, 960, 961,
+                                          1024};
     if (!ninfer::bench::parse_sweep_args(argc, argv, options)) {
-        std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N]\n", argv[0]);
+        std::fprintf(stderr, "usage: %s [--k2048] [--tokens T,...] [--repeat N] [--warmup N]\n",
+                     argv[0]);
         return 2;
     }
-    sweep_for_k(5120, options);
+    if (k2048) {
+        sweep_k2048(options);
+    } else {
+        sweep_for_k(5120, options);
+    }
     return 0;
 }

--- a/src/ops/linear_pair/w8/w8_pair_plan.cpp
+++ b/src/ops/linear_pair/w8/w8_pair_plan.cpp
@@ -50,20 +50,29 @@ constexpr std::array<W8PairRouteSpec, 3> kK5120Routes{{
     {449, kAnyCols, W8PairScheduleId::DualMmaR32C128},
 }};
 
-constexpr std::array<W8PairRouteSpec, 37> kK2048Routes{{
+constexpr std::array<W8PairRouteSpec, 29> kK2048Routes{{
     {1, 1, W8PairScheduleId::DualDecodeR4},
     {2, 32, W8PairScheduleId::DualSplitKMmaExactT},
     {33, 48, W8PairScheduleId::DualSplitKMediumC48},
     {49, 64, W8PairScheduleId::DualSplitKMediumC64},
-    {65, 80, W8PairScheduleId::DualSplitKMediumC80},
-    {81, 88, W8PairScheduleId::DualSplitKMediumC88},
-    {89, 96, W8PairScheduleId::DualSplitKMediumC96},
-    {97, 104, W8PairScheduleId::DualSplitKMediumC104},
-    {105, 112, W8PairScheduleId::DualSplitKMediumC112},
-    {113, 128, W8PairScheduleId::DualSplitKMediumC128},
-    {129, 160, W8PairScheduleId::DualSplitKMediumC160},
-    {161, 192, W8PairScheduleId::DualSplitKMediumC192},
-    {193, 384, W8PairScheduleId::ConcatMmaR32C64},
+    // Upstream splits 65..192 across eight DualSplitKMedium routes (C80, C88, C96, C104, C112,
+    // C128, C160, C192). On sm_86 those eight are the *same kernel*: under NINFER_SM8X_COMPAT
+    // w8_pair_splitk_medium_launch discards its schedule argument and loops
+    // w8_pair_splitk_exact_t over <=32-column chunks, so the medium family cannot tile wider than
+    // 32 here and its cost grows linearly with T while the concat kernels do not.
+    //
+    // Measured on this card (cold, median of 9, us), routed cost against ConcatMmaR32C64:
+    //
+    //     T      64     80     96    112    128    160    192
+    //     medium 36.9   44.0   47.1   58.4   61.4   75.8   91.1
+    //     concat 38.9   39.9   39.9   41.0   37.9   45.1   43.0
+    //     gain      -   9.3%  15.2%  29.8%  38.3%  40.5%  52.8%
+    //
+    // The crossover is sharp and sits at 65: medium still wins at 64 (36.9 vs 38.9) and loses from
+    // 66 on. ConcatMmaR32C64 already owned {193,384} and is within a step of the best schedule at
+    // every width in between, so the eight routes and the one below collapse into a single band
+    // rather than being retuned individually.
+    {65, 384, W8PairScheduleId::ConcatMmaR32C64},
     {385, 480, W8PairScheduleId::ConcatMmaR32C96},
     {481, 640, W8PairScheduleId::ConcatMmaR32C128},
     {641, 641, W8PairScheduleId::ExactConcatMmaR32C128},

--- a/tests/ops/linear_pair/test_w8_a16.cpp
+++ b/tests/ops/linear_pair/test_w8_a16.cpp
@@ -22,14 +22,19 @@ int w8_a16_conformance() {
     failures += ninfer::test::linear_pair::run_w8_a16_shape(
         "W8_A16 LinearPair", ShapeCase{5120, 431U, kK5120RouteStarts, kK5120RouteInteriors});
 
-    constexpr std::array<std::int32_t, 36> kK2048RouteStarts{
-        2,    33,   49,   65,   81,   89,   97,   105,  113,  129,  161,  193,
-        385,  481,  641,  642,  673,  681,  785,  897,  961,  977,  1281, 1317,
-        1345, 1346, 1441, 1467, 1681, 1709, 1921, 1923, 2017, 2019, 2209, 2271,
+    // These track kK2048Routes. The eight DualSplitKMedium starts that used to sit between 81 and
+    // 193 are gone: on sm_86 that whole family is one kernel, and 65..384 is now a single
+    // ConcatMmaR32C64 band. The widths themselves stay below as interiors, so the coverage that
+    // mattered -- every one of those column counts -- is unchanged.
+    constexpr std::array<std::int32_t, 28> kK2048RouteStarts{
+        2,    33,   49,   65,   385,  481,  641,  642,  673,  681,
+        785,  897,  961,  977,  1281, 1317, 1345, 1346, 1441, 1467,
+        1681, 1709, 1921, 1923, 2017, 2019, 2209, 2271,
     };
-    constexpr std::array<std::int32_t, 37> kK2048RouteInteriors{
-        1,    16,   40,   56,   72,   84,   92,   100,  108,  120,  144,  176,  288,
-        432,  560,  641,  656,  676,  736,  840,  928,  968,  1120, 1296, 1332, 1345,
+    constexpr std::array<std::int32_t, 53> kK2048RouteInteriors{
+        1,    16,   40,   56,   72,   80,   81,   84,   88,   89,   92,   96,   97,   100,
+        104,  105,  108,  112,  113,  120,  128,  129,  144,  160,  161,  176,  192,  193,
+        288,  432,  560,  641,  656,  676,  736,  840,  928,  968,  1120, 1296, 1332, 1345,
         1392, 1456, 1576, 1696, 1816, 1921, 1968, 2017, 2112, 2240, 4096,
     };
     failures += ninfer::test::linear_pair::run_w8_a16_shape(


### PR DESCRIPTION
Closes the `w8_pair` k=2048 item in TODO.md §4 — the largest route table in the tree (37 routes, on
the 35B DFlash pair) and the last one never measured on sm_86.

## Eight routes could not win, structurally

Under `NINFER_SM8X_COMPAT` — defined on **every** sm_86/89 build — `w8_pair_splitk_medium_launch`
does `(void)schedule` and loops `w8_pair_splitk_exact_t` over ≤32-column chunks:

```cpp
#if defined(NINFER_SM8X_COMPAT)
    (void)schedule;
    while (offset < x.ne[1]) {
        const std::int32_t count = std::min<std::int32_t>(kLastExactT, x.ne[1] - offset);
        ...
```

So all twelve `DualSplitKMediumC*` schedules are **the same kernel** here. The family cannot tile
wider than 32 columns, and its cost grows linearly with T while the concat kernels' does not.

Confirmed empirically before changing anything: at T=33 the four swept `medium_c*` entries read
**exactly 24.576 µs each**.

This is the route-table trap in a new shape. `q4_q5` had a tuned table nobody read, beside a live
hardcoded chain. Here the table is live and read — but eight of its *distinctions* do not exist on
this hardware.

## Measured

Cold, median of 9, public Op, µs:

| T | 80 | 96 | 112 | 128 | 160 | 176 | 192 |
|---|---|---|---|---|---|---|---|
| before | 44.0 | 47.1 | 58.4 | 62.5 | 75.8 | 88.1 | 91.1 |
| after | 39.9 | 41.0 | 39.9 | 37.9 | 46.1 | 46.1 | 43.0 |
| **gain** | 9.3% | 13.0% | 31.6% | 39.3% | 39.2% | 47.7% | **52.8%** |

The crossover is sharp: medium still wins at T=64 (36.9 vs 38.9) and loses from T=66 on.

`ConcatMmaR32C64` already owned `{193,384}` and is within a rounding step of the best schedule at
every width between, so the eight medium routes and the concat route below them collapse into one
`{65,384}` band. **The table drops from 37 routes to 29** and is simpler than what it replaced.

## Deliberately not retuned

Everything above 384. T=384 measured **80.9 µs and 92.2 µs on two runs of the same binary** (~14%),
so the apparent 8–24% gains up there sit inside run-to-run noise; tuning them would be fitting a
sample, not measuring the hardware.

## Bench

Adds a `--k2048` mode. That shape needs the two weights to be exact adjacent row views into a
6144-row parent at rows 4096/5120, which `require_dflash_row_views` enforces —
`make_row_split_weight` already lays the parent out that way (W8G32_F16S has no high plane, so the
scale plane starts exactly at `6144*2048`), making the views pointer arithmetic rather than a
second allocation.

Every swept schedule has a **throwing** domain check rather than a faulting one — `exact_t` throws
outside T=2..32, medium throws below 33, exact-tail throws outside tail 1..62 — so the harness
reports `n/a` below a minimum instead of taking the process down, which is what §4 warned about.

## Coverage

Test route starts follow the table. The eight removed starts are re-added as **interiors**, along
with every other column count the removed routes owned, so coverage rises from 37 interiors to 53
rather than falling.

`ninfer_linear_pair_w8_a16_test` passes; full suite **123/123**.