### PR TITLE
chore: clear the repo-root clutter and close the housekeeping items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,8 @@ dist/*
 
 # Claude Code personal/local settings (may contain API tokens)
 .claude/settings.local.json
+
+# Captured request payloads kept for reproducing a specific investigation locally. Deliberately not
+# committed: they are whole real prompts, so they carry third-party system-prompt text and are
+# large (100 KB+ each) for something only the person who captured them can act on.
+repro/

--- a/TODO.md
+++ b/TODO.md
@@ -369,11 +369,17 @@ about it fails on a different one.
       redundant. That missing pair is exactly what made upstream's small-T reach for the bf16
       helper and silently reinterpret every value, so collapsing them removes the trap rather than
       just tidying.
-- [ ] **Clean up the extra worktrees**: `C:/ninfer-fork/baseline-master` (created to get a
-      pre-merge baseline; its purpose is served) and `C:/ninfer-fork/wt-readme`.
-- [ ] **Untracked clutter in the repo root**: `config.bat`, `config_exit.txt`, `repro/`,
-      `scripts/download-ornith-1.5-35b-a3b.bat`. Decide keep-and-commit or delete.
-      `build_merge.bat` *is* committed and carries the toolchain pinning this host needs.
+- [x] ~~Clean up the extra worktrees.~~ **Done.** `baseline-master` was already gone; `wt-readme`
+      removed after checking clean status and confirming `feat/dual-gpu-graph-mode` is fully merged
+      into master with nothing unpushed. The branch is kept, so the history survives.
+- [x] ~~Untracked clutter in the repo root.~~ **Decided, per file:** `config.bat`/`config_exit.txt`
+      deleted (a failed VS 2026/MSVC 14.50 configure attempt, superseded by `scripts/build.ps1`
+      documenting exactly why CUDA 12.8 rejects that compiler); `scripts/download-ornith-1.5-35b-a3b.bat`
+      deleted (byte-identical to the tracked `download-qwen36-35b-a3b.bat` but named for a model it
+      does not download, and never shipped); `repro/` gitignored rather than deleted (two captured
+      Responses-API payloads carrying third-party prompt text, not this repo's data to bin).
+      `build_merge.bat` *is* committed and carries the toolchain pinning this host needs. PR #12
+      closed as the record of the abandoned dual-GPU overlap experiment.
 
 ---
 


### PR DESCRIPTION
Closes the housekeeping items in TODO.md §1 and §7 — decided rather than deferred.

## In the tree

| file | decision | why |
|---|---|---|
| `config.bat`, `config_exit.txt` | **deleted** | A VS 2026 configure attempt (`Studio\18`, MSVC 14.50) with `-allow-unsupported-compiler`, plus its output recording `exit=1`. It failed, and `scripts/build.ps1` now documents exactly why: CUDA 12.8's `host_config.h` accepts `_MSC_VER` 1910–1949 and rejects 14.50 outright. A failed experiment superseded by a working script. |
| `scripts/download-ornith-1.5-35b-a3b.bat` | **deleted** | **Byte-identical** to the tracked `download-qwen36-35b-a3b.bat`, but named for a model it does not download — it fetches `qwen3_6_35b_a3b.ninfer`. It never shipped (the packager globs `download-qwen*`), but it would mislead anyone reading `scripts/`. |
| `repro/` | **gitignored, not deleted** | Two captured Responses-API payloads (12,536 and 28,691 tokens) from the shared-prefix investigation. They are **whole real prompts**, so they carry third-party system-prompt text, and at 100 KB+ each they are only actionable by whoever captured them. Ignoring gets a clean `git status` without binning data that is not mine to bin. |

## Outside the tree

- **`wt-readme` worktree removed.** Checked first: clean status, branch `feat/dual-gpu-graph-mode`
  fully merged into master, nothing unpushed. The branch is kept, so the history survives.
- **PR #12 closed.** A complete implementation that does not achieve its goal, with its overlap
  default deliberately left *on* so the measurement table reproduces — which made an open
  `DO NOT MERGE` draft a standing hazard rather than a useful reminder. Closing costs nothing on
  GitHub: body, diff, commits and branch all remain, and it reopens in one click. The conclusion is
  also recorded in TODO.md independently of GitHub.

The deleted files are backed up outside the repo for this session in case any turns out to be wanted.

`git status` is now clean apart from the ignored `repro/`.