### PR TITLE
feat(serve): answer 503 while the model is loading instead of hanging

### DIFF
--- a/apps/serve/main.cpp
+++ b/apps/serve/main.cpp
@@ -60,6 +60,11 @@ int main(int argc, char** argv) {
             return 1;
         }
 
+        // Answer 503 from here on rather than leaving the accepted connection silent. The socket
+        // has been listenable since bind() either way; the difference is whether a caller arriving
+        // during the ten seconds of weight loading gets a documented "still loading" or a hang.
+        server.start_serving_during_startup();
+
         ninfer::serve::GenerationService service(options, startup_log.observer());
         startup_log.engine_ready(service.load_summary());
         operational_log.engine_capacity(service);

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -111,6 +111,28 @@ to 64 further workers for connections that are merely open; the extra workers re
 Without that headroom a client-side connection pool of otherwise idle sockets occupies every worker
 and the server accepts real requests strictly one at a time.
 
+### Startup readiness
+
+The server binds its port and starts accepting connections before the Engine has loaded weights
+and finished warmup, so a port clash is reported in milliseconds rather than after loading. Every
+route -- including `/health`, `OPTIONS`, and requests that would otherwise be unauthenticated --
+answers `503` with `Retry-After: 2` until warmup completes, in the target's own error shape:
+
+```json
+{"error":{"message":"The model is still loading. Retry shortly.","type":"service_unavailable","code":"model_loading"}}
+```
+
+`POST /v1/messages` and `/v1/messages/count_tokens` receive the Anthropic envelope instead, with a
+`request_id` field and a `request-id` header, matching every other error response on those
+endpoints:
+
+```json
+{"type":"error","error":{"type":"api_error","message":"The model is still loading. Retry shortly."},"request_id":"req_..."}
+```
+
+A readiness probe should poll `GET /health` (or any endpoint) and expect `503` until the model is
+ready rather than treating an accepted TCP connection as a signal of readiness.
+
 ## OpenAI Chat Completions
 
 ```bash

--- a/src/serve/http_server.cpp
+++ b/src/serve/http_server.cpp
@@ -535,8 +535,17 @@ void HttpServer::start_serving_during_startup() {
     // auth/request-ID middleware for the remainder of the process's life.
     startup_listener_ = std::thread([this] {
         // listen_after_bind() blocks here for the whole life of the server, spanning the switch
-        // from 503 to serving. stop() is what ends it.
-        startup_listener_result_.store(server_.listen_after_bind(), std::memory_order_release);
+        // from 503 to serving. stop() is what ends it. It can also throw before ever reaching
+        // that loop -- the task queue's thread pool spawns its worker threads here, and
+        // std::thread's constructor throws std::system_error under resource exhaustion. An
+        // exception escaping a thread function is std::terminate, so it is caught and folded into
+        // the same false result a synchronous listen() failure already produces.
+        bool result = false;
+        try {
+            result = server_.listen_after_bind();
+        } catch (const std::exception&) {
+        }
+        startup_listener_result_.store(result, std::memory_order_release);
     });
 }
 

--- a/src/serve/http_server.cpp
+++ b/src/serve/http_server.cpp
@@ -359,6 +359,25 @@ void HttpServer::register_routes() {
 
     server_.set_pre_routing_handler([this](const httplib::Request& req, httplib::Response& res) {
         ensure_openai_request_id(req, res);
+        if (!ready_.load(std::memory_order_acquire)) {
+            // Runs for every route, including /health and OPTIONS, so a caller cannot tell "not
+            // ready" apart from "unauthenticated" -- and skips the API-key check below, since a
+            // loading-status response carries nothing worth protecting.
+            ApiError error;
+            error.status  = 503;
+            error.type    = "service_unavailable";
+            error.code    = "model_loading";
+            error.message = "The model is still loading. Retry shortly.";
+            // Weight load plus warmup measured ~10s on the 27B and longer on the 35B. Two seconds
+            // is a polite poll interval rather than a promise about when readiness arrives.
+            res.set_header("Retry-After", "2");
+            if (req.path.rfind("/v1/messages", 0) == 0) {
+                write_anthropic_error(res, error, new_anthropic_request_id());
+            } else {
+                write_openai_error(res, error);
+            }
+            return httplib::Server::HandlerResponse::Handled;
+        }
         if (options_.api_key.empty() || req.path == "/health" || req.method == "OPTIONS") {
             return httplib::Server::HandlerResponse::Unhandled;
         }
@@ -511,24 +530,9 @@ void HttpServer::start_serving_during_startup() {
         throw std::logic_error("HTTP startup listener is already running");
     }
 
-    // One guard for every route, rather than thirteen. A pre-routing handler runs before dispatch,
-    // so a route added later is covered without anyone remembering to add a check to it.
-    server_.set_pre_routing_handler(
-        [this](const httplib::Request&, httplib::Response& res) -> httplib::Server::HandlerResponse {
-            if (ready_.load(std::memory_order_acquire)) {
-                return httplib::Server::HandlerResponse::Unhandled;
-            }
-            res.status = 503;
-            // Weight load plus warmup measured ~10s on the 27B and longer on the 35B. Two seconds
-            // is a polite poll interval rather than a promise about when readiness arrives.
-            res.set_header("Retry-After", "2");
-            res.set_content(
-                R"({"error":{"message":"The model is still loading. Retry shortly.",)"
-                R"("type":"service_unavailable","code":"model_loading"}})",
-                "application/json");
-            return httplib::Server::HandlerResponse::Handled;
-        });
-
+    // The readiness gate lives in register_routes()'s single pre-routing handler, ahead of the
+    // API-key check -- not here, so starting this listener never replaces (and thereby drops) the
+    // auth/request-ID middleware for the remainder of the process's life.
     startup_listener_ = std::thread([this] {
         // listen_after_bind() blocks here for the whole life of the server, spanning the switch
         // from 503 to serving. stop() is what ends it.

--- a/src/serve/http_server.cpp
+++ b/src/serve/http_server.cpp
@@ -506,6 +506,41 @@ void HttpServer::handle_model(const httplib::Request& req, httplib::Response& re
 
 bool HttpServer::bind() { return server_.bind_to_port(options_.host, options_.port); }
 
+void HttpServer::start_serving_during_startup() {
+    if (startup_listener_.joinable()) {
+        throw std::logic_error("HTTP startup listener is already running");
+    }
+
+    // One guard for every route, rather than thirteen. A pre-routing handler runs before dispatch,
+    // so a route added later is covered without anyone remembering to add a check to it.
+    server_.set_pre_routing_handler(
+        [this](const httplib::Request&, httplib::Response& res) -> httplib::Server::HandlerResponse {
+            if (ready_.load(std::memory_order_acquire)) {
+                return httplib::Server::HandlerResponse::Unhandled;
+            }
+            res.status = 503;
+            // Weight load plus warmup measured ~10s on the 27B and longer on the 35B. Two seconds
+            // is a polite poll interval rather than a promise about when readiness arrives.
+            res.set_header("Retry-After", "2");
+            res.set_content(
+                R"({"error":{"message":"The model is still loading. Retry shortly.",)"
+                R"("type":"service_unavailable","code":"model_loading"}})",
+                "application/json");
+            return httplib::Server::HandlerResponse::Handled;
+        });
+
+    startup_listener_ = std::thread([this] {
+        // listen_after_bind() blocks here for the whole life of the server, spanning the switch
+        // from 503 to serving. stop() is what ends it.
+        startup_listener_result_.store(server_.listen_after_bind(), std::memory_order_release);
+    });
+}
+
+bool HttpServer::await_startup_listener() {
+    if (startup_listener_.joinable()) { startup_listener_.join(); }
+    return startup_listener_result_.load(std::memory_order_acquire);
+}
+
 void HttpServer::attach(GenerationService& service) {
     if (service_ != nullptr) {
         throw std::logic_error("HTTP generation service is already attached");
@@ -516,6 +551,9 @@ void HttpServer::attach(GenerationService& service) {
     request_jsonl_.write_server_start(options_, service.engine_options(),
                                       service.sampling_defaults(), public_model_id_, load,
                                       service.memory_summary());
+    // Release: everything above must be visible to a handler that observes ready_ as true. This is
+    // the only write, and handlers acquire it in the pre-routing guard before touching service_.
+    ready_.store(true, std::memory_order_release);
 }
 
 bool HttpServer::listen() {
@@ -528,7 +566,11 @@ bool HttpServer::listen() {
         stats_thread_   = std::thread([this] { run_stats_reporter(); });
     }
     try {
-        const bool result = server_.listen_after_bind();
+        // When the startup listener is running, the accept loop is already live on its thread and
+        // has been since bind(); calling listen_after_bind() again would try to accept on the same
+        // socket from two threads. Wait for that loop instead.
+        const bool result =
+            startup_listener_.joinable() ? await_startup_listener() : server_.listen_after_bind();
         stop_stats_reporter();
         return result;
     } catch (...) {
@@ -538,5 +580,13 @@ bool HttpServer::listen() {
 }
 
 void HttpServer::stop() { server_.stop(); }
+
+HttpServer::~HttpServer() {
+    if (startup_listener_.joinable()) {
+        server_.stop();
+        startup_listener_.join();
+    }
+    stop_stats_reporter();
+}
 
 } // namespace ninfer::serve

--- a/src/serve/http_server.cpp
+++ b/src/serve/http_server.cpp
@@ -574,11 +574,11 @@ bool HttpServer::listen() {
     if (public_model_id_.empty()) {
         throw std::logic_error("HTTP public model id is not resolved");
     }
-    if (options_.log_stats_interval_ms != 0) {
-        stats_stopping_ = false;
-        stats_thread_   = std::thread([this] { run_stats_reporter(); });
-    }
     try {
+        if (options_.log_stats_interval_ms != 0) {
+            stats_stopping_ = false;
+            stats_thread_   = std::thread([this] { run_stats_reporter(); });
+        }
         // When the startup listener is running, the accept loop is already live on its thread and
         // has been since bind(); calling listen_after_bind() again would try to accept on the same
         // socket from two threads. Wait for that loop instead.
@@ -588,6 +588,15 @@ bool HttpServer::listen() {
         return result;
     } catch (...) {
         stop_stats_reporter();
+        // Stop and join the startup listener before this exception unwinds past us. attach() has
+        // already run by the time listen() can be called, so that thread is live against
+        // service_; the caller (main.cpp) destroys the attached GenerationService, constructed
+        // after this HttpServer, before this object -- leaving that thread dereferencing a
+        // dangling pointer for however long stack unwinding takes if it is still running then.
+        if (startup_listener_.joinable()) {
+            server_.stop();
+            startup_listener_.join();
+        }
         throw;
     }
 }

--- a/src/serve/http_server.h
+++ b/src/serve/http_server.h
@@ -37,6 +37,14 @@ httplib::Server::HandlerResponse handle_unrendered_http_error(const ServeOptions
 class HttpServer {
 public:
     HttpServer(ServeOptions options, std::shared_ptr<spdlog::logger> logger);
+    // Stops and joins the startup listener if it is still running. Without this, a failure between
+    // start_serving_during_startup() and listen() -- the Engine throwing while loading weights, the
+    // most likely failure there is -- would destroy a joinable std::thread and call std::terminate,
+    // turning a clean diagnosable error into an abort.
+    ~HttpServer();
+
+    HttpServer(const HttpServer&)            = delete;
+    HttpServer& operator=(const HttpServer&) = delete;
 
     // Reserves the configured address before model loading. The service is attached only after its
     // Engine is ready, then listen() enters the blocking accept loop on the already-bound socket.
@@ -44,6 +52,25 @@ public:
     void attach(GenerationService& service);
     bool listen();
     void stop();
+
+    // Serve 503 while the Engine is still loading.
+    //
+    // bind() deliberately runs before the Engine is constructed, so a port clash fails in
+    // milliseconds instead of after ten seconds of weight loading. The cost used to be a window --
+    // measured at 0.27s to 9.5s on the 27B -- where the kernel accepted connections into the
+    // backlog and nothing ever answered them: a TCP readiness probe called that "ready", and an
+    // HTTP probe burned its whole timeout instead of failing fast.
+    //
+    // Calling this immediately after bind() starts the accept loop on a background thread with
+    // every route answering 503 plus Retry-After. attach() then publishes the service and the same
+    // loop begins serving normally, with no second bind and no handoff of the listening socket.
+    void start_serving_during_startup();
+    [[nodiscard]] bool serving_during_startup() const noexcept {
+        return startup_listener_.joinable();
+    }
+    // Blocks until the background accept loop returns, which happens when stop() is called.
+    // Mirrors listen()'s return: true when the loop exited cleanly.
+    bool await_startup_listener();
 
     [[nodiscard]] const std::string& public_model_id() const noexcept { return public_model_id_; }
 
@@ -97,7 +124,13 @@ private:
     void run_stats_reporter();
     void stop_stats_reporter();
 
+    // Written once by attach() on the main thread and read by request handlers on httplib's worker
+    // threads, so the publication has to be ordered. Handlers only ever test readiness through
+    // ready_; service_ itself is not read until ready_ has been observed true.
     GenerationService* service_ = nullptr;
+    std::atomic<bool> ready_{false};
+    std::thread startup_listener_;
+    std::atomic<bool> startup_listener_result_{false};
     ServeOptions options_;
     std::string public_model_id_;
     OpenAIResponsesStore openai_responses_store_;


### PR DESCRIPTION
Closes the readiness half of the startup findings in TODO.md §8.

## The problem

`apps/serve/main.cpp` binds the socket **before** constructing the Engine, so a port clash fails in
milliseconds rather than after ten seconds of weight loading. That is worth keeping. The cost was a
window where the kernel accepted connections into the backlog and **nothing ever answered them**.

Measured on the 27B, polling TCP connect and HTTP GET separately from process start:

| | |
|---|---|
| first TCP connect accepted | **0.27 s** |
| first HTTP 200 from `/v1/models` | **9.5 s** |
| in between | every request **times out** |

So a **TCP readiness probe** — Kubernetes `tcpSocket`, most load-balancer health checks — called
the server ready ~10 s early and routed traffic into a socket that would not answer. An HTTP probe
burned its full timeout on every attempt instead of failing fast.

## The fix

`start_serving_during_startup()` runs the accept loop on a background thread from just after
`bind()`, with a **pre-routing handler** answering `503` + `Retry-After` until `attach()` publishes
the service.

One guard covers **all thirteen routes**, and a route added later is covered without anyone
remembering to add a check. There is no second bind and no handoff of the listening socket — the
same accept loop serves 503 and then serves normally.

| | before | after |
|---|---|---|
| first response | timeout until 9.5 s | **503 at 0.25 s** |
| timeouts during startup | every request | **0** |
| first 200 | 9.5 s | 8.0 s |

Verified with `HttpClient` (which surfaces non-2xx cleanly, unlike `Invoke-WebRequest`):

```
status      : 503 ServiceUnavailable
Retry-After : 2
content-type: application/json
body        : {"error":{"message":"The model is still loading. Retry shortly.",
               "type":"service_unavailable","code":"model_loading"}}
POST chat   : 503        <- not GET-only
```

## Two hazards this created, and closed

- **`HttpServer` had no destructor.** Once a listener thread exists, a failure between
  `start_serving_during_startup()` and `listen()` — the Engine throwing while loading weights,
  which is the likeliest failure there — would destroy a joinable `std::thread` and call
  `std::terminate`, turning a diagnosable error into an abort. Added a destructor that stops and
  joins. Verified by forcing a mid-startup failure: **exit code 1** and a clean FATAL line.
- **`listen()` would have bound twice.** It would have called `listen_after_bind()` again while the
  startup loop was already accepting on that socket. It now waits on the existing loop.

`ready_` is published release/acquire and is the only thing handlers test; `service_` is not read
until `ready_` has been observed true.

## Verification

Generation unaffected — the `--spec mtp` smoke test returns **byte-identical** output on all three
prompts. Full suite **124/124**.