### PR TITLE
fix(scripts): make the launchers overridable, and stop shipping a LAN bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ Download `ninfer-rtx3090-windows-x64-*.zip`, unzip it, and from that folder:
 
 ```powershell
 .\download-qwen36-35b-a3b.bat            # downloads qwen3_6_35b_a3b.ninfer (~21 GB, resumable)
-.\run-qwen36-35b-a3b-c1-maxctx.bat        # serves on 0.0.0.0:8080, 114,688-token context
+.\run-qwen36-35b-a3b-c1-maxctx.bat        # serves on 127.0.0.1:8080, 114,688-token context
 ```
+
+`NINFER_HOST`, `NINFER_PORT`, `NINFER_MODEL` and `NINFER_SERVER` override it without editing the
+file; `set NINFER_HOST=0.0.0.0` exposes it to the LAN, unauthenticated.
 
 ### Headless Linux — full 256K context, two users, everything on
 
@@ -113,10 +116,11 @@ predictable. Same shape of command:
 ./run-qwen38-c1-maxctx.sh                 # two users, 212,992 tokens each, same knobs
 ```
 
-The plain `run-qwen38-c1` and `run-qwen38-c8` launchers are still there and unchanged. They are
-deliberately conservative — `c1` serves 65,536 tokens of INT8 and leaves 2.85 GiB of the card
-unused — so prefer the `-maxctx` pair unless you specifically want INT8's quality default or `c8`'s
-eight-lane throughput profile.
+The plain `run-qwen38-c1` and `run-qwen38-c8` launchers are still there, with the same profile
+defaults as before — `c1` serves 65,536 tokens of INT8 and leaves 2.85 GiB of the card unused — so
+prefer the `-maxctx` pair unless you specifically want INT8's quality default or `c8`'s eight-lane
+throughput profile. Like every launcher here, their host and port now default to `127.0.0.1:8080`
+and accept the same `NINFER_HOST`/`NINFER_PORT` overrides.
 
 | Profile | lanes | context | KV | vision | runtime | free (desktop) |
 |---|---|---|---|---|---|---|

--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
@@ -121,23 +121,39 @@ rem tighter on a given boot and the server refuses to start, drop --vision first
 rem context rung -- it is the newest addition, not the load-bearing one.
 rem ---------------------------------------------------------------------------------------------
 
-set "MODEL=C:\Ninefer-3090\models\qwen3_6_35b_a3b.ninfer"
+rem Every setting below can be overridden from the environment without editing this file:
+rem
+rem   set NINFER_CONTEXT=196608 && run-qwen36-35b-a3b-c1-maxctx.bat
+rem
+rem The default model path matches what download-qwen36-35b-a3b.bat writes and how the release
+rem archive is laid out: this launcher sits beside models\.
+set "MODEL=%~dp0models\qwen3_6_35b_a3b.ninfer"
 
 rem Profile A (active): speculation on. Rungs: 81920 / 90112 / 98304 / 114688 / 131072.
-rem set "CONTEXT=81920"
-set "CONTEXT=114688"
-rem Profile B: comment out the line above, uncomment this, and swap the commands at the bottom.
+rem Profile B: set NINFER_CONTEXT to a 196608+ rung and swap the commands at the bottom.
 rem Rungs: 196608 / 212992 / 229376 / 245760 / 262144.
-rem set "CONTEXT=196608"
+set "CONTEXT=114688"
 
-rem Bind address. 0.0.0.0 exposes an unauthenticated OpenAI-compatible endpoint to your whole LAN,
-rem which is what the qwen38 launcher does; use 127.0.0.1 to keep it on this machine only.
-set "HOST=0.0.0.0"
+rem Loopback by default. 0.0.0.0 publishes an unauthenticated OpenAI-compatible endpoint to every
+rem network this machine is on, so it is opt-in per run rather than the shipped default:
+rem   set NINFER_HOST=0.0.0.0
+set "HOST=127.0.0.1"
 set "PORT=8080"
+set "KV_DTYPE=rk8v4"
 
-rem scripts\ -> repo root -> the Ninja build output.
+if not "%NINFER_MODEL%"=="" set "MODEL=%NINFER_MODEL%"
+if not "%NINFER_CONTEXT%"=="" set "CONTEXT=%NINFER_CONTEXT%"
+if not "%NINFER_HOST%"=="" set "HOST=%NINFER_HOST%"
+if not "%NINFER_PORT%"=="" set "PORT=%NINFER_PORT%"
+if not "%NINFER_KV_DTYPE%"=="" set "KV_DTYPE=%NINFER_KV_DTYPE%"
+
+rem In the repo, scripts\ -> repo root -> the Ninja build output. In a release archive this
+rem launcher sits beside ninfer-serve.exe instead, which is the fallback -- without it the shipped
+rem copy of this script could never find the server.
 set "ROOT=%~dp0.."
 set "SERVER=%ROOT%\build-ninja\apps\ninfer-serve.exe"
+if not exist "%SERVER%" set "SERVER=%~dp0ninfer-serve.exe"
+if not "%NINFER_SERVER%"=="" set "SERVER=%NINFER_SERVER%"
 
 if not exist "%SERVER%" (
   echo Missing %SERVER%
@@ -161,7 +177,7 @@ rem --- Profile A: speculation on. ~240 tok/s decode. ---
   --max-concurrency 1 ^
   --max-context %CONTEXT% ^
   --kv-capacity %CONTEXT% ^
-  --kv-dtype rk8v4 ^
+  --kv-dtype %KV_DTYPE% ^
   --spec mtp --draft-tokens 3 --lm-head-draft ^
   --prefill-chunk 512 ^
   --max-pending-requests 16 --pending-timeout-ms 600000 ^

--- a/scripts/run-qwen36-35b-vision.bat
+++ b/scripts/run-qwen36-35b-vision.bat
@@ -4,6 +4,15 @@ set "ROOT=%~dp0"
 set "SERVER=%ROOT%ninfer-serve.exe"
 set "MODEL=%~1"
 if "%MODEL%"=="" set "MODEL=%ROOT%models\qwen3_6_35b_a3b.ninfer"
+rem Overridable without editing this file:  set NINFER_HOST=0.0.0.0 && this-script.bat
+rem Loopback by default -- 0.0.0.0 publishes an unauthenticated OpenAI-compatible endpoint to every
+rem network this machine is on, so it is opt-in per run rather than the shipped default.
+set "HOST=127.0.0.1"
+set "PORT=8080"
+if not "%NINFER_SERVER%"=="" set "SERVER=%NINFER_SERVER%"
+if not "%NINFER_MODEL%"=="" set "MODEL=%NINFER_MODEL%"
+if not "%NINFER_HOST%"=="" set "HOST=%NINFER_HOST%"
+if not "%NINFER_PORT%"=="" set "PORT=%NINFER_PORT%"
 
 if not exist "%SERVER%" (
   echo Missing %SERVER%
@@ -16,6 +25,6 @@ if not exist "%MODEL%" (
   exit /b 1
 )
 
-echo Starting Qwen3.6-35B-A3B Vision at http://127.0.0.1:8080/v1
+echo Starting Qwen3.6-35B-A3B Vision at http://%HOST%:%PORT%/v1
 echo Safe RTX 3090 profile: one request, 32K context, vision enabled, MTP disabled
-"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 32768 --kv-capacity 32768 --max-concurrency 1 --max-pending-requests 8 --pending-timeout-ms 600000 --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 512 --vision --no-thinking --temperature 0.2
+"%SERVER%" "%MODEL%" --host %HOST% --port %PORT% --max-context 32768 --kv-capacity 32768 --max-concurrency 1 --max-pending-requests 8 --pending-timeout-ms 600000 --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 512 --vision --no-thinking --temperature 0.2

--- a/scripts/run-qwen38-c1-maxctx.bat
+++ b/scripts/run-qwen38-c1-maxctx.bat
@@ -36,17 +36,32 @@ rem for the plain 32K image profile.
 rem Rungs if startup refuses: 163840 / 131072 / 114688 / 98304 / 65536.
 rem ---------------------------------------------------------------------------------------------
 
-set "MODEL=%~dp0..\..\qwen3_8_27b.ninfer"
-if not "%NINFER_MODEL%"=="" set "MODEL=%NINFER_MODEL%"
-
+rem Every setting below can be overridden from the environment without editing this file:
+rem
+rem   set NINFER_HOST=0.0.0.0 && run-qwen38-c1-maxctx.bat
+rem
+rem The default model path matches what download-qwen38-27b.bat writes and how the release archive
+rem is laid out: this launcher sits beside models\.
+set "MODEL=%~dp0models\qwen3_8_27b.ninfer"
 set "CONTEXT=131072"
 set "CONCURRENCY=1"
+rem Loopback by default. 0.0.0.0 publishes an unauthenticated OpenAI-compatible endpoint to every
+rem network this machine is on, so it is opt-in per run rather than the shipped default.
 set "HOST=127.0.0.1"
 set "PORT=8080"
+set "KV_DTYPE=rk8v4"
+
+if not "%NINFER_MODEL%"=="" set "MODEL=%NINFER_MODEL%"
+if not "%NINFER_CONTEXT%"=="" set "CONTEXT=%NINFER_CONTEXT%"
+if not "%NINFER_CONCURRENCY%"=="" set "CONCURRENCY=%NINFER_CONCURRENCY%"
+if not "%NINFER_HOST%"=="" set "HOST=%NINFER_HOST%"
+if not "%NINFER_PORT%"=="" set "PORT=%NINFER_PORT%"
+if not "%NINFER_KV_DTYPE%"=="" set "KV_DTYPE=%NINFER_KV_DTYPE%"
 
 set "ROOT=%~dp0.."
 set "SERVER=%ROOT%\build-ninja\apps\ninfer-serve.exe"
 if not exist "%SERVER%" set "SERVER=%~dp0ninfer-serve.exe"
+if not "%NINFER_SERVER%"=="" set "SERVER=%NINFER_SERVER%"
 
 if not exist "%SERVER%" (
   echo Missing %SERVER%
@@ -69,7 +84,7 @@ echo.
   --max-concurrency %CONCURRENCY% ^
   --max-context %CONTEXT% ^
   --kv-capacity %CONTEXT% ^
-  --kv-dtype rk8v4 ^
+  --kv-dtype %KV_DTYPE% ^
   --spec mtp --draft-tokens 3 --lm-head-draft ^
   --prefill-chunk 1024 ^
   --max-pending-requests 16 --pending-timeout-ms 600000 ^

--- a/scripts/run-qwen38-c1.bat
+++ b/scripts/run-qwen38-c1.bat
@@ -5,6 +5,16 @@ set "SERVER=%ROOT%ninfer-serve.exe"
 set "MODEL=%~1"
 if "%MODEL%"=="" set "MODEL=%ROOT%models\qwen3_8_27b.ninfer"
 
+rem Overridable without editing this file:  set NINFER_HOST=0.0.0.0 && run-qwen38-c1.bat
+rem Loopback by default -- 0.0.0.0 publishes an unauthenticated OpenAI-compatible endpoint to every
+rem network this machine is on, so it is opt-in per run rather than the shipped default.
+set "HOST=127.0.0.1"
+set "PORT=8080"
+if not "%NINFER_SERVER%"=="" set "SERVER=%NINFER_SERVER%"
+if not "%NINFER_MODEL%"=="" set "MODEL=%NINFER_MODEL%"
+if not "%NINFER_HOST%"=="" set "HOST=%NINFER_HOST%"
+if not "%NINFER_PORT%"=="" set "PORT=%NINFER_PORT%"
+
 if not exist "%SERVER%" (
   echo Missing %SERVER%
   echo Put this launcher beside the v0.6.1 release files.
@@ -16,6 +26,6 @@ if not exist "%MODEL%" (
   exit /b 1
 )
 
-echo Starting Qwen3.8-27B at http://127.0.0.1:8080/v1
+echo Starting Qwen3.8-27B at http://%HOST%:%PORT%/v1
 echo Profile: one request, 64K context, MTP3, ReplaySSM
-"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 65536 --kv-capacity 65536 --max-concurrency 1 --max-pending-requests 16 --pending-timeout-ms 600000 --prefill-chunk 1024 --kv-dtype int8 --spec mtp --draft-tokens 3 --lm-head-draft
+"%SERVER%" "%MODEL%" --host %HOST% --port %PORT% --max-context 65536 --kv-capacity 65536 --max-concurrency 1 --max-pending-requests 16 --pending-timeout-ms 600000 --prefill-chunk 1024 --kv-dtype int8 --spec mtp --draft-tokens 3 --lm-head-draft

--- a/scripts/run-qwen38-c8.bat
+++ b/scripts/run-qwen38-c8.bat
@@ -4,6 +4,15 @@ set "ROOT=%~dp0"
 set "SERVER=%ROOT%ninfer-serve.exe"
 set "MODEL=%~1"
 if "%MODEL%"=="" set "MODEL=%ROOT%models\qwen3_8_27b.ninfer"
+rem Overridable without editing this file:  set NINFER_HOST=0.0.0.0 && this-script.bat
+rem Loopback by default -- 0.0.0.0 publishes an unauthenticated OpenAI-compatible endpoint to every
+rem network this machine is on, so it is opt-in per run rather than the shipped default.
+set "HOST=127.0.0.1"
+set "PORT=8080"
+if not "%NINFER_SERVER%"=="" set "SERVER=%NINFER_SERVER%"
+if not "%NINFER_MODEL%"=="" set "MODEL=%NINFER_MODEL%"
+if not "%NINFER_HOST%"=="" set "HOST=%NINFER_HOST%"
+if not "%NINFER_PORT%"=="" set "PORT=%NINFER_PORT%"
 
 if not exist "%SERVER%" (
   echo Missing %SERVER%
@@ -16,6 +25,6 @@ if not exist "%MODEL%" (
   exit /b 1
 )
 
-echo Starting Qwen3.8-27B at http://127.0.0.1:8080/v1
+echo Starting Qwen3.8-27B at http://%HOST%:%PORT%/v1
 echo Profile: up to eight requests, 8K context, MTP3, ReplaySSM
-"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 8192 --kv-capacity 16384 --max-concurrency 8 --max-pending-requests 32 --pending-timeout-ms 600000 --prefill-chunk 512 --kv-dtype int8 --spec mtp --draft-tokens 3 --lm-head-draft
+"%SERVER%" "%MODEL%" --host %HOST% --port %PORT% --max-context 8192 --kv-capacity 16384 --max-concurrency 8 --max-pending-requests 32 --pending-timeout-ms 600000 --prefill-chunk 512 --kv-dtype int8 --spec mtp --draft-tokens 3 --lm-head-draft

--- a/scripts/run-qwen38-vision.bat
+++ b/scripts/run-qwen38-vision.bat
@@ -4,6 +4,15 @@ set "ROOT=%~dp0"
 set "SERVER=%ROOT%ninfer-serve.exe"
 set "MODEL=%~1"
 if "%MODEL%"=="" set "MODEL=%ROOT%models\qwen3_8_27b.ninfer"
+rem Overridable without editing this file:  set NINFER_HOST=0.0.0.0 && this-script.bat
+rem Loopback by default -- 0.0.0.0 publishes an unauthenticated OpenAI-compatible endpoint to every
+rem network this machine is on, so it is opt-in per run rather than the shipped default.
+set "HOST=127.0.0.1"
+set "PORT=8080"
+if not "%NINFER_SERVER%"=="" set "SERVER=%NINFER_SERVER%"
+if not "%NINFER_MODEL%"=="" set "MODEL=%NINFER_MODEL%"
+if not "%NINFER_HOST%"=="" set "HOST=%NINFER_HOST%"
+if not "%NINFER_PORT%"=="" set "PORT=%NINFER_PORT%"
 
 if not exist "%SERVER%" (
   echo Missing %SERVER%
@@ -16,6 +25,6 @@ if not exist "%MODEL%" (
   exit /b 1
 )
 
-echo Starting Qwen3.8-27B Vision at http://127.0.0.1:8080/v1
+echo Starting Qwen3.8-27B Vision at http://%HOST%:%PORT%/v1
 echo Tested RTX 3090 profile: one request, 32K context, ReplaySSM and MTP3
-"%SERVER%" "%MODEL%" --host 127.0.0.1 --port 8080 --max-context 32768 --kv-capacity 32768 --max-concurrency 1 --max-pending-requests 8 --pending-timeout-ms 600000 --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 1024 --vision --spec mtp --draft-tokens 3 --lm-head-draft
+"%SERVER%" "%MODEL%" --host %HOST% --port %PORT% --max-context 32768 --kv-capacity 32768 --max-concurrency 1 --max-pending-requests 8 --pending-timeout-ms 600000 --prefill-chunk 512 --kv-dtype int8 --default-max-tokens 1024 --vision --spec mtp --draft-tokens 3 --lm-head-draft


### PR DESCRIPTION
Three bugs and one usability gap in the shipped `run-qwen*.bat` launchers. All six ship in the
release archive — `package-release-*.ps1` copies every `download-qwen*`/`run-qwen*` `.bat` flat,
beside `models\` — so the paths they assume have to match that layout.

## Bugs

| | |
|---|---|
| **`run-qwen36-35b-a3b-c1-maxctx.bat` shipped `HOST=0.0.0.0`** | Publishes an **unauthenticated** OpenAI-compatible endpoint to every network the machine is on. It was deliberate and commented, but it is the wrong default for an archive people download. Both maxctx launchers now default to `127.0.0.1`, with `NINFER_HOST` for the LAN case. |
| **…and hardcoded `C:\Ninefer-3090\models\qwen3_6_35b_a3b.ninfer`** | One machine's absolute path, shipped to everyone. Now `%~dp0models\`, which is where `download-qwen36-35b-a3b.bat` actually writes. |
| **`run-qwen38-c1-maxctx.bat` looked for its model at `%~dp0..\..\`** | Two directories *above* the launcher — a location that exists in no layout. Same fix. Reported by @Warlax, who hit it directly. |
| **`run-qwen36-35b-a3b-c1-maxctx.bat` resolved the server only as `build-ninja\apps\ninfer-serve.exe`** | So the *shipped* copy could never find it. Now falls back to `%~dp0ninfer-serve.exe` like the other launchers. |

## Overrides

Every setting is now overridable without editing the file:

```bat
set NINFER_HOST=0.0.0.0 && run-qwen38-c1.bat
```

`NINFER_SERVER`, `NINFER_MODEL`, `NINFER_HOST`, `NINFER_PORT`, plus `NINFER_CONTEXT`,
`NINFER_CONCURRENCY` and `NINFER_KV_DTYPE` where the launcher has them.

**Defaults are unchanged** apart from the two bind addresses and the paths above.

## Verification

Ran all six against a stand-in server that echoes its arguments — twelve cases, each launcher with
and without overrides:

```
run-qwen36-35b-a3b-c1-maxctx.bat   default   host=127.0.0.1   port=8080
run-qwen36-35b-a3b-c1-maxctx.bat   override  host=0.0.0.0     port=9999
run-qwen36-35b-vision.bat          default   host=127.0.0.1   port=8080
run-qwen36-35b-vision.bat          override  host=0.0.0.0     port=9999
run-qwen38-c1-maxctx.bat           default   host=127.0.0.1   port=8080
run-qwen38-c1-maxctx.bat           override  host=0.0.0.0     port=9999
run-qwen38-c1.bat                  default   host=127.0.0.1   port=8080
run-qwen38-c1.bat                  override  host=0.0.0.0     port=9999
run-qwen38-c8.bat                  default   host=127.0.0.1   port=8080
run-qwen38-c8.bat                  override  host=0.0.0.0     port=9999
run-qwen38-vision.bat              default   host=127.0.0.1   port=8080
run-qwen38-vision.bat              override  host=0.0.0.0     port=9999
```

Batch scripts fail at runtime rather than at parse time, so executing each one was the only way to
confirm this rather than eyeballing the diff.