### PR TITLE
fix(serve): say which knob to turn when a pinned host allocation fails

### DIFF
--- a/src/core/arena.cu
+++ b/src/core/arena.cu
@@ -338,7 +338,15 @@ PinnedHostBuffer::PinnedHostBuffer(std::size_t size_bytes) {
     void* ptr             = nullptr;
     const cudaError_t err = cudaMallocHost(&ptr, size_bytes);
     if (err != cudaSuccess) {
-        throw std::runtime_error(cuda_error_message("cudaMallocHost failed", err));
+        // Say the size, and say *host*. The bare CUDA text is
+        // "cudaErrorMemoryAllocation: out of memory", which reads as a VRAM shortfall and sends
+        // people to look at nvidia-smi -- but this allocation is pinned system RAM and can fail
+        // with the card almost entirely free. The caller adds which knob shrinks it.
+        const std::string prefix =
+            "cudaMallocHost failed to pin " +
+            std::to_string((size_bytes + (1ULL << 20) - 1) >> 20) +
+            " MiB of host memory (this is system RAM, not VRAM)";
+        throw std::runtime_error(cuda_error_message(prefix.c_str(), err));
     }
 
     data_ = ptr;

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -903,8 +903,22 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
             plan.context_cache.host_state_slots;
         StartupPhaseScope host_state_phase(startup_observer, StartupPhase::HostStatePin,
                                            StartupProgressUnit::Bytes, host_state_bytes);
-        host_state_images = std::make_unique<qwen3_6::HostStatePool>(
-            state_images->host_layout(), plan.context_cache.host_state_slots);
+        // The other large pinned-host allocation, and it scales with the model: a StateImage is
+        // 61.4 MiB on the 35B-A3B and 147 MiB on the 27B, so the default eight slots is 1.15 GiB
+        // there. Same reasoning as the host KV arena below -- name the knob, because the CUDA
+        // error underneath says only "out of memory".
+        try {
+            host_state_images = std::make_unique<qwen3_6::HostStatePool>(
+                state_images->host_layout(), plan.context_cache.host_state_slots);
+        } catch (const std::exception& error) {
+            throw std::runtime_error(
+                std::string("failed to reserve host StateImage slots: ") + error.what() +
+                "\nThis is the context cache's pinned StateImage pool, " +
+                std::to_string(plan.context_cache.host_state_slots) + " slots of " +
+                std::to_string((state_images->host_layout().image_bytes + (1ULL << 20) - 1) >> 20) +
+                " MiB, sized by --host-state-slots. Lower it to use less system RAM, or pass "
+                "--no-prefix-reuse to disable the context cache entirely.");
+        }
         host_state_phase.complete(host_state_bytes, host_state_bytes);
     }
     const std::uint64_t logical_state_capacity =
@@ -968,9 +982,22 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
         StartupPhaseScope host_kv_phase(
             startup_observer, StartupPhase::HostKvPin, StartupProgressUnit::Bytes,
             static_cast<std::uint64_t>(plan.context_cache.host_kv_capacity_bytes));
-        host_kv_arena = std::make_unique<HostKVArena>(
-            plan.context_cache.host_kv_capacity_bytes,
-            std::span<const HostKVPageLayout>(layouts.data(), layouts.size()));
+        // Name the knob. This is the largest pinned-host allocation the server makes -- 8 GiB by
+        // default (kDefaultHostKvCapacityBytes) regardless of how much RAM the machine has -- so it
+        // is the first thing to fail on a box with a modest amount free, and the underlying CUDA
+        // error says only "out of memory" with no hint that it means system RAM or which flag
+        // shrinks it. Prefix reuse degrades gracefully at a smaller size; it does not need 8 GiB.
+        try {
+            host_kv_arena = std::make_unique<HostKVArena>(
+                plan.context_cache.host_kv_capacity_bytes,
+                std::span<const HostKVPageLayout>(layouts.data(), layouts.size()));
+        } catch (const std::exception& error) {
+            throw std::runtime_error(
+                std::string("failed to reserve the host KV cache: ") + error.what() +
+                "\nThis is the context cache's pinned host buffer, sized by --host-kv-mib "
+                "(default 8192). Lower it (for example --host-kv-mib 512) to use less system RAM, "
+                "or pass --no-prefix-reuse to disable the context cache entirely.");
+        }
         host_kv_phase.complete(
             static_cast<std::uint64_t>(plan.context_cache.host_kv_capacity_bytes),
             static_cast<std::uint64_t>(plan.context_cache.host_kv_capacity_bytes));


### PR DESCRIPTION
Closes the `--spec mtp` startup finding in TODO.md §8.

## The problem

Starting the server with speculation on a box with modest free RAM dies with:

```
FATAL server failed during startup | cudaMallocHost failed: cudaErrorMemoryAllocation: out of memory
```

**Every word of that points at the GPU.** It is not the GPU — `cudaMallocHost` pins *system* RAM,
and this fails with the card almost entirely free. Nothing says how much was requested, that the
shortfall is host memory, or which flag shrinks it.

Hit while smoke-testing `--spec mtp`: the context cache asks for **8 GiB** of pinned host KV by
default (`kDefaultHostKvCapacityBytes`), regardless of how much the machine actually has.

## The fix

Three layers, each adding only what it alone knows:

| layer | adds |
|---|---|
| `PinnedHostBuffer` | the size, and that it is **system RAM, not VRAM** — it is the generic allocator, so that is as specific as it can honestly be |
| host KV arena | `--host-kv-mib`, its 8192 default, a concrete smaller value, and `--no-prefix-reuse` |
| host StateImage pool | `--host-state-slots`, plus **the per-slot size it computed**, so the arithmetic behind the total is visible |

## Verification

Both paths triggered, not just read:

```
--host-kv-mib 900000
  -> failed to reserve the host KV cache: cudaMallocHost failed to pin 900000 MiB of host
     memory (this is system RAM, not VRAM): cudaErrorMemoryAllocation: out of memory
     This is the context cache's pinned host buffer, sized by --host-kv-mib (default 8192).
     Lower it (for example --host-kv-mib 512)... or pass --no-prefix-reuse...

--host-state-slots 4096
  -> failed to reserve host StateImage slots: ... 4096 slots of 147 MiB, sized by
     --host-state-slots. Lower it to use less system RAM, or pass --no-prefix-reuse...
```

The **147 MiB** it reports matches the figure documented in `run-qwen38-c1-maxctx.bat`, so the
per-slot arithmetic is right rather than merely plausible.

**No behaviour change** — defaults, sizing and the success path are untouched. Confirmed by
re-running the `--spec mtp` smoke test end to end: output byte-identical to before, and the server
still answers correctly on all three prompts. Full suite **124/124**.

## Deliberately not changed

The 8 GiB default regardless of host RAM. Making it adaptive is a policy change that needs its own
measurement (what "available" means differs by OS, and shrinking it silently would regress prefix
reuse for people who have the memory). Tracked in §8 rather than folded in here.