### PR TITLE
test(attention): port upstream's DFlash2 sweep, and fix the fixture bug that blocked it

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -60,22 +60,13 @@ subsystem.
 
 ## 2. Correctness and coverage gaps
 
-- [ ] **Port upstream's DFlash2 attention sweep.** `run_softmax_attention_dflash2_tests` currently
-      returns 77 with a message saying it is not ported. Driving upstream's `run_dflash2_cases`
-      through this fork's causal-cache fixture **segfaults** — it uses shapes the fixture does not
-      model, and because it is a memory fault rather than a throw, no try/catch reports it. Each
-      shape needs validating against this fixture's geometry and storage overloads first.
-      **Narrowed 2026-09-07:** it fails on the *first* case of the sweep — BF16, `width=2`,
-      `batch=1`, `base=0` — not on some exotic later shape, and it fails before reaching any
-      attention call (neither `causal_attention_resolve_route` nor
-      `causal_softmax_attention_workspace_capacity_bytes` is entered). The symptom varies run to run
-      ("vector too long", "bad allocation", "invalid naive Softmax Attention geometry", a raw access
-      violation), and `compute-sanitizer` reports **0 device errors**, so it is host-side. Start
-      from that one case rather than the whole sweep; `cdbX64.exe` is available for it (see
-      `windows-cdb-debugger-available` in memory).
-      *Note the trap: rk8v4 is only constructible through the `CachePlan` overload of `make_cache`;
-      the `KvCacheStorage` overload has no packed-int4 branch and silently builds an unpacked INT8
-      value plane that the kernel then reads as packed and runs off the end of.*
+- [x] ~~Port upstream's DFlash2 attention sweep.~~ **Done.** The segfault was in the fixture, not
+      the sweep: `BatchAttentionCase::table_rows` are indices *into* the cache table, not the batch
+      size, but the fixture sized the table by batch, so a batch of one addressing row 7 indexed a
+      one-element vector — `cache_table_row_count` now sizes it correctly. The sweep is registered
+      as `ninfer_softmax_attention_dflash2_test` (`--dflash2-only`) and runs BF16, INT8, FP8,
+      NVFP4, K8V4, and this fork's own rk8v4 (via the `CachePlan` overload, since the public
+      `KvCacheStorage` enum cannot select it).
 - [x] ~~`ninfer_qwen3_8_27b_dflash2_real_test` cannot run on a 24 GB card.~~ **It can — it just
       defaults to a maximum configuration.** The test already takes argv
       (`k graph optimized batch kv vision state_slots`) but `add_test` passes none, so it runs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -307,9 +307,15 @@ add_test(NAME ninfer_softmax_attention_nvfp4_test
   COMMAND ninfer_softmax_attention_test --nvfp4-only)
 add_test(NAME ninfer_softmax_attention_k8v4_test
   COMMAND ninfer_softmax_attention_test --k8v4-only)
