### PR TITLE
test(ops): make unrouted schedules visible

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -406,6 +406,10 @@ ninfer_add_fused_linear_test(
   ninfer_linear_pair_w8_a16_test
   ops/linear_pair/test_w8_a16.cpp
   ops/linear_pair/linear_pair_test_common.cpp)
+# Pure host resolution -- no device work, so it runs on a machine with no GPU at all.
+ninfer_add_op_test(ninfer_route_coverage_test
+  SOURCES ops/test_route_coverage.cpp
+  LIBRARIES ninfer_ops)
 ninfer_add_fused_linear_test(
   ninfer_linear_swiglu_q4_a16_test
   ops/linear_swiglu/test_q4_a16.cpp

--- a/tests/ops/test_route_coverage.cpp
+++ b/tests/ops/test_route_coverage.cpp
@@ -9,8 +9,10 @@
 //
 // So this test does not fail on unrouted schedules. Keeping an upstream schedule that wins nowhere
 // here is a deliberate and correct choice -- deleting it costs merge effort for no measured gain.
-// What is not acceptable is not knowing. This prints the set, and fails only if it *changes*, so
-// the set stays deliberate rather than accumulating by accident.
+// What is not acceptable is not knowing. This prints the set and pins it two ways: the aggregate
+// count below, and each Op's exact schedule names against `survey`'s `expected_unrouted` argument.
+// The count alone would pass unchanged if a route edit stranded one schedule while un-stranding
+// another -- the per-Op name set is what catches that the identity, not just the size, moved.
 //
 // It also catches the k=2048 case from a different angle: an Op can route to twelve distinct
 // schedule ids that are one kernel on this hardware. That does not show up here -- all twelve are
@@ -25,7 +27,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <exception>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -68,32 +69,48 @@ struct OpReport {
     std::string op;
     std::size_t declared = 0;
     std::vector<std::string> unrouted;
+    std::vector<std::string> expected_unrouted;
+    bool identity_ok = true;
 };
 
 // One Op, all of its shapes. Surveying per shape would be misleading: the w8_pair k=5120 table
 // selects three schedules, so 42 of its 45 ids look "unrouted" there while most are live at
 // k=2048. What matters is whether an id is reachable from *any* registered shape of the Op.
+//
+// `expected_unrouted` is the exact baseline for this Op, compared as a set so reordering the enum
+// does not itself fail the test. Update it, in the same commit as the route table that moved,
+// naming which schedules changed state -- that is the identity check `kExpectedUnrouted` alone
+// cannot make: a route edit that strands one schedule while un-stranding another leaves the total
+// unchanged, and only comparing the sets themselves catches that the membership moved.
 template <typename Id, typename NameFn, typename ResolveFn>
 OpReport survey(const std::string& op, NameFn name, std::string_view unknown,
                 const std::vector<std::string>& shape_names,
-                const std::vector<ResolveFn>& resolvers) {
+                const std::vector<ResolveFn>& resolvers,
+                std::vector<std::string> expected_unrouted) {
     const std::vector<Id> declared = declared_schedules<Id>(name, unknown);
     std::set<int> routed;
     for (const auto& resolve : resolvers) {
+        // Every route table this survey uses is compile-time verified contiguous and closed from
+        // column 1 through the unbounded tail (each Op's own `catalog_is_closed`/
+        // `routes_are_closed` static_assert), and every shape here is one `*_admits` already
+        // accepts. So no probed width can fail to resolve -- a throw here is not "this shape
+        // doesn't admit this width", it is one of those guarantees breaking, which must fail the
+        // test loudly rather than get folded into "unrouted" by a catch that assumed a gap that
+        // cannot exist.
         for (const std::int32_t cols : probe_widths()) {
-            try {
-                routed.insert(static_cast<int>(resolve(cols)));
-            } catch (const std::exception&) {
-                // A width this shape does not admit. Not every table is defined over every column
-                // count, and a throw says so rather than hiding a schedule.
-            }
+            routed.insert(static_cast<int>(resolve(cols)));
         }
     }
 
-    OpReport report{op, declared.size(), {}};
+    OpReport report{op, declared.size(), {}, std::move(expected_unrouted), true};
     for (const Id id : declared) {
         if (routed.count(static_cast<int>(id)) == 0) { report.unrouted.emplace_back(name(id)); }
     }
+    std::vector<std::string> actual_sorted = report.unrouted;
+    std::vector<std::string> expected_sorted = report.expected_unrouted;
+    std::sort(actual_sorted.begin(), actual_sorted.end());
+    std::sort(expected_sorted.begin(), expected_sorted.end());
+    report.identity_ok = actual_sorted == expected_sorted;
     (void)shape_names;
     return report;
 }
@@ -113,7 +130,17 @@ int main() {
          }),
          PairFn([](std::int32_t cols) {
              return detail::w8_pair_resolve_plan({1024, 2048, 2048, cols}).schedule;
-         })}));
+         })},
+        {"w8_pair.dual_decode.k2048.r8", "w8_pair.dual_decode.k2048.r16",
+         "w8_pair.splitk4.mma.r16.c80", "w8_pair.splitk4.mma.r16.c88",
+         "w8_pair.splitk4.mma.r16.c96", "w8_pair.splitk4.mma.r16.c104",
+         "w8_pair.splitk4.mma.r16.c112", "w8_pair.splitk2.mma.r16.c128",
+         "w8_pair.splitk2.mma.r16.c160", "w8_pair.splitk2.mma.r16.c192",
+         "w8_pair.splitk2.mma.r16.c224", "w8_pair.splitk2.mma.r16.c256",
+         "w8_pair.concat_mma.r32.c80", "w8_pair.concat_mma.r32.c112",
+         "w8_pair.concat_mma.r48.c64", "w8_pair.concat_mma.r64.c64",
+         "w8_pair.concat_mma.r64.c80", "w8_pair.concat_mma.r96.c80",
+         "w8_pair.concat_mma.r96.c112"}));
 
     using AttnFn = std::function<detail::W8AttnInputScheduleId(std::int32_t)>;
     reports.push_back(
@@ -137,7 +164,9 @@ int main() {
                             return detail::w8_attn_input_resolve_plan(
                                        {5120, 4096, 1024, 6144, 5120, cols})
                                 .schedule;
-                        })}));
+                        })},
+                       {"attn_input_proj.w8.simt.r8.c4",
+                        "attn_input_proj.w8.dflash2.mma.r16.c64.k128"}));
 
     using SwigluFn = std::function<detail::W8LinearSwiGluScheduleId(std::int32_t)>;
     reports.push_back(
@@ -153,7 +182,8 @@ int main() {
                               return detail::w8_linear_swiglu_resolve_plan(
                                          {34816, 17408, 5120, 5120, cols})
                                   .schedule;
-                          })}));
+                          })},
+                         {"linear_swiglu.w8.dflash2.mma.r32.c64.k128"}));
 
     using AddFn = std::function<detail::Q5LinearAddScheduleId(std::int32_t)>;
     reports.push_back(
@@ -165,7 +195,8 @@ int main() {
              }),
              AddFn([](std::int32_t cols) {
                  return detail::q5_linear_add_resolve_plan({5120, 17408, 17408, cols}).schedule;
-             })}));
+             })},
+            {"linear_add.q5.mma.r64.c32.cta_collective_residual"}));
 
     using Q4Q5Fn = std::function<detail::Q4Q5AttnInputScheduleId(std::int32_t)>;
     reports.push_back(
@@ -176,14 +207,33 @@ int main() {
                            return detail::q4_q5_attn_input_resolve_plan({5120, 6144, 1024, 5120,
                                                                          cols})
                                .schedule;
-                       })}));
+                       })},
+                       {"attn_input_proj.q4_q5.grouped_homogeneous_pair.mma.r32.c64.s4",
+                        "attn_input_proj.q4_q5.pair.r32.c64.s3",
+                        "attn_input_proj.q4_q5.pair.r32.c64.s4"}));
 
     std::size_t total = 0;
