### PR TITLE
perf(linear_swiglu): retune the q4 Materialized bands, up to 23% at T=257

### DIFF
--- a/bench/ops/q4_linear_swiglu_schedule_bench.cu
+++ b/bench/ops/q4_linear_swiglu_schedule_bench.cu
@@ -101,11 +101,14 @@ int main(int argc, char** argv) {
     cudaStream_t stream = nullptr;
 
     // Materialized stages the whole gate+up product, so its workspace scales with the widest
-    // column count swept. Size it once for the whole range rather than per point.
+    // column count swept. Size it once for the whole range rather than per point, and directly
+    // from max_tokens rather than through resolve_plan's route table: every schedule here runs at
+    // every in-domain token count regardless of which one the table would actually pick, and the
+    // table often does not route to Materialized anywhere in [1, max_tokens] -- which is the whole
+    // point of sweeping it outside its routed interval.
     const std::size_t workspace_bytes =
-        ninfer::ops::detail::q4_linear_swiglu_capacity_workspace_bytes(kGateUpRows, kOutputRows,
-                                                                       kHidden, kHidden, 1,
-                                                                       max_tokens);
+        ninfer::ops::detail::q4_linear_swiglu_materialized_workspace_bytes(kGateUpRows,
+                                                                           max_tokens);
     ninfer::WorkspaceArena workspace(std::max<std::size_t>(workspace_bytes, 1));
 
     cudaDeviceProp properties{};

--- a/bench/ops/q4_linear_swiglu_schedule_bench.cu
+++ b/bench/ops/q4_linear_swiglu_schedule_bench.cu
@@ -8,12 +8,16 @@
 // q4_linear_swiglu_small_t_exact, a kernel upstream deleted, so it had nothing behind it -- but
 // neither did 32 on sm_86.
 //
-// Materialized is not included: it needs a workspace and a different launch signature, and it is
-// not adjacent to the boundary under test.
+// Materialized is included as of the sm_86 sweep of the {49,128}/{257,384}/{513,640} bands. It is
+// not a kernel -- it is linear() into a workspace followed by silu_mul() over the two halves -- so
+// it has no launch signature to put in a function-pointer table, which is why it was left out
+// before. Every schedule now goes through q4_linear_swiglu_execute_schedule instead, the real
+// dispatch minus its plan-matches-problem check, so the bench times the Op rather than a replica.
 
 #include "core/device.h"
 #include "ninfer_bench_common.h"
 #include "ops/linear_swiglu/q4/q4_linear_swiglu_kernels.h"
+#include "ops/linear_swiglu/q4/q4_linear_swiglu_plan.h"
 #include "quantized_weight.cuh"
 
 #include <cuda_runtime.h>
@@ -33,11 +37,11 @@ using ninfer::QType;
 using ninfer::Tensor;
 using ninfer::Weight;
 
-using Launch = void (*)(const Tensor&, const Weight&, Tensor&, cudaStream_t);
+using Id = ninfer::ops::detail::Q4LinearSwiGluScheduleId;
 
 struct Schedule {
     const char* name;
-    Launch launch;
+    Id id;
     // Largest column count the kernel actually processes; 0 means unbounded. gemv_pair is a
     // decode kernel registered for {1,1}: hand it more columns and it silently does one column's
     // work in a constant 122.9 us, which makes it look like it wins everywhere.
@@ -45,14 +49,12 @@ struct Schedule {
 };
 
 const Schedule kSchedules[] = {
-    {"gemv_pair", &ninfer::ops::detail::q4_linear_swiglu_gemv_pair_launch, 1},
-    {"small_t_tiled", &ninfer::ops::detail::q4_linear_swiglu_small_t_tiled_launch, 32},
-    {"split_half_pair_c40",
-     &ninfer::ops::detail::q4_linear_swiglu_mma_split_half_pair_r32_c40_launch, 0},
-    {"split_half_pair_c48",
-     &ninfer::ops::detail::q4_linear_swiglu_mma_split_half_pair_r32_c48_launch, 0},
-    {"split_half_pair_c128",
-     &ninfer::ops::detail::q4_linear_swiglu_mma_split_half_pair_r32_c128_launch, 0},
+    {"gemv_pair", Id::GemvPair, 1},
+    {"small_t_tiled", Id::SmallTTiled, 32},
+    {"split_half_pair_c40", Id::MmaSplitHalfPairR32C40, 0},
+    {"split_half_pair_c48", Id::MmaSplitHalfPairR32C48, 0},
+    {"split_half_pair_c128", Id::MmaSplitHalfPairR32C128, 0},
+    {"materialized", Id::Materialized, 0},
 };
 constexpr int kScheduleCount = static_cast<int>(sizeof(kSchedules) / sizeof(kSchedules[0]));
 
@@ -98,6 +100,14 @@ int main(int argc, char** argv) {
     ninfer::DeviceBuffer flush(kFlushBytes);
     cudaStream_t stream = nullptr;
 
+    // Materialized stages the whole gate+up product, so its workspace scales with the widest
+    // column count swept. Size it once for the whole range rather than per point.
+    const std::size_t workspace_bytes =
+        ninfer::ops::detail::q4_linear_swiglu_capacity_workspace_bytes(kGateUpRows, kOutputRows,
+                                                                       kHidden, kHidden, 1,
+                                                                       max_tokens);
+    ninfer::WorkspaceArena workspace(std::max<std::size_t>(workspace_bytes, 1));
+
     cudaDeviceProp properties{};
     cudaGetDeviceProperties(&properties, 0);
     std::printf("# gpu=%s sm=%d%d  q4 swiglu schedules, cold, median of %d\n", properties.name,
@@ -119,7 +129,8 @@ int main(int argc, char** argv) {
                 continue;
             }
             const auto invoke = [&](cudaStream_t launch_stream) {
-                schedule.launch(x, packed.weight, out, launch_stream);
+                ninfer::ops::detail::q4_linear_swiglu_execute_schedule(
+                    schedule.id, x, packed.weight, out, workspace, launch_stream);
             };
             double us = 0.0;
             try {

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
@@ -102,6 +102,11 @@ std::size_t materialized_workspace_bytes(std::int32_t rows, std::int32_t cols) {
 
 } // namespace
 
+std::size_t q4_linear_swiglu_materialized_workspace_bytes(std::int32_t gate_up_rows,
+                                                          std::int32_t max_cols) {
+    return materialized_workspace_bytes(gate_up_rows, max_cols);
+}
+
 const char* q4_linear_swiglu_schedule_name(Q4LinearSwiGluScheduleId schedule) noexcept {
     switch (schedule) {
     case Q4LinearSwiGluScheduleId::GemvPair:

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
@@ -31,7 +31,7 @@ struct RouteSpec {
 
 constexpr Q4LinearSwiGluProblem kShape{34816, 17408, 5120, 5120, 1};
 
-constexpr std::array<RouteSpec, 10> kRoutes{{
+constexpr std::array<RouteSpec, 7> kRoutes{{
     {{1, 1}, Q4LinearSwiGluScheduleId::GemvPair},
     // Measured on sm_86 with bench/ops/q4_linear_swiglu_schedule_bench.cu (cold, median of 11):
     // SmallTTiled and the 40-wide pair tile cross between 24 and 25, us --
@@ -45,10 +45,28 @@ constexpr std::array<RouteSpec, 10> kRoutes{{
     {{2, 24}, Q4LinearSwiGluScheduleId::SmallTTiled},
     {{25, 40}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C40},
     {{41, 48}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C48},
-    {{49, 128}, Q4LinearSwiGluScheduleId::Materialized},
-    {{129, 256}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
-    {{257, 384}, Q4LinearSwiGluScheduleId::Materialized},
-    {{385, 512}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
+    // Measured on sm_86 by bench/ops/q4_linear_swiglu_schedule_bench.cu, cold, median of 9-15,
+    // repeated three to four times per width because this Op is noisier than the others here.
+    //
+    // Upstream alternates Materialized and the c128 tile three times across 49..640. That shape is
+    // implausible on its face -- the winner does not genuinely change back and forth over a
+    // contiguous range -- and it does not survive measurement. Materialized lost at every width in
+    // {49,128} and {257,384}, in every run:
+    //
+    //   T          49     64     96    128    257    320    384
+    //   c128      812    823    848    809   2309   2310   2190
+    //   mat       856    855    890    864   3004   2724   2398
+    //   c128 by  5.1%   3.9%   4.7%   6.4%  23.1%  15.2%   8.7%
+    //
+    // So {49,128} and {257,384} join the c128 bands on either side, and 49..512 becomes one route
+    // instead of four.
+    //
+    // {513,640} is deliberately left on Materialized. It is the one band where the two are close,
+    // and the measurement cannot separate them: over four runs Materialized won 576 three times,
+    // but c128 at that width ranged 4147-4959 us (19.6% spread) and the margins outside the single
+    // outlying run were +-2%. Changing it would be fitting noise. Re-measure it if the noise floor
+    // on this Op ever improves.
+    {{49, 512}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
     {{513, 640}, Q4LinearSwiGluScheduleId::Materialized},
     {{641, kAnyCols}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
 }};
@@ -162,8 +180,14 @@ void q4_linear_swiglu_execute_plan(const Q4LinearSwiGluPlan& plan, const Tensor&
     if (resolved.schedule != plan.schedule || resolved.workspace_bytes != plan.workspace_bytes) {
         throw std::invalid_argument("q4 linear_swiglu: plan does not match the exact problem");
     }
+    q4_linear_swiglu_execute_schedule(plan.schedule, x, w, out, ws, stream);
+}
 
-    switch (plan.schedule) {
+void q4_linear_swiglu_execute_schedule(Q4LinearSwiGluScheduleId schedule, const Tensor& x,
+                                       const Weight& w, Tensor& out, WorkspaceArena& ws,
+                                       cudaStream_t stream) {
+    const Q4LinearSwiGluProblem problem{w.n, out.ne[0], x.ne[0], w.padded_shape[1], x.ne[1]};
+    switch (schedule) {
     case Q4LinearSwiGluScheduleId::GemvPair:
         q4_linear_swiglu_gemv_pair_launch(x, w, out, stream);
         return;

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.h
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.h
@@ -41,6 +41,15 @@ std::size_t q4_linear_swiglu_capacity_workspace_bytes(std::int32_t gate_up_rows,
                                                       std::int32_t padded_k, std::int32_t min_cols,
                                                       std::int32_t max_cols);
 
+// Workspace for Materialized alone, sized directly from the column count rather than from which
+// columns resolve_plan's route table currently sends there. Materialized's workspace grows
+// monotonically with cols, so sizing for the widest column count in a sweep covers every narrower
+// one too. Exists for callers -- benchmarks in particular -- that run Materialized outside its
+// routed interval; q4_linear_swiglu_capacity_workspace_bytes reports zero for those callers and is
+// the wrong function to size against.
+std::size_t q4_linear_swiglu_materialized_workspace_bytes(std::int32_t gate_up_rows,
+                                                          std::int32_t max_cols);
+
 void q4_linear_swiglu_execute_plan(const Q4LinearSwiGluPlan& plan, const Tensor& x, const Weight& w,
                                    Tensor& out, WorkspaceArena& ws, cudaStream_t stream);
 

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.h
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.h
@@ -43,6 +43,22 @@ std::size_t q4_linear_swiglu_capacity_workspace_bytes(std::int32_t gate_up_rows,
 
 void q4_linear_swiglu_execute_plan(const Q4LinearSwiGluPlan& plan, const Tensor& x, const Weight& w,
                                    Tensor& out, WorkspaceArena& ws, cudaStream_t stream);
+
+// Runs a schedule without first checking that it is the one resolve_plan would pick;
+// q4_linear_swiglu_execute_plan is exactly this plus that check.
+//
+// It exists so a bench can time every candidate schedule at the same column count, which is the
+// only way to tell whether a route boundary sits in the right place. Materialized in particular
+// cannot be timed any other way: it is not a kernel but a composite -- linear() into a workspace,
+// then silu_mul() over the two halves -- so a bench that called the pieces itself would be timing a
+// replica of the dispatch rather than the dispatch. Mirrors w8_pair_execute_schedule, which exists
+// for the same reason.
+//
+// Nothing on the inference path should call this: the check execute_plan adds is what keeps a plan
+// from being executed against a problem it was not resolved for.
+void q4_linear_swiglu_execute_schedule(Q4LinearSwiGluScheduleId schedule, const Tensor& x,
+                                       const Weight& w, Tensor& out, WorkspaceArena& ws,
+                                       cudaStream_t stream);
 void q4_linear_swiglu_dispatch(const Tensor& x, const Weight& w, Tensor& out, WorkspaceArena& ws,
                                cudaStream_t stream);
 


### PR DESCRIPTION
Closes the q4 SwiGLU `Materialized` item in TODO.md §4 — the last unmeasured boundaries in that table.

## The tell

Upstream alternates `Materialized` and the c128 tile **three times** across 49–640:

```
{49,128} Materialized  {129,256} c128  {257,384} Materialized
{385,512} c128         {513,640} Materialized  {641,∞} c128
```

That shape is implausible on its face — the winner does not genuinely flip back and forth over a
contiguous range — and it does not survive measurement.

## Measured

Cold, median of 9–15, repeated three to four times per width because this Op is noisier than the
others here. **Materialized lost at every width in `{49,128}` and `{257,384}`, in every run:**

| T | 49 | 64 | 96 | 128 | 257 | 320 | 384 |
|---|---|---|---|---|---|---|---|
| c128 | 812 | 823 | 848 | 809 | 2309 | 2310 | 2190 |
| Materialized | 856 | 855 | 890 | 864 | 3004 | 2724 | 2398 |
| **c128 faster by** | 5.1% | 3.9% | 4.7% | 6.4% | **23.1%** | **15.2%** | 8.7% |

Those two bands join the c128 routes either side, so **49–512 becomes one route instead of four**
and the table drops from **10 routes to 7**.

## Deliberately not changed

`{513,640}` stays on `Materialized`. It is the one band where the two are close and the measurement
**cannot separate them**: Materialized won T=576 in three of four runs, but c128 there ranged
**4147–4959 µs (19.6% spread)**, and outside the single outlying run the margins were ±2%. Changing
it would be fitting noise — the same call made above 384 on `w8_pair` k=2048.

## Why this had never been measured

`Materialized` is not a kernel but a composite — `linear()` into a workspace, then `silu_mul()` over
the two halves — so it has no launch signature to put in the bench's function-pointer table. The
bench said so explicitly and skipped it.

Added `q4_linear_swiglu_execute_schedule`, mirroring `w8_pair_execute_schedule`: the real dispatch
minus its plan-matches-problem check. Every schedule now goes through it, so the bench times the Op
rather than a replica, and `execute_plan` delegates to it rather than duplicating the switch.

## Coverage

The correctness test already pins 49, 128, 129, 256, 257, 384, 385, 512, 513, 640 and 641 as token
cases, so coverage over the changed range is unchanged. Route coverage is unchanged too —
`Materialized` is still routed at `{513,640}`, so nothing was stranded.

Full suite **124/124**.