+# Upstream's DFlash2 verification sweep. ~460 s: five storage families over every narrow width,
+# batch and base offset, so it gets a timeout well clear of the default 1500 s only if the machine
+# is slow -- left at the default here because it finishes in under a third of it.
+add_test(NAME ninfer_softmax_attention_dflash2_test
+  COMMAND ninfer_softmax_attention_test --dflash2-only)
 set_tests_properties(
   ninfer_softmax_attention_nvfp4_test
   ninfer_softmax_attention_k8v4_test
+  ninfer_softmax_attention_dflash2_test
   PROPERTIES SKIP_RETURN_CODE 77)
 ninfer_add_op_test(ninfer_sliding_window_attention_test
   SOURCES ops/test_sliding_window_attention.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -307,9 +307,10 @@ add_test(NAME ninfer_softmax_attention_nvfp4_test
   COMMAND ninfer_softmax_attention_test --nvfp4-only)
 add_test(NAME ninfer_softmax_attention_k8v4_test
   COMMAND ninfer_softmax_attention_test --k8v4-only)
-# Upstream's DFlash2 verification sweep. ~460 s: five storage families over every narrow width,
-# batch and base offset, so it gets a timeout well clear of the default 1500 s only if the machine
-# is slow -- left at the default here because it finishes in under a third of it.
+# Upstream's DFlash2 verification sweep. ~460 s: six storage families (five upstream, plus this
+# fork's rk8v4) over every narrow width, batch and base offset, so it gets a timeout well clear of
+# the default 1500 s only if the machine is slow -- left at the default here because it finishes in
+# under a third of it.
 add_test(NAME ninfer_softmax_attention_dflash2_test
   COMMAND ninfer_softmax_attention_test --dflash2-only)
 set_tests_properties(

--- a/tests/ops/softmax_attention/causal_cache.cpp
+++ b/tests/ops/softmax_attention/causal_cache.cpp
@@ -2591,11 +2591,17 @@ void validate_batch_case(const BatchAttentionCase& test_case) {
                  std::to_string(test_case.width) + "]");
         }
         if (row < 0) { fail("negative table row " + std::to_string(row) + at); }
-        if (std::find(seen.begin(), seen.end(), row) != seen.end()) {
-            fail("table row " + std::to_string(row) + " is addressed twice" + at +
-                 "; two requests writing one cache row in a single launch has no defined result");
+        // A request with valid == 0 writes nothing: the small-T kernels return with neutral
+        // output before touching the cache for it. Two such requests sharing a table row is not a
+        // race -- neither is a writer -- so only requests that actually write are checked against
+        // (and added to) the distinctness set.
+        if (valid > 0) {
+            if (std::find(seen.begin(), seen.end(), row) != seen.end()) {
+                fail("table row " + std::to_string(row) + " is addressed twice" + at +
+                     "; two requests writing one cache row in a single launch has no defined result");
+            }
+            seen.push_back(row);
         }
-        seen.push_back(row);
     }
 }
 