+    bool identity_changed = false;
     for (const OpReport& report : reports) {
         std::cout << report.op << ": " << report.unrouted.size() << " of " << report.declared
                   << " unrouted\n";
         for (const std::string& name : report.unrouted) { std::cout << "    " << name << '\n'; }
+        if (!report.identity_ok) {
+            identity_changed = true;
+            std::cerr << report.op << ": unrouted schedule set changed.\n  expected:";
+            for (const std::string& name : report.expected_unrouted) { std::cerr << ' ' << name; }
+            std::cerr << "\n  actual:  ";
+            for (const std::string& name : report.unrouted) { std::cerr << ' ' << name; }
+            std::cerr << '\n';
+        }
         total += report.unrouted.size();
+    }
+    if (identity_changed) {
+        std::cerr << "route coverage identity changed -- see the per-Op diff above. Update the "
+                     "expected_unrouted list in this file for the Op that moved, in the same "
+                     "commit as the route table that moved, and say which schedules changed "
+                     "state; the aggregate count can stay the same while the membership moves.\n";
+        return 1;
     }
 
     // The pin. Change it deliberately, in the same commit as the route table that moved, and say

--- a/tests/ops/test_route_coverage.cpp
+++ b/tests/ops/test_route_coverage.cpp
@@ -192,9 +192,14 @@ int main() {
     //
     // The inventory as measured, and what is known about each group:
     //
-    //   w8_pair            11  decode r8/r16 and splitk c224/c256 have no band in either table;
+    //   w8_pair            19  decode r8/r16 and splitk c224/c256 have no band in either table;
     //                          the seven concat tile shapes are upstream ids this fork's measured
-    //                          boundaries never select.
+    //                          boundaries never select; and the eight DualSplitKMediumC80..C192
+    //                          ids were stranded by the k=2048 retune (c0c3000e), which collapsed
+    //                          {65,192} into one ConcatMmaR32C64 band because all twelve medium
+    //                          schedules are the same kernel under NINFER_SM8X_COMPAT. Those eight
+    //                          are exactly the routes that retune deleted, which is this test
+    //                          doing its job -- the count moved 18 -> 26 and had to be looked at.
     //   w8_attn_input       2  DFlash2MmaR16C64K128 won at no width in the sm_86 sweep. SimtR8C4
     //                          is reachable in principle but no shape's table picks it.
     //   w8_linear_swiglu    1  DFlash2MmaR32C64K128 ties R64C64K128 at 33..44 and wins nowhere.
@@ -204,7 +209,7 @@ int main() {
     //
     // All of them are kept on purpose: deleting an upstream schedule costs merge effort at every
     // future catch-up for no measured gain here. The point is that the set is written down.
-    constexpr std::size_t kExpectedUnrouted = 18;
+    constexpr std::size_t kExpectedUnrouted = 26;
     if (total != kExpectedUnrouted) {
         std::cerr << "route coverage changed: " << total << " unrouted schedules, expected "
                   << kExpectedUnrouted

--- a/tests/ops/test_route_coverage.cpp
+++ b/tests/ops/test_route_coverage.cpp
@@ -1,0 +1,217 @@
+// Lists the schedules an Op declares but never routes to.
+//
+// A schedule nothing selects is where dispatch bugs hide. Both switch fallthroughs found in the
+// 2026-09 catch-up -- q4_q5 GroupedHomogeneousPairMmaR32C32S4 with no `return`, and
+// GroupedHomogeneousPairMmaR32C64S4 with no `case` at all -- were dormant precisely because the
+// live route table never picked the affected ids. Neither is visible to a correctness test: a
+// fallthrough runs a second kernel over the first, both compute the same projection, and only the
+// cost doubles.
+//
+// So this test does not fail on unrouted schedules. Keeping an upstream schedule that wins nowhere
+// here is a deliberate and correct choice -- deleting it costs merge effort for no measured gain.
+// What is not acceptable is not knowing. This prints the set, and fails only if it *changes*, so
+// the set stays deliberate rather than accumulating by accident.
+//
+// It also catches the k=2048 case from a different angle: an Op can route to twelve distinct
+// schedule ids that are one kernel on this hardware. That does not show up here -- all twelve are
+// "routed" -- which is why the comment in w8_pair_plan.cpp spells the collapse out. Unrouted is the
+// cheap half of the question; grep the launchers for NINFER_SM8X_COMPAT for the other half.
+
+#include "ops/attn_input_proj/q4_q5/q4_q5_attn_input_plan.h"
+#include "ops/attn_input_proj/w8/w8_attn_input_plan.h"
+#include "ops/linear_add/q5/q5_linear_add_plan.h"
+#include "ops/linear_pair/w8/w8_pair_plan.h"
+#include "ops/linear_swiglu/w8/w8_linear_swiglu_plan.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+constexpr std::int32_t kAnyCols = std::numeric_limits<std::int32_t>::max();
+
+// Column counts to resolve at. Every width to 2304 covers each table's dense low end and its
+// narrow exact-tail bands, and the tail values reach the unbounded final route. Resolution is pure
+// host logic, so exhaustive is cheaper than clever.
+std::vector<std::int32_t> probe_widths() {
+    std::vector<std::int32_t> widths;
+    for (std::int32_t t = 1; t <= 2304; ++t) { widths.push_back(t); }
+    for (const std::int32_t t : {4096, 8192, 16384, 65536, kAnyCols - 1, kAnyCols}) {
+        widths.push_back(t);
+    }
+    return widths;
+}
+
+// Walks the enum by integer value until the name function stops recognising it. Every Op here
+// returns a "<op>.unknown" sentinel past its last id, which is what bounds the walk -- no header
+// needs a Count member it would then have to defend at the next merge.
+template <typename Id, typename NameFn>
+std::vector<Id> declared_schedules(NameFn name, std::string_view unknown) {
+    std::vector<Id> ids;
+    for (int raw = 0; raw < 512; ++raw) {
+        const Id id = static_cast<Id>(raw);
+        if (std::string_view(name(id)) == unknown) { break; }
+        ids.push_back(id);
+    }
+    return ids;
+}
+
+struct OpReport {
+    std::string op;
+    std::size_t declared = 0;
+    std::vector<std::string> unrouted;
+};
+
+// One Op, all of its shapes. Surveying per shape would be misleading: the w8_pair k=5120 table
+// selects three schedules, so 42 of its 45 ids look "unrouted" there while most are live at
+// k=2048. What matters is whether an id is reachable from *any* registered shape of the Op.
+template <typename Id, typename NameFn, typename ResolveFn>
+OpReport survey(const std::string& op, NameFn name, std::string_view unknown,
+                const std::vector<std::string>& shape_names,
+                const std::vector<ResolveFn>& resolvers) {
+    const std::vector<Id> declared = declared_schedules<Id>(name, unknown);
+    std::set<int> routed;
+    for (const auto& resolve : resolvers) {
+        for (const std::int32_t cols : probe_widths()) {
+            try {
+                routed.insert(static_cast<int>(resolve(cols)));
+            } catch (const std::exception&) {
+                // A width this shape does not admit. Not every table is defined over every column
+                // count, and a throw says so rather than hiding a schedule.
+            }
+        }
+    }
+
+    OpReport report{op, declared.size(), {}};
+    for (const Id id : declared) {
+        if (routed.count(static_cast<int>(id)) == 0) { report.unrouted.emplace_back(name(id)); }
+    }
+    (void)shape_names;
+    return report;
+}
+
+} // namespace
+
+int main() {
+    namespace detail = ninfer::ops::detail;
+    std::vector<OpReport> reports;
+
+    using PairFn = std::function<detail::W8PairScheduleId(std::int32_t)>;
+    reports.push_back(survey<detail::W8PairScheduleId, decltype(detail::w8_pair_schedule_name),
+                             PairFn>(
+        "w8_pair", detail::w8_pair_schedule_name, "w8_pair.unknown", {"k=5120", "k=2048"},
+        {PairFn([](std::int32_t cols) {
+             return detail::w8_pair_resolve_plan({1024, 5120, 5120, cols}).schedule;
+         }),
+         PairFn([](std::int32_t cols) {
+             return detail::w8_pair_resolve_plan({1024, 2048, 2048, cols}).schedule;
+         })}));
+
+    using AttnFn = std::function<detail::W8AttnInputScheduleId(std::int32_t)>;
+    reports.push_back(
+        survey<detail::W8AttnInputScheduleId, decltype(detail::w8_attn_input_schedule_name),
+               AttnFn>("w8_attn_input", detail::w8_attn_input_schedule_name,
+                       "attn_input_proj.w8.unknown", {"target", "companion", "dflash2"},
+                       // All three shapes the resolver distinguishes -- see supported_shape() in
+                       // w8_attn_input_plan.cpp. Surveying only dflash2 reported 11 of 16
+                       // unrouted, because it never asked the other two tables.
+                       {AttnFn([](std::int32_t cols) {
+                            return detail::w8_attn_input_resolve_plan(
+                                       {2048, 4096, 512, 9216, 2048, cols})
+                                .schedule;
+                        }),
+                        AttnFn([](std::int32_t cols) {
+                            return detail::w8_attn_input_resolve_plan(
+                                       {2048, 4096, 1024, 6144, 2048, cols})
+                                .schedule;
+                        }),
+                        AttnFn([](std::int32_t cols) {
+                            return detail::w8_attn_input_resolve_plan(
+                                       {5120, 4096, 1024, 6144, 5120, cols})
+                                .schedule;
+                        })}));
+
+    using SwigluFn = std::function<detail::W8LinearSwiGluScheduleId(std::int32_t)>;
+    reports.push_back(
+        survey<detail::W8LinearSwiGluScheduleId, decltype(detail::w8_linear_swiglu_schedule_name),
+               SwigluFn>("w8_linear_swiglu", detail::w8_linear_swiglu_schedule_name,
+                         "linear_swiglu.w8.unknown", {"companion", "dflash2"},
+                         {SwigluFn([](std::int32_t cols) {
+                              return detail::w8_linear_swiglu_resolve_plan(
+                                         {12288, 6144, 2048, 2048, cols})
+                                  .schedule;
+                          }),
+                          SwigluFn([](std::int32_t cols) {
+                              return detail::w8_linear_swiglu_resolve_plan(
+                                         {34816, 17408, 5120, 5120, cols})
+                                  .schedule;
+                          })}));
+
+    using AddFn = std::function<detail::Q5LinearAddScheduleId(std::int32_t)>;
+    reports.push_back(
+        survey<detail::Q5LinearAddScheduleId, decltype(detail::q5_linear_add_schedule_name), AddFn>(
+            "q5_linear_add", detail::q5_linear_add_schedule_name, "linear_add.q5.unknown",
+            {"k=6144", "k=17408"},
+            {AddFn([](std::int32_t cols) {
+                 return detail::q5_linear_add_resolve_plan({5120, 6144, 6144, cols}).schedule;
+             }),
+             AddFn([](std::int32_t cols) {
+                 return detail::q5_linear_add_resolve_plan({5120, 17408, 17408, cols}).schedule;
+             })}));
+
+    using Q4Q5Fn = std::function<detail::Q4Q5AttnInputScheduleId(std::int32_t)>;
+    reports.push_back(
+        survey<detail::Q4Q5AttnInputScheduleId, decltype(detail::q4_q5_attn_input_schedule_name),
+               Q4Q5Fn>("q4_q5_attn_input", detail::q4_q5_attn_input_schedule_name,
+                       "attn_input_proj.q4_q5.unknown", {"35B"},
+                       {Q4Q5Fn([](std::int32_t cols) {
+                           return detail::q4_q5_attn_input_resolve_plan({5120, 6144, 1024, 5120,
+                                                                         cols})
+                               .schedule;
+                       })}));
+
+    std::size_t total = 0;
+    for (const OpReport& report : reports) {
+        std::cout << report.op << ": " << report.unrouted.size() << " of " << report.declared
+                  << " unrouted\n";
+        for (const std::string& name : report.unrouted) { std::cout << "    " << name << '\n'; }
+        total += report.unrouted.size();
+    }
+
+    // The pin. Change it deliberately, in the same commit as the route table that moved, and say
+    // in that commit which schedules changed state. An unexplained change here means a table edit
+    // had a coverage side effect nobody looked at.
+    //
+    // The inventory as measured, and what is known about each group:
+    //
+    //   w8_pair            11  decode r8/r16 and splitk c224/c256 have no band in either table;
+    //                          the seven concat tile shapes are upstream ids this fork's measured
+    //                          boundaries never select.
+    //   w8_attn_input       2  DFlash2MmaR16C64K128 won at no width in the sm_86 sweep. SimtR8C4
+    //                          is reachable in principle but no shape's table picks it.
+    //   w8_linear_swiglu    1  DFlash2MmaR32C64K128 ties R64C64K128 at 33..44 and wins nowhere.
+    //   q5_linear_add       1  MmaResidualR64C32, likewise.
+    //   q4_q5_attn_input    3  grouped_r32_c64_s4, pair_r32_c64_s3, pair_r32_c64_s4 -- the family
+    //                          whose dispatch held both switch bugs the catch-up merge shipped.
+    //
+    // All of them are kept on purpose: deleting an upstream schedule costs merge effort at every
+    // future catch-up for no measured gain here. The point is that the set is written down.
+    constexpr std::size_t kExpectedUnrouted = 18;
+    if (total != kExpectedUnrouted) {
+        std::cerr << "route coverage changed: " << total << " unrouted schedules, expected "
+                  << kExpectedUnrouted
+                  << ".\nUpdate kExpectedUnrouted in this file together with the route table that "
+                     "moved, and record which schedules changed state.\n";
+        return 1;
+    }
+    std::cout << "OK route coverage\n";
+    return 0;
+}


### PR DESCRIPTION
Closes the "consider a test that lists unrouted schedules per Op" item in TODO.md §4.

## Why

A schedule nothing selects is where dispatch bugs hide. **Both** switch fallthroughs the 2026-09
catch-up shipped were dormant precisely because the live route table never picked the affected ids:

- `q4_q5 GroupedHomogeneousPairMmaR32C32S4` had no `return`, so it ran the next case's kernel over
  its own — 502.8 µs at T=16 against 226.3 for the kernel alone.
- `GroupedHomogeneousPairMmaR32C64S4` had no `case` at all.

Neither is visible to a correctness test: both kernels compute the same projection, so the output
stays right and only the cost doubles.

## What it does

Walks each Op's schedule enum, resolves every column count from 1 to 2304 plus the unbounded tail,
across **all** of that Op's registered shapes, and lists what is declared but never selected. Pure
host logic — no GPU, runs in milliseconds.

| Op | unrouted |
|---|---|
| `w8_pair` | 11 of 45 |
| `w8_attn_input` | 2 of 16 |
| `w8_linear_swiglu` | 1 of 17 |
| `q5_linear_add` | 1 of 9 |
| `q4_q5_attn_input` | 3 of 7 |

It independently reproduces the three schedules §4 records as "routed at no width", and finds
several that were not written down.

**It does not fail on unrouted schedules.** Keeping an upstream schedule that wins nowhere here is
the right call — deleting one costs merge effort at every future catch-up for no measured gain. It
fails when the set *changes*, so a route edit cannot quietly strand a kernel.

## Two implementation notes

- The enum is walked by integer value until the name function returns its `"<op>.unknown"`
  sentinel, so **no header needs a `Count` member** it would then have to defend at every merge.
- **Survey per Op, not per shape.** Per shape is misleading — `w8_pair k=5120` selects three
  schedules, so 42 of 45 look unrouted there while most are live at k=2048. It is also easy to
  under-register: surveying only `w8_attn_input`'s dflash2 shape reported **11 of 16** unrouted;
  adding the target and companion shapes took that to **2**.

## Verification

Adversarial — narrowing a q5 route so one schedule is stranded:

```
q5_linear_add: 2 of 9 unrouted
route coverage changed: 19 unrouted schedules, expected 18.
```

exit 1. Restored, it passes. Full suite **124/124**.

## Interaction with #22

**PR #22 removes eight `w8_pair` medium routes**, which strands those schedules and moves this
count from 18 to 26. Whichever of the two merges second needs `kExpectedUnrouted` updated in the
same commit. That is the test working as intended — making a route change's coverage consequence
visible instead of silent.