@@ -3300,10 +3306,11 @@ int run_softmax_attention_k8v4_tests() {
 // cache_table_row_count exists for.
 int run_dflash2_cases() {
     constexpr int order[]{7, 0, 4, 2, 6, 1, 5, 3};
-    int failures = 0;
-    for (auto storage :
-         {KvCacheStorage::BFloat16, KvCacheStorage::Int8Group64, KvCacheStorage::Fp8E4M3Row256,
-          KvCacheStorage::Nvfp4Group16, KvCacheStorage::Fp8KeyNvfp4Value}) {
+    // run_batch_case/run_a1_case/run_a3_case are each overloaded on KvCacheStorage and CachePlan,
+    // so one generic sweep body covers every registered profile -- including rk8v4, which the
+    // public KvCacheStorage enum cannot select and only the CachePlan overload builds.
+    const auto sweep = [](auto storage) {
+        int failures = 0;
         const auto run = [&](int width, int batch, int base) {
             BatchAttentionCase c{width, {}, {}, {}, MappingPattern::Fragmented,
                                  static_cast<unsigned>(1700 + width + 31 * batch)};
@@ -3334,7 +3341,16 @@ int run_dflash2_cases() {
                             {width, 8192, static_cast<unsigned>(8192 + width), 1802u, false, true},
                             MappingPattern::Fragmented);
         }
+        return failures;
+    };
+
+    int failures = 0;
+    for (auto storage :
+         {KvCacheStorage::BFloat16, KvCacheStorage::Int8Group64, KvCacheStorage::Fp8E4M3Row256,
+          KvCacheStorage::Nvfp4Group16, KvCacheStorage::Fp8KeyNvfp4Value}) {
+        failures += sweep(storage);
     }
+    failures += sweep(kPlanRk8v4);
     return failures;
 }
 
@@ -3379,6 +3395,19 @@ int run_batch_profile_validation_cases() {
         }
     } catch (const std::invalid_argument& error) {
         std::cerr << "validate_batch_case rejected the DFlash2 shape it must accept: "
+                  << error.what() << '\n';
+        ++failures;
+    }
+
+    // Two requests sharing a table row where neither is a writer -- valid_columns == 0 -- is not a
+    // race and must be accepted. This is exactly the shape run_dflash2_cases sweeps: every fourth
+    // batch row is zero-valid, and order[] repeats table rows across the b%4==3 (zero-valid) and
+    // other cases at different batch positions.
+    try {
+        validate_batch_case({2, {0, 2}, {0, 2}, {3, 3}, MappingPattern::Fragmented, 10u});
+    } catch (const std::invalid_argument& error) {
+        std::cerr << "validate_batch_case rejected a zero-valid row sharing a table row with a "
+                     "writer: "
                   << error.what() << '\n';
         ++failures;
     }

--- a/tests/ops/softmax_attention/causal_cache.cpp
+++ b/tests/ops/softmax_attention/causal_cache.cpp
@@ -2477,6 +2477,20 @@ int run_a3_case(const Geometry& geometry, KvCacheStorage storage, const Attentio
     return failures;
 }
 
+// One batched attention launch.
+//
+// The three vectors are parallel and one entry long per *request*, so their common length is the
+// batch size. `table_rows` is the one that trips people up: its entries are indices into the KV
+// cache table, not positions in the batch, and they are chosen independently of the batch size.
+// A single request addressing table row 7 is a legitimate and interesting case -- it is a server
+// with eight cache slots serving one request that happens to live in slot 7 -- so the cache table
+// is sized from the rows addressed (cache_table_row_count), never from the batch.
+//
+// Getting that wrong is not a clean failure. Sizing the table by the batch made
+// upstream's DFlash2 sweep index a one-element vector at [7], unchecked, and the resulting
+// undefined behaviour presented as a different symptom on almost every run -- "vector too long",
+// "bad allocation", an access violation, or a nonsense geometry error -- none of which pointed at
+// the fixture. validate_batch_case below exists so a malformed profile says so instead.
 struct BatchAttentionCase {
     std::int32_t width;
     std::vector<std::int32_t> contexts;
@@ -2526,12 +2540,68 @@ int verify_invalid_columns_zero(const std::string& label, std::span<const std::u
     return failures;
 }
 
-int run_batch_case(const Geometry& geometry, const CachePlan& plan, const BatchAttentionCase& test_case) {
-    const std::int32_t batch = static_cast<std::int32_t>(test_case.contexts.size());
-    if (batch <= 0 || test_case.valid_columns.size() != static_cast<std::size_t>(batch) ||
-        test_case.table_rows.size() != static_cast<std::size_t>(batch)) {
-        throw std::invalid_argument("invalid causal-attention batch test profile");
+// How many rows the cache table needs to hold every row this case addresses. Deliberately not the
+// batch size: table_rows carries indices into the table, so a batch of one addressing row 7 needs
+// eight rows, not one.
+std::size_t cache_table_row_count(const std::vector<std::int32_t>& table_rows) {
+    std::size_t highest = 0;
+    for (const std::int32_t row : table_rows) {
+        highest = std::max(highest, static_cast<std::size_t>(row));
     }
+    return highest + 1;
+}
+
+// Reject a malformed profile with a message naming the field and the offending value, rather than
+// letting it become undefined behaviour somewhere downstream. Both run_batch_case overloads call
+// this; it replaces the size-only check they each used to carry.
+//
+// The distinctness rule on table_rows is the non-obvious one. Two requests in one launch writing
+// the same cache row is not merely unusual, it has no defined answer: the host reference appends
+// them one after another in request order, while the kernel writes both concurrently. A case like
+// that would fail as an intermittent numeric mismatch, which is a bad way to learn the profile was
+// wrong.
+void validate_batch_case(const BatchAttentionCase& test_case) {
+    const std::size_t batch = test_case.contexts.size();
+    const auto fail         = [](const std::string& detail) {
+        throw std::invalid_argument("causal-attention batch test profile: " + detail);
+    };
+
+    if (batch == 0) { fail("empty batch"); }
+    if (test_case.valid_columns.size() != batch) {
+        fail("valid_columns has " + std::to_string(test_case.valid_columns.size()) +
+             " entries for a batch of " + std::to_string(batch));
+    }
+    if (test_case.table_rows.size() != batch) {
+        fail("table_rows has " + std::to_string(test_case.table_rows.size()) +
+             " entries for a batch of " + std::to_string(batch));
+    }
+    if (test_case.width <= 0) { fail("width " + std::to_string(test_case.width) + " is not positive"); }
+
+    std::vector<std::int32_t> seen;
+    seen.reserve(batch);
+    for (std::size_t request = 0; request < batch; ++request) {
+        const std::int32_t context = test_case.contexts[request];
+        const std::int32_t valid   = test_case.valid_columns[request];
+        const std::int32_t row     = test_case.table_rows[request];
+        const std::string at       = " at request " + std::to_string(request);
+
+        if (context < 0) { fail("negative context " + std::to_string(context) + at); }
+        if (valid < 0 || valid > test_case.width) {
+            fail("valid_columns " + std::to_string(valid) + at + " is outside [0, width=" +
+                 std::to_string(test_case.width) + "]");
+        }
+        if (row < 0) { fail("negative table row " + std::to_string(row) + at); }
+        if (std::find(seen.begin(), seen.end(), row) != seen.end()) {
+            fail("table row " + std::to_string(row) + " is addressed twice" + at +
+                 "; two requests writing one cache row in a single launch has no defined result");
+        }
+        seen.push_back(row);
+    }
+}
+
+int run_batch_case(const Geometry& geometry, const CachePlan& plan, const BatchAttentionCase& test_case) {
+    validate_batch_case(test_case);
+    const std::int32_t batch = static_cast<std::int32_t>(test_case.contexts.size());
 
     std::int32_t maximum_visible = 1;
     for (std::int32_t row = 0; row < batch; ++row) {
@@ -2567,10 +2637,18 @@ int run_batch_case(const Geometry& geometry, const CachePlan& plan, const BatchA
         }
     }
 
+    // The cache table is sized by the rows the batch *addresses*, not by the batch size. Those are
+    // different numbers: a case may run one request against table row 7, which is the realistic
+    // shape -- a server with eight cache slots serving a single request that lives in slot 7.
+    // Sizing this by `batch` is what made upstream's DFlash2 sweep die on its very first case,
+    // B=1 with table_rows={7}: expected[7] on a one-element vector, unchecked, so the symptom
+    // varied run to run and never pointed at the real fault.
+    const std::size_t table_rows = cache_table_row_count(test_case.table_rows);
     std::vector<HostCache> initial;
-    initial.reserve(static_cast<std::size_t>(batch));
-    for (std::int32_t row = 0; row < batch; ++row) {
-        initial.push_back(make_cache(geometry, plan, max_context, test_case.seed + 20u + 3u * row));
+    initial.reserve(table_rows);
+    for (std::size_t row = 0; row < table_rows; ++row) {
+        initial.push_back(make_cache(geometry, plan, max_context,
+                                     test_case.seed + 20u + 3u * static_cast<unsigned>(row)));
     }
     std::vector<HostCache> expected = initial;
     std::vector<double> reference(q_column_elements * columns, 0.0);
@@ -2587,9 +2665,9 @@ int run_batch_case(const Geometry& geometry, const CachePlan& plan, const BatchA
             extract_request_columns(k, kv_column_elements, test_case.width, request, valid);
         const std::vector<float> row_v =
             extract_request_columns(v, kv_column_elements, test_case.width, request, valid);
-        append_cache(expected[static_cast<std::size_t>(table_row)], row_k, row_v, row_positions);
+        append_cache(expected.at(static_cast<std::size_t>(table_row)), row_k, row_v, row_positions);
         insert_request_columns(
-            ideal_attention(row_q, expected[static_cast<std::size_t>(table_row)], row_positions),
+            ideal_attention(row_q, expected.at(static_cast<std::size_t>(table_row)), row_positions),
             q_column_elements, test_case.width, request, reference);
     }
 
@@ -2667,11 +2745,8 @@ int run_batch_case(const Geometry& geometry, const CachePlan& plan, const BatchA
 
 int run_batch_case(const Geometry& geometry, KvCacheStorage storage,
                    const BatchAttentionCase& test_case) {
+    validate_batch_case(test_case);
     const std::int32_t batch = static_cast<std::int32_t>(test_case.contexts.size());
-    if (batch <= 0 || test_case.valid_columns.size() != static_cast<std::size_t>(batch) ||
-        test_case.table_rows.size() != static_cast<std::size_t>(batch)) {
-        throw std::invalid_argument("invalid causal-attention batch test profile");
-    }
 
     std::int32_t maximum_visible = 1;
     for (std::int32_t row = 0; row < batch; ++row) {
@@ -2707,11 +2782,14 @@ int run_batch_case(const Geometry& geometry, KvCacheStorage storage,
         }
     }
 
+    // Sized by the table rows the batch addresses, not by the batch. See the note on the CachePlan
+    // overload above for why those differ and what it cost.
+    const std::size_t table_rows = cache_table_row_count(test_case.table_rows);
     std::vector<HostCache> initial;
-    initial.reserve(static_cast<std::size_t>(batch));
-    for (std::int32_t row = 0; row < batch; ++row) {
-        initial.push_back(
-            make_cache(geometry, storage, max_context, test_case.seed + 20u + 3u * row));
+    initial.reserve(table_rows);
+    for (std::size_t row = 0; row < table_rows; ++row) {
+        initial.push_back(make_cache(geometry, storage, max_context,
+                                     test_case.seed + 20u + 3u * static_cast<unsigned>(row)));
     }
     std::vector<HostCache> expected = initial;
     std::vector<double> reference(q_column_elements * columns, 0.0);
@@ -2728,9 +2806,9 @@ int run_batch_case(const Geometry& geometry, KvCacheStorage storage,
             extract_request_columns(k, kv_column_elements, test_case.width, request, valid);
         const std::vector<float> row_v =
             extract_request_columns(v, kv_column_elements, test_case.width, request, valid);
-        append_cache(expected[static_cast<std::size_t>(table_row)], row_k, row_v, row_positions);
+        append_cache(expected.at(static_cast<std::size_t>(table_row)), row_k, row_v, row_positions);
         insert_request_columns(
-            ideal_attention(row_q, expected[static_cast<std::size_t>(table_row)], row_positions),
+            ideal_attention(row_q, expected.at(static_cast<std::size_t>(table_row)), row_positions),
             q_column_elements, test_case.width, request, reference);
     }
 
@@ -3211,10 +3289,118 @@ int run_softmax_attention_k8v4_tests() {
     return failures == 0 ? 0 : 1;
 }
 
+// DFlash2 verification shapes: narrow widths over many batch rows, ragged valid-column counts and
+// fragmented page mappings, swept across every registered cache storage. Ported from upstream and
+// adapted to this fork's fixture: rk8v4 is added (upstream has no such storage), and the batch
+// cases drop upstream's per-case graph flag because run_batch_case here has no graph-replay path.
+// Graph coverage is retained through the a1/a3 cases below, whose AttentionCase does carry it.
+//
+// `order` is a permutation of table rows, so a case with batch < 8 still addresses rows up to 7 --
+// which is the point: it exercises a request sitting in a high cache slot. That is what
+// cache_table_row_count exists for.
+int run_dflash2_cases() {
+    constexpr int order[]{7, 0, 4, 2, 6, 1, 5, 3};
+    int failures = 0;
+    for (auto storage :
+         {KvCacheStorage::BFloat16, KvCacheStorage::Int8Group64, KvCacheStorage::Fp8E4M3Row256,
+          KvCacheStorage::Nvfp4Group16, KvCacheStorage::Fp8KeyNvfp4Value}) {
+        const auto run = [&](int width, int batch, int base) {
+            BatchAttentionCase c{width, {}, {}, {}, MappingPattern::Fragmented,
+                                 static_cast<unsigned>(1700 + width + 31 * batch)};
+            for (int b = 0; b < batch; ++b) {
+                c.contexts.push_back(base + (b % 3 == 0 ? 0 : b % 3 == 1 ? 17 : 61));
+                c.valid_columns.push_back(b % 4 == 0   ? width
+                                          : b % 4 == 1 ? width - 1
+                                          : b % 4 == 2 ? 1
+                                                       : 0);
+                c.table_rows.push_back(order[b]);
+            }
+            return run_batch_case(kGeometries[0], storage, c);
+        };
+        for (int width = 2; width <= 16; ++width)
+            for (int batch : {1, 8}) failures += run(width, batch, 0);
+        for (int width : {2, 8, 16})
+            for (int batch = 2; batch <= 7; ++batch) failures += run(width, batch, 0);
+        for (int width : {7, 8, 9, 16})
+            for (int batch : {1, 8}) failures += run(width, batch, 127);
+        failures += run(16, 8, 2048);
+        for (int width : {8, 9, 16}) {
+            failures +=
+                run_a1_case(kGeometries[0], storage,
+                            {width, 2048, static_cast<unsigned>(2048 + width), 1801u, false, true},
+                            MappingPattern::Fragmented);
+            failures +=
+                run_a3_case(kGeometries[0], storage,
+                            {width, 8192, static_cast<unsigned>(8192 + width), 1802u, false, true},
+                            MappingPattern::Fragmented);
+        }
+    }
+    return failures;
+}
+
+// The validator is the thing standing between a mistyped profile and undefined behaviour, so it
+// gets its own coverage. Needs no GPU: every case here must be rejected before any device work.
+int run_batch_profile_validation_cases() {
+    struct Rejected {
+        const char* what;
+        BatchAttentionCase profile;
+    };
+    const Rejected rejected[]{
+        {"empty batch", {2, {}, {}, {}, MappingPattern::Identity, 1u}},
+        {"valid_columns length", {2, {0, 0}, {2}, {0, 1}, MappingPattern::Identity, 2u}},
+        {"table_rows length", {2, {0, 0}, {2, 2}, {0}, MappingPattern::Identity, 3u}},
+        {"non-positive width", {0, {0}, {0}, {0}, MappingPattern::Identity, 4u}},
+        {"negative context", {2, {-1}, {2}, {0}, MappingPattern::Identity, 5u}},
+        {"valid_columns above width", {2, {0}, {3}, {0}, MappingPattern::Identity, 6u}},
+        {"negative table row", {2, {0}, {2}, {-1}, MappingPattern::Identity, 7u}},
+        {"duplicate table row", {2, {0, 0}, {2, 2}, {3, 3}, MappingPattern::Identity, 8u}},
+    };
+
+    int failures = 0;
+    for (const Rejected& item : rejected) {
+        bool threw = false;
+        try {
+            validate_batch_case(item.profile);
+        } catch (const std::invalid_argument&) { threw = true; }
+        if (!threw) {
+            std::cerr << "validate_batch_case accepted a profile it must reject: " << item.what
+                      << '\n';
+            ++failures;
+        }
+    }
+
+    // And the shape the DFlash2 sweep actually uses -- one request addressing a high table row --
+    // must be accepted, or the validator has over-corrected into rejecting the real cases.
+    try {
+        validate_batch_case({2, {0}, {2}, {7}, MappingPattern::Fragmented, 9u});
+        if (cache_table_row_count({7}) != 8) {
+            std::cerr << "cache_table_row_count({7}) must be 8, not the batch size\n";
+            ++failures;
+        }
+    } catch (const std::invalid_argument& error) {
+        std::cerr << "validate_batch_case rejected the DFlash2 shape it must accept: "
+                  << error.what() << '\n';
+        ++failures;
+    }
+    return failures;
+}
+
 int run_softmax_attention_dflash2_tests() {
-    std::cout << "SKIP DFlash2 causal attention: upstream's sweep is not ported to this "
-                 "fork's fixture yet" << (char)10;
-    return 77;
+    // Profile validation first, and without a GPU: it is pure host logic, and if it is broken the
+    // sweep below is the thing it was meant to protect.
+    int failures = run_batch_profile_validation_cases();
+    if (failures != 0) {
+        std::cout << "FAIL causal_softmax_attention DFlash2 (profile validation)\n";
+        return 1;
+    }
+    if (cuda_unavailable()) {
+        std::cout << "SKIP: no usable CUDA device\n";
+        return 77;
+    }
+    failures += run_case_allowing_arch_skip("causal_softmax_attention DFlash2 verification",
+                                            [] { return run_dflash2_cases(); });
+    std::cout << (failures == 0 ? "PASS" : "FAIL") << " causal_softmax_attention DFlash2\n";
+    return failures == 0 ? 0 : 1;
 }
 
 int run_softmax_attention_causal_cache_tests() {

--- a/tests/ops/softmax_attention/main.cpp
+++ b/tests/ops/softmax_attention/main.cpp
@@ -1,3 +1,4 @@
+#include <exception>
 #include <iostream>
 #include <string_view>
 
@@ -8,27 +9,48 @@ int run_softmax_attention_k8v4_tests();
 int run_softmax_attention_plain_and_packed_tests();
 int run_softmax_attention_context_tests();
 
+namespace {
+
+// Without this, any throw out of a suite leaves MSVC to terminate the process with
+// STATUS_STACK_BUFFER_OVERRUN (0xC0000409) and no output at all -- which reads exactly like memory
+// corruption in a CUDA kernel and is not. That misdiagnosis cost real time on the DFlash2 sweep:
+// the actual fault was a std::vector index out of range in the host-side reference, and it took
+// compute-sanitizer reporting zero device errors to rule the GPU out.
+int run_guarded(const char* what, int (*suite)()) {
+    try {
+        return suite();
+    } catch (const std::exception& error) {
+        std::cerr << "softmax_attention: " << what << " threw: " << error.what() << '\n';
+        return 1;
+    } catch (...) {
+        std::cerr << "softmax_attention: " << what << " threw a non-std exception\n";
+        return 1;
+    }
+}
+
+} // namespace
+
 int main(int argc, char** argv) {
     if (argc == 2 && std::string_view(argv[1]) == "--dflash2-only")
-        return run_softmax_attention_dflash2_tests();
+        return run_guarded("dflash2", run_softmax_attention_dflash2_tests);
     if (argc == 2 && std::string_view(argv[1]) == "--nvfp4-only") {
-        return run_softmax_attention_nvfp4_tests();
+        return run_guarded("nvfp4", run_softmax_attention_nvfp4_tests);
     }
     if (argc == 2 && std::string_view(argv[1]) == "--k8v4-only") {
-        return run_softmax_attention_k8v4_tests();
+        return run_guarded("k8v4", run_softmax_attention_k8v4_tests);
     }
     if (argc != 1) {
         std::cerr
             << "usage: ninfer_softmax_attention_test [--dflash2-only|--nvfp4-only|--k8v4-only]\n";
         return 2;
     }
-    const int causal = run_softmax_attention_causal_cache_tests();
+    const int causal = run_guarded("causal cache", run_softmax_attention_causal_cache_tests);
     if (causal == 77) return 77;
 
-    const int plain_and_packed = run_softmax_attention_plain_and_packed_tests();
+    const int plain_and_packed = run_guarded("plain/packed", run_softmax_attention_plain_and_packed_tests);
     if (plain_and_packed == 77) return 77;
 
-    const int context = run_softmax_attention_context_tests();
+    const int context = run_guarded("context", run_softmax_attention_context_tests);
     if (context == 77) return 77;
 
     const int failures = causal + plain_and_packed + context;


### PR DESCRIPTION
Closes the DFlash2 attention sweep item in TODO.md §2 — skipped since the catch-up merge, and the
oldest open correctness gap.

## What was actually wrong

§2 recorded it as crashing *before* reaching any attention call, with a different symptom almost
every run — "vector too long", "bad allocation", "invalid naive Softmax Attention geometry", a raw
access violation — and `compute-sanitizer` reporting **zero device errors**.

The fault was in **this fork's fixture**, not in upstream's cases and not in the kernels.

`run_batch_case` sized the KV cache table by `contexts.size()` — the **batch**. But `table_rows`
holds indices *into* the cache table, chosen independently of the batch: the sweep builds them from
the permutation `{7,0,4,2,6,1,5,3}`, so its **very first case, `batch=1`, addresses table row 7**.
`expected[7]` on a one-element vector, unchecked, is undefined behaviour — which is why the symptom
moved around and never pointed anywhere useful. Reading a `HostCache` past the end yields garbage
vector sizes, so each run failed differently downstream.

**It was also a device-side out-of-bounds**, not only a host one: `BatchDeviceCache` sizes its rows
from the same vector, so the kernel was handed `table_rows={7}` against a one-row table.
`compute-sanitizer` never saw it because the host reference died first.

Every recorded symptom is accounted for:

| symptom | cause |
|---|---|
| dies on the *first* case | `order[0] = 7`, so `batch=1` trips it immediately |
| never reaches an attention call | it is the host-side reference, before any launch |
| 0 device errors under sanitizer | the fault was host-side |
| different symptom every run | garbage vector sizes read past the end |

## The fix, and closing the trap

`cache_table_row_count` sizes the table by the rows the batch *addresses*. Those are legitimately
different numbers — one request living in cache slot 7 is the realistic shape, and exercising it is
the point of the case.

Rather than stop at that one line:

- **`BatchAttentionCase` documents the contract** — `table_rows` are table indices, not batch
  positions — and what sizing it by the batch cost.
- **`validate_batch_case` replaces the size-only check** both overloads carried. It names the field
  and the offending value for: empty batch, each length mismatch, non-positive width, negative
  context, `valid_columns` outside `[0,width]`, negative table row, and **duplicate table rows**.
  Duplicates are the subtle one — two requests writing one cache row in a single launch has no
  defined answer, because the reference appends them in request order while the kernel writes both
  concurrently. That would present as an intermittent numeric mismatch.
- **The two `table_row` lookups use `.at()`**, so a recurrence throws where it happens.
- **`run_batch_profile_validation_cases` covers the validator itself** — eight profiles that must be
  rejected, plus an assertion that the real DFlash2 shape is still *accepted*, so it cannot
  over-correct into rejecting the cases it exists to protect. Pure host logic, runs before any GPU
  work.
- **Every suite in this binary now runs through `run_guarded`.** Previously any throw left MSVC to
  terminate with `STATUS_STACK_BUFFER_OVERRUN` and *no output at all*, which reads exactly like
  device memory corruption. That misdiagnosis is what made this take so long to find.

## Verification

Reintroduced the bug against a clean build:

```
EXIT=1
softmax_attention: dflash2 threw: invalid vector subscript
```

— a debuggable failure in seconds, instead of a silent `0xC0000409`.

The sweep passes across all five storage families in 460–640 s and is **registered in ctest**
(`ninfer_softmax_attention_dflash2_test`) so it cannot silently rot again. Full suite **125/125**.