### PR TITLE
docs: add a measured fit calculator for KV format, context and speculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ but only 2375691264 bytes are available for runtime capacity
 `--kv-capacity` is the shared pool and `--max-context` is the per-request cap, so a second lane
 does not cost twice the memory unless you also want twice the per-request context.
 
+**To size a profile that is not in this table, open
+[`docs/config-calculator.html`](docs/config-calculator.html) in a browser.** It is a single
+self-contained file in this repository — no network access needed — that takes a model, a KV
+format and a context length and tells you whether it fits in 24 GiB, what the largest context you
+could run instead would be, and what the choice costs in decode speed and perplexity. Every
+constant in it is measured on an RTX 3090 against this fork.
+
 If startup refuses, drop a context rung first — 262144 / 196608 / 131072 / 114688 / 98304 / 81920.
 Speculation is the next lever, worth 992 MiB (MTP head 856 MiB, draft head 136 MiB, roughly 130,000
 rk8v4 tokens) at the cost of dropping decode to ~183 tok/s. Drop `--vision` last: in overlay
@@ -290,15 +297,46 @@ output. Upstream's `kv_cache_append` contract stores values from the represented
 directly, and measurement showed that is sufficient, so this port keeps it: there is no
 inverse-rotation kernel and no extra pass over the output.
 
-| KV profile | Automatic-sizing context | KV bytes at 2,048 tokens | Perplexity |
-|---|---:|---:|---:|
-| `bf16` | — | 128.00 MiB | 4.343225 |
-| `int8` | 171,648 tokens | 66.00 MiB | 4.343263 |
-| `rk8v4` | **226,560 tokens** | **51.00 MiB** | 4.346811 |
+### Choosing a KV format
+
+All six SM86 KV formats, measured on Qwen3.8-27B. Size and perplexity are what most people weigh;
+the decode column is the one that surprises, because the smallest formats are not the fastest.
+
+| KV profile | Bytes/token | KV at 2,048 tokens | Perplexity | vs `bf16` | Decode at 32K depth |
+|---|---:|---:|---:|---:|---:|
+| `bf16` | 65,536 | 128.00 MiB | 4.343225 | — | 32.50 tok/s |
+| `int8` | 33,792 | 66.00 MiB | 4.343263 | +0.0009% | **33.86 tok/s** |
+| `fp8` | 33,024 | 64.50 MiB | 4.347181 | +0.0911% | 30.13 tok/s |
+| `rk8v4` | 26,112 | 51.00 MiB | 4.346811 | +0.0826% | 33.54 tok/s |
+| `k8v4` | 25,728 | 50.25 MiB | 4.347596 | +0.1006% | 28.61 tok/s |
+| `nvfp4` | **18,432** | **36.00 MiB** | 4.358924 | +0.3615% | 29.62 tok/s |
 
 Perplexity is `ninfer-perplexity` on the fixed `ninfer-ppl-1m-v1` corpus, `--quick`, context/stride
-4096/2048, 261,167 scored tokens. **32% more context costs 0.082% perplexity.** INT8 spends
-5.40 GiB of KV on its 171,648 tokens; rk8v4 spends 5.51 GiB on 226,560.
+4096/2048, 261,167 scored tokens — the same corpus and window for every row. Decode is 128 timed
+steps on top of a 32,768-token prefill, no speculation; attention re-reads the whole cache each
+step, so a format's cost only shows at depth.
+
+Three of these six are worth using:
+
+- **`int8`** is the default for good reason. Its perplexity cost is +0.0009%, which is nothing, and
+  it has the second-flattest decode curve.
+- **`rk8v4`** is the best all-round choice: 23% smaller than INT8 for +0.08% perplexity, and the
+  flattest decode curve measured (−6.2% from 4K to 32K, against INT8's −6.3%).
+- **`nvfp4`** buys the most context by a wide margin — 45% smaller than INT8. On the 35B with MTP3
+  and the draft head, on a machine running a desktop, it is the only format that still reaches the
+  full 262,144 native context: `rk8v4` gets to about 231,000 and INT8 to about 179,000 there.
+  Headless, `rk8v4` clears 262,144 as well. It costs about 13% of decode speed at 32K and +0.36%
+  perplexity.
+
+`fp8` and `k8v4` have no niche. `fp8` is larger, slower at depth *and* worse quality than `rk8v4`;
+`k8v4` is within 1.5% of `rk8v4`'s size but has the worst decode falloff of any format measured
+(−17.9% on the 27B, −25.2% on the 35B) and slightly worse perplexity.
+
+Per-format numbers for the 35B, plus a fit calculator that solves for context and memory, are in
+[`docs/config-calculator.html`](docs/config-calculator.html).
+
+At the 1 GiB automatic-sizing boundary INT8 spends 5.40 GiB of KV on 171,648 tokens; rk8v4 spends
+5.51 GiB on 226,560.
 
 Decode cost depends on whether you speculate. The packed value plane halves value traffic but adds
 an unpack, and those very nearly cancel: without speculation, decode measured 39.07 tok/s on INT8
@@ -563,9 +601,11 @@ a 24 GB card and the server can reuse fast CUDA Graphs instead of rebuilding wor
 - Tool calls are returned to the client but are not executed by NInfer.
 - NVFP4 A4, FP8 A8, and TMA kernels require Blackwell and are unavailable on SM86. FP8 and NVFP4
   weights are admitted through their A16 dequantizing routes.
-- The paged runtime exposes BF16, INT8 group-64 and RotorQuant `rk8v4` KV; INT8 remains the
-  quality-default path and `rk8v4` is opt-in. Upstream's row-scaled FP8 E4M3 KV profile parses but
-  is rejected on SM86, because its causal-attention kernels are Blackwell-only.
+- The paged runtime exposes six KV formats on SM86 — `bf16`, `int8` group-64, row-scaled FP8 E4M3
+  `fp8`, RotorQuant `rk8v4`, `k8v4` and `nvfp4`. INT8 remains the quality default and the rest are
+  opt-in; [`docs/config-calculator.html`](docs/config-calculator.html) has the measured size,
+  speed and perplexity of each. Note that this is KV storage only: NVFP4 A4 and FP8 A8 *weight and
+  activation* kernels still require Blackwell and are unavailable here.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ On an RTX 3090, Qwen3.8-27B supports a measured **171K-token INT8 context** with
 > KV the INT8 profile spends on 171,648 tokens, for **+0.082% perplexity**. It is opt-in; INT8
 > remains the default and the quality-default profile.
 
-This fork targets `sm_86`. Blackwell-only NVFP4/W4A4 and FP8 A8 tensor-core execution are
-unavailable. FP8 and NVFP4 *weights* are admitted through their A16 dequantizing routes, but the
-FP8 E4M3 *KV-cache* profile is not: its attention kernels have no SM86 implementation. 
+This fork targets `sm_86`. Blackwell-only NVFP4/W4A4 and FP8 A8 tensor-core *weight and
+activation* execution are unavailable. FP8 and NVFP4 weights are admitted through their A16
+dequantizing routes. The paged runtime's KV-cache storage is a separate axis from weight/activation
+kernels: all six KV formats, including row-scaled FP8 E4M3, are measured and available on SM86 —
+see [`docs/config-calculator.html`](docs/config-calculator.html).
 
 The goal is the make the utmost rippin Qwen inference stack for the 3000 series. Gladly taking PR's, all help much appreciated. 
 

--- a/TODO.md
+++ b/TODO.md
@@ -125,6 +125,24 @@ Idle (~21.9 GiB free): it passes. The 35B's runtime reservation scales with the 
 262,144 → 4.15 GB, 32,768 → 1.48 GB, 16,384 → 1.29 GB, 8,192 → fits — against ~1.02 GiB available
 once the 20.8 GiB of weights are resident.
 
+### 1.3 `docs/config-calculator.html` undercounts startup memory for speculative configurations
+
+- [ ] Its "Startup memory" total only adds the extra resident weights measured for each
+      speculation option; it reuses the no-speculation CUDA graph allowance
+      (`DATA.graphBytes`, 12 MiB) for every mode and adds no extra KV pages for either backend.
+      The real engine (`src/targets/qwen3_6/impl/runtime/layouts_impl.h`) sizes the graph
+      allowance per speculative backend and draft window — up to ~86 MiB/lane for MTP, ~96
+      MiB/lane for DFlash under `NINFER_SM8X_COMPAT`, against the calculator's flat 12 MiB — and
+      `persistent_layout`'s `mtp_extra_pages` reserves additional paged-KV pages for MTP's
+      buffered draft tokens that the calculator never adds either. Closing this properly needs
+      either a full port of `mtp_graph_profiles`/`dflash_graph_profiles`/
+      `graph_topology_allowance` into the page's JS (nontrivial, capacity- and
+      draft-window-dependent piecewise logic) or fresh `ninfer_bench` measurements of the actual
+      per-mode graph allowance and extra KV pages — both out of scope for a docs PR. Descoped with
+      a prominent in-page caveat (the "What this does not model" section and the speculation
+      hint) rather than patched inline; the no-speculation case is unaffected and is the one this
+      page's own engine cross-check validates.
+
 ---
 
 ## 2. Genuinely blocked, and what by

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -244,14 +244,12 @@ Run `./build/apps/ninfer --help` for the exact option contract.
 The registered model IDs have a native context limit of 262,144 tokens. The practical allocation
 on one RTX 3090 depends on the selected artifact, media workload, output budget, and KV-cache type.
 Use `--kv-dtype int8` for the recommended large-context quality profile; BF16 is also available.
-Artifact identity selects the weight profile; `--kv-dtype` selects runtime KV storage.
-
-Upstream's row-scaled `fp8` E4M3 KV profile is **not available on SM86**: its causal attention
-kernels use the Blackwell-only `mma.sync...kind::f8f6f4` instruction and there is no dequantizing
-attention route for FP8 KV. It parses and then fails at engine construction with a specific
-diagnostic. The experimental `rk8v4` RotorQuant profile is available and opt-in: it stores rotated
-INT8 keys with a packed signed int4 value plane, buying about 32% more context for about 0.082%
-perplexity. The prepared prompt must fit
+Artifact identity selects the weight profile; `--kv-dtype` selects runtime KV storage. All six
+formats — `bf16`, `int8`, `fp8`, `rk8v4`, `k8v4`, `nvfp4` — are accepted on SM86; measured size,
+decode speed and perplexity for each are in
+[`docs/config-calculator.html`](config-calculator.html). `rk8v4` (RotorQuant: rotated INT8 keys
+with a packed signed int4 value plane) is the best all-round choice — about 23% smaller than int8
+with the flattest decode falloff measured, for about 0.08% perplexity. The prepared prompt must fit
 `--max-context`; generation stops at the remaining context capacity when necessary.
 `--kv-capacity N` controls the shared physical Main Text KV pool independently and is rounded up to
 the 64-token page size. `--kv-capacity auto` loads the selected weights, measures the remaining GPU

--- a/docs/config-calculator.html
+++ b/docs/config-calculator.html
@@ -6,6 +6,11 @@
   checkout with no connectivity. Every constant in DATA below is measured on this fork against an
   RTX 3090; provenance for each is in the "How these numbers were taken" section at the foot of the
   page. If you rerun the sweeps, update DATA and the method notes together.
+
+  Run `node docs/config-calculator.test.mjs` after touching the arithmetic below (page rounding,
+  speculative reservations, or decode interpolation/extrapolation): it extracts this script and
+  runs it against a stubbed DOM, so a change here that silently breaks the math is caught without
+  needing a browser.
 -->
 <style>
   :root {
@@ -366,8 +371,12 @@
   <ul>
     <li>
       <strong>Memory</strong> is read from the engine's own capacity report at load, not inferred.
-      Per-token cache cost is <code>kv_payload_bytes / max_context</code>, which is exactly linear
-      with no intercept. Two things about that report are easy to get wrong, so both were checked
+      Per-token cache cost is <code>kv_payload_bytes / max_context</code>, linear with no intercept
+      &mdash; but the cache itself is reserved in whole 64-token physical pages
+      (<code>src/core/paged_kv_cache.h</code>), so this page rounds a requested context up to its
+      page boundary before pricing the cache, and rounds a reported maximum context <em>down</em>
+      to one so it is never a page-partial figure the engine would round past. Two more things
+      about the capacity report are easy to get wrong, so both were checked
       at four context lengths rather than assumed: the engine's <code>sequence</code> capacity
       <em>contains</em> the KV payload rather than sitting beside it, so adding the two columns
       double-counts the cache; and the remainder above the cache is
@@ -417,6 +426,24 @@
     expert offload are all out of scope here &mdash; see <code>docs/performance.md</code>.
   </p>
   <p>
+    <strong>Speculative-mode startup memory is an undercount, not just an approximation</strong>
+    (tracked in <code>TODO.md</code>). The "Startup memory" total above only adds the extra
+    resident weights measured for each speculation option; it reuses the no-speculation CUDA graph
+    allowance and adds no extra KV pages for either backend. The real engine sizes the graph
+    allowance per backend and draft window and can need tens of MiB more per lane for MTP or
+    DFlash than the flat figure used here, and MTP separately reserves extra paged-KV pages for
+    buffered draft tokens. The engine-cross-check above is for <code>--spec</code> unset; it does
+    not validate a speculative configuration. Leave headroom, or verify empirically, before relying
+    on a speculative "Fits" verdict close to the edge.
+  </p>
+  <p>
+    <strong>Weight profile.</strong> Every model here is measured against the one
+    groupwise-int-quantized weight artifact its download script fetches. The runtime also accepts
+    other weight profiles for the same model family with different resident sizes (see
+    <code>src/runtime/engine/context_cost_defaults.cpp</code>); these figures do not apply to a
+    differently-quantized weight artifact.
+  </p>
+  <p>
     Estimates between measured depths are interpolated, and anything past the deepest measured
     point is extrapolated and marked as such. Both are done in seconds-per-token rather than
     tokens-per-second, because step time is what grows linearly with cache depth; extrapolating the
@@ -444,7 +471,11 @@ const DATA = {
 
   models: {
     "27b": {
-      label: "Qwen3.8-27B (dense)",
+      /* Measured against the official groupwise-int artifact fetched by download-qwen38-27b
+         (weights_id "groupwise-int"). The runtime also recognizes other weight profiles (see
+         src/runtime/engine/context_cost_defaults.cpp), with different resident weightsBytes;
+         these figures do not apply to a differently-quantized weight artifact of this model. */
+      label: "Qwen3.8-27B (dense, groupwise-int weights)",
       weightsBytes: 17093490688,
       workspaceBytes: 159981568,
       nativeMaxContext: 262144,
@@ -473,7 +504,9 @@ const DATA = {
       }
     },
     "35b": {
-      label: "Qwen3.6-35B-A3B (MoE)",
+      /* Measured against the pinned 560f227e groupwise-int artifact fetched by
+         download-qwen36-35b-a3b.{sh,bat}; see the note on the 27B entry above. */
+      label: "Qwen3.6-35B-A3B (MoE, groupwise-int weights)",
       weightsBytes: 21038469632,
       workspaceBytes: 109453312,
       nativeMaxContext: 262144,
@@ -535,6 +568,12 @@ const DATA = {
 const GIB = 1024 * 1024 * 1024;
 const MIB = 1024 * 1024;
 const KV_ORDER = ["bf16", "int8", "fp8", "rk8v4", "k8v4", "nvfp4"];
+/* The paged KV allocator reserves whole 64-token pages (src/core/paged_kv_cache.h,
+   kPagedKVPageSize), rounding a requested capacity up to the next page boundary
+   (layouts_impl.h's page_count). Charging KV bytes as pure ctx * bytes-per-token, as this page did
+   before, understates the actual reservation by up to one page's worth. */
+const PAGE_TOKENS = 64;
+const pageRoundUp = (tokens) => Math.ceil(tokens / PAGE_TOKENS) * PAGE_TOKENS;
 
 const $ = (id) => document.getElementById(id);
 const fmtGiB = (b) => (b / GIB).toFixed(2) + " GiB";
@@ -551,7 +590,14 @@ function perToken(model, kv) {
 function fixedBytes(model, specKey) {
   const spec = model.spec[specKey];
   const base = model.spec.none.weightsGiB;
-  /* Speculation heads are extra resident weights; the measured deltas are in GiB. */
+  /* Speculation heads are extra resident weights; the measured deltas are in GiB.
+     KNOWN GAP (see TODO.md): DATA.graphBytes is the no-speculation CUDA graph allowance for
+     every spec mode. The real engine sizes it per speculative backend and draft window
+     (layouts_impl.h: 12 MiB flat for None, up to ~86 MiB/lane for MTP, up to ~96 MiB/lane for
+     DFlash), and MTP also reserves extra paged-KV pages for buffered draft tokens
+     (persistent_layout's mtp_extra_pages) that this function does not add either. Both are
+     undercounts specific to specKey != "none"; the no-speculation case is unaffected and is the
+     one figure this page's engine cross-check (see the method notes) actually validates. */
   const specExtra = (spec.weightsGiB - base) * GIB;
   return model.weightsBytes + specExtra + model.workspaceBytes + DATA.graphBytes +
          model.seqFixedBytes;
@@ -573,7 +619,12 @@ function decodeAtDepth(model, kv, ctx) {
   const cost = series.map((r) => 1 / r);
   const at = (c) => (c <= 0 ? null : 1 / c);
 
-  if (ctx <= d[0]) return { value: series[0], exact: ctx === d[0], extrapolated: false };
+  if (ctx <= d[0]) {
+    /* No measurement exists below the shallowest depth. Holding the shallowest rate is a
+       lower-bound estimate, not interpolation: decode is typically faster at shallower depth, so
+       this reads conservatively slow rather than wrong in the optimistic direction. */
+    return { value: series[0], exact: ctx === d[0], extrapolated: false, floored: ctx !== d[0] };
+  }
   for (let i = 1; i < d.length; i++) {
     if (ctx <= d[i]) {
       const t = (ctx - d[i - 1]) / (d[i] - d[i - 1]);
@@ -597,7 +648,9 @@ function render() {
   const usable = usableBytes();
 
   const haveKv = pt !== null;
-  const kvBytes = haveKv ? model.kv[kv] * ctx : 0;
+  /* KV is reserved by the physical page the requested context rounds up to, not by the exact
+     token count -- see the PAGE_TOKENS note above. */
+  const kvBytes = haveKv ? model.kv[kv] * pageRoundUp(ctx) : 0;
   const ovhBytes = haveKv ? model.seqFixedBytes + DATA.seqPerToken * ctx : 0;
   const specExtra = (model.spec[specKey].weightsGiB - model.spec.none.weightsGiB) * GIB;
   const weightsBytes = model.weightsBytes + specExtra;
@@ -659,10 +712,15 @@ function render() {
       fmtGiB(total) + " of " + fmtGiB(usable) + ", leaving " + fmtGiB(headroom) + ".";
   }
 
-  /* Largest context that fits */
+  /* Largest context that fits, at a page boundary. Within one physical page p (tokens
+     64(p-1)+1..64p) the KV reservation is fixed at kv-per-token * 64p, so the hardest token count
+     to fit in that page is its last one, c=64p, costing 64p*pt total (kv and per-token overhead
+     both scale with c there). The largest fully-fitting page is p = floor(room / (64*pt)); the
+     max context is that page's own boundary, which is therefore exact and always achievable --
+     never a page-partial value the engine would round up past what was checked. */
   if (haveKv) {
     const room = usable - fixed;
-    const maxCtx = Math.max(0, Math.floor(room / pt));
+    const maxCtx = Math.max(0, PAGE_TOKENS * Math.floor(room / (PAGE_TOKENS * pt)));
     const capped = Math.min(maxCtx, model.nativeMaxContext);
     $("out-maxctx").firstChild.nodeValue = fmtInt(capped);
     $("out-maxctx-sub").textContent = maxCtx > model.nativeMaxContext
@@ -684,6 +742,7 @@ function render() {
     $("out-speed").firstChild.nodeValue = value.toFixed(1);
     const bits = ["tok/s"];
     if (dec.extrapolated) bits.push("extrapolated past " + fmtInt(model.depths[model.depths.length - 1]));
+    else if (dec.floored) bits.push("lower bound — held at the " + fmtInt(model.depths[0]) + "-token measurement");
     else if (!dec.exact) bits.push("interpolated");
     else bits.push("measured");
     if (specKey !== "none") bits.push("speculation scaled from INT8");
@@ -706,9 +765,15 @@ function render() {
   $("overhead-note").textContent =
     (model.seqFixedBytes / MIB).toFixed(1) + " MiB fixed + 1/16 B per token";
   $("kv-hint").textContent = DATA.kvNotes[kv];
-  $("spec-hint").textContent = spec.accept !== null
-    ? "Measured draft acceptance " + (spec.accept * 100).toFixed(1) + "% on this model."
-    : "Weights " + spec.weightsGiB.toFixed(2) + " GiB at an 8k context.";
+  $("spec-hint").textContent = (spec.accept !== null
+    ? "Measured draft acceptance " + (spec.accept * 100).toFixed(1) + "% on this model. "
+    : "Weights " + spec.weightsGiB.toFixed(2) + " GiB at an 8k context. ") +
+    (specKey !== "none"
+      ? "Startup memory above only counts the extra resident weights; the CUDA graph allowance " +
+        "and any extra KV pages this backend needs are not modeled and can be larger than the " +
+        "no-speculation figure used here (up to ~50 MiB more per lane for some DFlash graph " +
+        "classes) -- see TODO.md."
+      : "");
   $("ctx-hint").textContent = haveKv
     ? fmtGiB(kvBytes + ovhBytes) + " of sequence memory at " + fmtInt(ctx) + " tokens."
     : "";
@@ -733,7 +798,9 @@ function buildKvTable() {
     const series = model.speed[kv];
     const deep = series ? series[series.length - 1] : null;
     if (b === null) return { kv, b, ppl, deep, ctx: null, capped: false };
-    const raw = Math.floor(budget / (b + DATA.seqPerToken));
+    // Page-aligned, same reasoning as render()'s "Largest context that fits": see the PAGE_TOKENS
+    // note near the top of this script.
+    const raw = PAGE_TOKENS * Math.floor(budget / (PAGE_TOKENS * (b + DATA.seqPerToken)));
     /* Report what is actually reachable: past the model's own context limit the extra budget
        buys nothing, and showing the uncapped figure would promise context that cannot be had. */
     return { kv, b, ppl, deep, ctx: Math.min(raw, model.nativeMaxContext),

--- a/docs/config-calculator.html
+++ b/docs/config-calculator.html
@@ -1,0 +1,847 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>NInfer 3090 Fit Calculator</title>
+<!--
+  A committed, self-contained page: no network requests, no CDN, no web fonts, so it works from a
+  checkout with no connectivity. Every constant in DATA below is measured on this fork against an
+  RTX 3090; provenance for each is in the "How these numbers were taken" section at the foot of the
+  page. If you rerun the sweeps, update DATA and the method notes together.
+-->
+<style>
+  :root {
+    color-scheme: light;
+    --ground:  #edf0f3;
+    --surface: #ffffff;
+    --sunken:  #e4e9ee;
+    --ink:     #121820;
+    --muted:   #5b6772;
+    --line:    #d2d9e0;
+    --accent:  #0e6e6e;
+    --accent-soft: #dcecec;
+    --ok:   #2e7d32;
+    --warn: #b26a00;
+    --over: #b3261e;
+    --seg-weights:   #3e4c59;
+    --seg-kv:        #0e6e6e;
+    --seg-overhead:  #7fa9a9;
+    --seg-workspace: #b9c4cc;
+    --seg-free:      #e4e9ee;
+    --mono: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "SF Mono", Menlo, Consolas,
+            "Liberation Mono", monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      color-scheme: dark;
+      --ground:  #0f141a;
+      --surface: #161d25;
+      --sunken:  #1e262f;
+      --ink:     #e3e9ef;
+      --muted:   #93a0ad;
+      --line:    #28323c;
+      --accent:  #3fb6ac;
+      --accent-soft: #17322f;
+      --ok:   #6fcf7a;
+      --warn: #e0a340;
+      --over: #f2685c;
+      --seg-weights:   #5b6b7a;
+      --seg-kv:        #3fb6ac;
+      --seg-overhead:  #2f6f6a;
+      --seg-workspace: #46535f;
+      --seg-free:      #1e262f;
+    }
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --ground:  #0f141a;
+    --surface: #161d25;
+    --sunken:  #1e262f;
+    --ink:     #e3e9ef;
+    --muted:   #93a0ad;
+    --line:    #28323c;
+    --accent:  #3fb6ac;
+    --accent-soft: #17322f;
+    --ok:   #6fcf7a;
+    --warn: #e0a340;
+    --over: #f2685c;
+    --seg-weights:   #5b6b7a;
+    --seg-kv:        #3fb6ac;
+    --seg-overhead:  #2f6f6a;
+    --seg-workspace: #46535f;
+    --seg-free:      #1e262f;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.55;
+  }
+  .wrap { max-width: 1180px; margin: 0 auto; padding: 32px 20px 72px; }
+
+  header { border-bottom: 2px solid var(--ink); padding-bottom: 18px; margin-bottom: 28px; }
+  .eyebrow {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .16em;
+    text-transform: uppercase; color: var(--accent); margin: 0 0 8px;
+  }
+  h1 {
+    font-family: var(--mono); font-weight: 600; font-size: clamp(24px, 4vw, 34px);
+    letter-spacing: -.02em; margin: 0 0 10px; text-wrap: balance;
+  }
+  .lede { margin: 0; max-width: 68ch; color: var(--muted); }
+  .lede strong { color: var(--ink); font-weight: 600; }
+
+  h2 {
+    font-family: var(--mono); font-weight: 600; font-size: 15px; letter-spacing: -.01em;
+    margin: 0 0 14px; padding-bottom: 8px; border-bottom: 1px solid var(--line);
+  }
+  h3 {
+    font-family: var(--mono); font-size: 12px; font-weight: 600; letter-spacing: .1em;
+    text-transform: uppercase; color: var(--muted); margin: 0 0 10px;
+  }
+
+  .grid { display: grid; grid-template-columns: minmax(0, 5fr) minmax(0, 6fr); gap: 20px; }
+  @media (max-width: 900px) { .grid { grid-template-columns: minmax(0, 1fr); } }
+
+  .panel {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 6px; padding: 20px;
+  }
+
+  .fields { display: grid; gap: 16px; }
+  .field { display: grid; gap: 6px; }
+  .field > label {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--muted);
+  }
+  select, input[type="number"] {
+    font-family: var(--mono); font-size: 14px; color: var(--ink);
+    background: var(--sunken); border: 1px solid var(--line); border-radius: 4px;
+    padding: 8px 10px; width: 100%;
+  }
+  input[type="range"] { width: 100%; accent-color: var(--accent); }
+  select:focus-visible, input:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 1px;
+  }
+  .ctx-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center; }
+  .ctx-row input[type="number"] { width: 11ch; }
+  .hint { font-size: 12.5px; color: var(--muted); margin: 0; }
+
+  /* The one deliberately bold element: the card's memory budget, drawn to scale. */
+  .bar {
+    display: flex; height: 46px; border-radius: 4px; overflow: hidden;
+    border: 1px solid var(--line); background: var(--seg-free); margin: 0 0 10px;
+  }
+  .bar > span { display: block; min-width: 0; }
+  .seg-weights   { background: var(--seg-weights); }
+  .seg-kv        { background: var(--seg-kv); }
+  .seg-overhead  { background: var(--seg-overhead); }
+  .seg-workspace { background: var(--seg-workspace); }
+  .seg-spacer    { background: var(--seg-free); }
+  /* The OS reserve is drawn at the far end of the card, hatched, so that "free" on the bar means
+     free to you rather than free-minus-whatever-the-desktop-takes. */
+  .seg-reserve {
+    background: repeating-linear-gradient(-45deg, var(--line) 0 4px, transparent 4px 8px);
+  }
+  .bar-scale {
+    display: flex; justify-content: space-between; font-family: var(--mono);
+    font-size: 11px; color: var(--muted); margin-bottom: 18px;
+  }
+
+  .legend { display: grid; gap: 6px; margin: 0 0 18px; }
+  .legend-row {
+    display: grid; grid-template-columns: 12px 1fr auto auto; gap: 10px; align-items: center;
+    font-size: 13px;
+  }
+  /* Bordered so the palest segments (free, workspace) stay visible against the panel. */
+  .swatch { width: 12px; height: 12px; border-radius: 2px; border: 1px solid var(--line); }
+  .legend-row .num, .legend-row .pct {
+    font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 13px;
+  }
+  .legend-row .pct { color: var(--muted); width: 5ch; text-align: right; }
+  .legend-row .num { width: 11ch; text-align: right; }
+
+  .verdict {
+    display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+    padding: 12px 14px; border-radius: 4px; margin: 0 0 18px;
+    border-left: 4px solid var(--accent); background: var(--accent-soft);
+  }
+  .verdict.is-ok   { border-left-color: var(--ok); }
+  .verdict.is-warn { border-left-color: var(--warn); }
+  .verdict.is-over { border-left-color: var(--over); }
+  .verdict strong { font-family: var(--mono); font-size: 14px; }
+  .verdict span { font-size: 13.5px; color: var(--muted); }
+  .verdict.is-over span, .verdict.is-over strong { color: var(--over); }
+
+  .readouts { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1px;
+              background: var(--line); border: 1px solid var(--line); border-radius: 4px; }
+  @media (max-width: 560px) { .readouts { grid-template-columns: minmax(0, 1fr); } }
+  .readout { background: var(--surface); padding: 12px 14px; }
+  .readout dt {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: .09em; text-transform: uppercase;
+    color: var(--muted); margin: 0 0 4px;
+  }
+  .readout dd {
+    margin: 0; font-family: var(--mono); font-variant-numeric: tabular-nums;
+    font-size: 19px; letter-spacing: -.02em;
+  }
+  .readout .sub { display: block; font-size: 11.5px; color: var(--muted); letter-spacing: 0; }
+
+  section { margin-top: 34px; }
+  .tablewrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 4px;
+               background: var(--surface); }
+  table { border-collapse: collapse; width: 100%; font-size: 13.5px; }
+  th, td { padding: 8px 12px; text-align: right; border-bottom: 1px solid var(--line);
+           white-space: nowrap; }
+  th:first-child, td:first-child { text-align: left; }
+  thead th {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .07em; text-transform: uppercase;
+    color: var(--muted); background: var(--sunken); border-bottom: 1px solid var(--line);
+  }
+  tbody tr:last-child td { border-bottom: 0; }
+  tbody td { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+  tbody td:first-child { font-weight: 600; }
+  tr.is-current td { background: var(--accent-soft); }
+  .best { color: var(--ok); font-weight: 600; }
+  .bad  { color: var(--over); }
+  caption { caption-side: bottom; padding: 10px 12px; text-align: left; font-size: 12.5px;
+            color: var(--muted); }
+
+  .prose { max-width: 74ch; }
+  .prose p { margin: 0 0 12px; }
+  .prose code, .inline-code {
+    font-family: var(--mono); font-size: 12.5px; background: var(--sunken);
+    padding: 1px 5px; border-radius: 3px;
+  }
+  .prose ul { margin: 0 0 12px; padding-left: 20px; }
+  .prose li { margin-bottom: 6px; }
+  footer { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--line);
+           font-size: 12.5px; color: var(--muted); }
+</style>
+
+<div class="wrap">
+<header>
+  <p class="eyebrow">NInfer-3090 &middot; RTX 3090 &middot; 24 GiB</p>
+  <h1>Fit Calculator</h1>
+  <p class="lede">
+    Pick a model, a KV format and a context length; this says whether it fits in 24 GiB, and what
+    it costs you in decode speed and perplexity. Every constant is <strong>measured on this
+    fork</strong>, not estimated from parameter counts &mdash; see the method notes at the foot.
+  </p>
+</header>
+
+<div class="grid">
+  <div class="panel">
+    <h2>Configure</h2>
+    <div class="fields">
+      <div class="field">
+        <label for="model">Model</label>
+        <select id="model"></select>
+      </div>
+      <div class="field">
+        <label for="kv">KV cache format</label>
+        <select id="kv"></select>
+        <p class="hint" id="kv-hint"></p>
+      </div>
+      <div class="field">
+        <label for="ctx">Context (tokens)</label>
+        <div class="ctx-row">
+          <input type="range" id="ctx-range" min="2048" max="262144" step="2048">
+          <input type="number" id="ctx" min="256" max="1048576" step="256">
+        </div>
+        <p class="hint" id="ctx-hint"></p>
+      </div>
+      <div class="field">
+        <label for="spec">Speculation</label>
+        <select id="spec"></select>
+        <p class="hint" id="spec-hint"></p>
+      </div>
+      <div class="field">
+        <label for="reserve">Reserved for the OS</label>
+        <select id="reserve">
+          <option value="307">Headless Linux &mdash; 0.3 GiB</option>
+          <option value="1536" selected>Windows / Linux desktop &mdash; 1.5 GiB</option>
+          <option value="2560">Desktop with a browser open &mdash; 2.5 GiB</option>
+          <option value="0">Nothing &mdash; the whole 24 GiB</option>
+        </select>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Result</h2>
+    <div class="verdict" id="verdict">
+      <strong id="verdict-head"></strong>
+      <span id="verdict-detail"></span>
+    </div>
+
+    <h3>Memory budget</h3>
+    <div class="bar" id="bar">
+      <span class="seg-weights"   id="seg-weights"></span>
+      <span class="seg-kv"        id="seg-kv"></span>
+      <span class="seg-overhead"  id="seg-overhead"></span>
+      <span class="seg-workspace" id="seg-workspace"></span>
+      <span class="seg-spacer"    id="seg-spacer"></span>
+      <span class="seg-reserve"   id="seg-reserve"></span>
+    </div>
+    <div class="bar-scale"><span>0</span><span>12 GiB</span><span id="scale-max">24 GiB</span></div>
+
+    <div class="legend" id="legend"></div>
+
+    <dl class="readouts">
+      <div class="readout">
+        <dt>Largest context that fits</dt>
+        <dd id="out-maxctx">&mdash;<span class="sub" id="out-maxctx-sub"></span></dd>
+      </div>
+      <div class="readout">
+        <dt>Decode at this depth</dt>
+        <dd id="out-speed">&mdash;<span class="sub" id="out-speed-sub"></span></dd>
+      </div>
+      <div class="readout">
+        <dt>Perplexity cost</dt>
+        <dd id="out-ppl">&mdash;<span class="sub" id="out-ppl-sub"></span></dd>
+      </div>
+    </dl>
+  </div>
+</div>
+
+<section>
+  <h2>KV formats, measured</h2>
+  <div class="tablewrap">
+    <table id="kv-table">
+      <thead>
+        <tr>
+          <th>Format</th><th>Bytes / token</th><th>Largest context</th>
+          <th>Perplexity</th><th>vs bf16</th><th>Decode @ 32k</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+      <caption id="kv-caption"></caption>
+    </table>
+  </div>
+</section>
+
+<section>
+  <h2>Decode speed against cache depth</h2>
+  <div class="tablewrap">
+    <table id="depth-table">
+      <thead><tr id="depth-head"></tr></thead>
+      <tbody></tbody>
+      <caption>
+        Decode tokens/second, no speculation. Attention re-reads the whole cache every step, so a
+        format's cost only appears at depth &mdash; measuring at a shallow cache would show almost
+        no difference between any of these. Each figure is the mean of three timed repetitions
+        after one warm-up.
+      </caption>
+    </table>
+  </div>
+</section>
+
+<section>
+  <h2>What speculation costs and buys</h2>
+  <div class="tablewrap">
+    <table id="spec-table">
+      <thead>
+        <tr><th>Model</th><th>Mode</th><th>Weights</th><th>Decode</th><th>Acceptance</th></tr>
+      </thead>
+      <tbody></tbody>
+      <caption>
+        Measured at an 8,192-token context with INT8 KV. Speculation is only worth its weight when
+        the draft is accepted often: on the 35B, MTP3 with the draft head accepts 59.4% and pays
+        back handsomely, while DFlash2 on the 27B accepts 10.8% and is a net loss against no
+        speculation at all.
+      </caption>
+    </table>
+  </div>
+</section>
+
+<section class="prose">
+  <h2>How these numbers were taken</h2>
+  <p>
+    All measurements are from one RTX 3090 (24 GiB, sm_86, CUDA 12.8) on this fork, with
+    <code>ninfer_bench</code> and <code>ninfer-perplexity</code>.
+  </p>
+  <ul>
+    <li>
+      <strong>Memory</strong> is read from the engine's own capacity report at load, not inferred.
+      Per-token cache cost is <code>kv_payload_bytes / max_context</code>, which is exactly linear
+      with no intercept. Two things about that report are easy to get wrong, so both were checked
+      at four context lengths rather than assumed: the engine's <code>sequence</code> capacity
+      <em>contains</em> the KV payload rather than sitting beside it, so adding the two columns
+      double-counts the cache; and the remainder above the cache is
+      <span class="inline-code" id="overhead-note"></span>, a <em>fixed</em> block rather than a
+      per-token cost. Measuring it at a single context length would have made it look like roughly
+      4 KB per token on the 27B, which understates memory at short contexts and overstates it badly
+      at long ones. It is identical across all six formats.
+    </li>
+    <li>
+      <strong>Perplexity</strong> is <code>ninfer-perplexity</code> on the fixed
+      <code>ninfer-ppl-1m-v1</code> corpus with <code>--quick</code>, context/stride 4096/2048,
+      261,167 scored tokens &mdash; the same corpus and window for all six formats, so the
+      differences are comparable to each other. Absolute values are not comparable to perplexity
+      numbers from other tools. All six were measured on <strong>Qwen3.8-27B</strong>: the ranking
+      is a property of how each format quantizes, so it carries across models, but the absolute
+      figures are the 27B's and are shown as such when another model is selected.
+    </li>
+    <li>
+      <strong>Decode speed</strong> is a <code>-pg P,128</code> run: prefill <em>P</em> tokens, then
+      time 128 decode steps on top of that cache. Prefill and decode are timed separately, so these
+      are decode-only rates at a genuine cache depth.
+    </li>
+  </ul>
+  <p>
+    <strong>The model is checked against the engine, not just against itself.</strong> Asking for a
+    262,144-token INT8 context on the 27B is refused with
+    <code>minimum Engine runtime reservation requires 9197389568 bytes in addition to 1073741824
+    bytes of automatic headroom</code>. Adding this page's own terms &mdash;
+    262,144&nbsp;&times;&nbsp;33,792 for the cache, 166,438,656 fixed, 16,384 for the per-token
+    remainder, 159,981,568 of workspace and 12,582,912 of graph allowance &mdash; gives
+    9,197,389,568. An exact match, so the arithmetic here is the arithmetic the engine actually
+    applies.
+  </p>
+  <p>
+    One difference worth knowing: <code>--kv-capacity auto</code> holds back a further 1 GiB of
+    sizing headroom on top of everything above. The largest context this page reports is what
+    physically fits; the largest the engine will <em>auto-size</em> to is whatever fits with that
+    extra gibibyte also spoken for. Ask for a context explicitly and you get the former.
+  </p>
+
+  <h3>What this does not model</h3>
+  <p>
+    Single-lane serving only. Concurrency changes the picture: <code>--kv-capacity</code> is a
+    shared pool while <code>--max-context</code> is a per-request cap, so a second lane does not
+    cost twice the memory unless you also want twice the per-request context. Vision in overlay
+    residency costs no resident capacity. Prefill throughput, time-to-first-token and multi-GPU
+    expert offload are all out of scope here &mdash; see <code>docs/performance.md</code>.
+  </p>
+  <p>
+    Estimates between measured depths are interpolated, and anything past the deepest measured
+    point is extrapolated and marked as such. Both are done in seconds-per-token rather than
+    tokens-per-second, because step time is what grows linearly with cache depth; extrapolating the
+    rate directly would have it fall through zero a few hundred thousand tokens out. Treat an
+    extrapolated figure as the shape of the curve, not a promise.
+  </p>
+</section>
+
+<footer>
+  Generated from measurements in this repository. Regenerate the constants in this file's
+  <code>DATA</code> block if you rerun the sweeps.
+</footer>
+</div>
+
+<script>
+"use strict";
+
+/* Every number below is measured; see the method notes in the page body. Bytes are bytes. */
+const DATA = {
+  cardMiB: 24576,
+  graphBytes: 12582912,
+  /* Measured: the non-KV sequence block also carries 1/16 byte per token on both models. Tiny,
+     but it is what makes the fixed constants above reproduce every measurement exactly. */
+  seqPerToken: 0.0625,
+
+  models: {
+    "27b": {
+      label: "Qwen3.8-27B (dense)",
+      weightsBytes: 17093490688,
+      workspaceBytes: 159981568,
+      nativeMaxContext: 262144,
+      /* Non-KV sequence state, = sequence capacity - KV payload. Measured at four context lengths:
+         it is a fixed block plus 1/16 byte per token, not a per-token cost. Solved exactly from
+         8k/16k/32k/64k, which reproduce all four measurements to the byte. */
+      seqFixedBytes: 166438656,
+      /* KV payload bytes per token, = kv_payload_bytes / max_context. */
+      kv: { bf16: 65536, int8: 33792, fp8: 33024, rk8v4: 26112, k8v4: 25728, nvfp4: 18432 },
+      /* decode tok/s, no speculation, at these cache depths */
+      depths: [4096, 16384, 32768],
+      speed: {
+        bf16:  [36.74, 34.72, 32.50],
+        int8:  [36.15, 35.11, 33.86],
+        fp8:   [35.28, 32.57, 30.13],
+        rk8v4: [35.77, 34.73, 33.54],
+        k8v4:  [34.86, 31.76, 28.61],
+        nvfp4: [35.14, 32.64, 29.62]
+      },
+      spec: {
+        none:          { label: "None",                weightsGiB: 15.92, decode: 34.41, accept: null },
+        mtp3:          { label: "MTP, 3 draft tokens", weightsGiB: 16.34, decode: 39.90, accept: null },
+        "mtp3+head":   { label: "MTP3 + draft head",   weightsGiB: 16.67, decode: 42.33, accept: 0.302 },
+        "dflash2-7":   { label: "DFlash2, 7 tokens",   weightsGiB: 17.99, decode: 27.57, accept: 0.108 },
+        "dflash2-7+head": { label: "DFlash2-7 + draft head", weightsGiB: 18.33, decode: 28.33, accept: null }
+      }
+    },
+    "35b": {
+      label: "Qwen3.6-35B-A3B (MoE)",
+      weightsBytes: 21038469632,
+      workspaceBytes: 109453312,
+      nativeMaxContext: 262144,
+      seqFixedBytes: 70579968,
+      kv: { bf16: 20480, int8: 10560, fp8: 10320, rk8v4: 8160, k8v4: 8040, nvfp4: 5760 },
+      depths: [4096, 16384, 32768],
+      speed: {
+        bf16:  [169.98, 159.17, 144.60],
+        int8:  [173.83, 167.18, 154.90],
+        fp8:   [166.06, 149.53, 131.19],
+        rk8v4: [172.08, 165.82, 155.76],
+        k8v4:  [163.28, 141.51, 122.07],
+        nvfp4: [167.49, 150.14, 132.12]
+      },
+      spec: {
+        none:          { label: "None",                weightsGiB: 19.59, decode: 178.00, accept: null },
+        mtp3:          { label: "MTP, 3 draft tokens", weightsGiB: 20.43, decode: 214.37, accept: null },
+        "mtp3+head":   { label: "MTP3 + draft head",   weightsGiB: 20.56, decode: 256.03, accept: 0.594 },
+        "dflash-3":    { label: "DFlash, 3 tokens",    weightsGiB: 19.98, decode: 173.73, accept: null },
+        "dflash-3+head": { label: "DFlash-3 + draft head", weightsGiB: 20.11, decode: 196.65, accept: 0.379 }
+      }
+    }
+  },
+
+  /* Perplexity is model-independent in the sense that it was measured once, on the 27B, over the
+     same corpus and window for all six formats. */
+  perplexity: {
+    bf16:  4.343225,
+    int8:  4.343263,
+    fp8:   4.347181,
+    rk8v4: 4.346811,
+    k8v4:  4.347596,
+    nvfp4: 4.358924
+  },
+  kvLabels: {
+    bf16:  "bf16 — full precision reference",
+    int8:  "int8 — rotated INT8, group-64",
+    fp8:   "fp8 — row-scaled E4M3",
+    rk8v4: "rk8v4 — RotorQuant, INT8 keys + 4-bit values",
+    k8v4:  "k8v4 — INT8 keys + 4-bit values",
+    nvfp4: "nvfp4 — NVFP4 keys and values"
+  },
+  kvNotes: {
+    bf16:  "The reference. Twice the cache of int8 for a perplexity difference too small to " +
+           "measure, and slower at depth. Useful for comparison, rarely the right choice.",
+    int8:  "The quality default: +0.0009% perplexity is effectively free, and it holds its decode " +
+           "rate at depth better than anything except rk8v4.",
+    fp8:   "No reason to choose it. rk8v4 is smaller, faster at depth and better quality, so fp8 " +
+           "is dominated on all three axes.",
+    rk8v4: "The best all-round choice. 23% smaller than int8, the flattest decode curve of any " +
+           "format measured, and +0.08% perplexity.",
+    k8v4:  "Within 1.5% of rk8v4's size but the worst decode falloff measured (-25% by 32k) and " +
+           "slightly worse quality. Prefer rk8v4.",
+    nvfp4: "Maximum context: 45% smaller than int8. You pay about 15% of decode speed at a 32k " +
+           "cache and +0.36% perplexity for it."
+  }
+};
+
+const GIB = 1024 * 1024 * 1024;
+const MIB = 1024 * 1024;
+const KV_ORDER = ["bf16", "int8", "fp8", "rk8v4", "k8v4", "nvfp4"];
+
+const $ = (id) => document.getElementById(id);
+const fmtGiB = (b) => (b / GIB).toFixed(2) + " GiB";
+const fmtInt = (n) => Math.round(n).toLocaleString("en-US");
+
+function modelOf() { return DATA.models[$("model").value]; }
+
+/* Per-token resident cost: the cache itself plus the non-KV sequence state that scales with it. */
+function perToken(model, kv) {
+  const k = model.kv[kv];
+  return k === null ? null : k + DATA.seqPerToken;
+}
+
+function fixedBytes(model, specKey) {
+  const spec = model.spec[specKey];
+  const base = model.spec.none.weightsGiB;
+  /* Speculation heads are extra resident weights; the measured deltas are in GiB. */
+  const specExtra = (spec.weightsGiB - base) * GIB;
+  return model.weightsBytes + specExtra + model.workspaceBytes + DATA.graphBytes +
+         model.seqFixedBytes;
+}
+
+function usableBytes() {
+  return (DATA.cardMiB - Number($("reserve").value)) * MIB;
+}
+
+/* Interpolates in seconds-per-token, not tokens-per-second. Attention reads the whole cache each
+   step, so step time is roughly (fixed work + something proportional to depth) and its reciprocal
+   is what bends. Working in the linear quantity keeps extrapolation physically sane: a straight
+   line through the rate would cross zero and then go negative a few hundred thousand tokens out,
+   whereas a straight line through the step time only ever approaches zero rate asymptotically. */
+function decodeAtDepth(model, kv, ctx) {
+  const series = model.speed[kv];
+  if (!series) return null;
+  const d = model.depths;
+  const cost = series.map((r) => 1 / r);
+  const at = (c) => (c <= 0 ? null : 1 / c);
+
+  if (ctx <= d[0]) return { value: series[0], exact: ctx === d[0], extrapolated: false };
+  for (let i = 1; i < d.length; i++) {
+    if (ctx <= d[i]) {
+      const t = (ctx - d[i - 1]) / (d[i] - d[i - 1]);
+      return { value: at(cost[i - 1] + t * (cost[i] - cost[i - 1])),
+               exact: ctx === d[i], extrapolated: false };
+    }
+  }
+  const n = d.length - 1;
+  const slope = (cost[n] - cost[n - 1]) / (d[n] - d[n - 1]);
+  return { value: at(cost[n] + slope * (ctx - d[n])), exact: false, extrapolated: true };
+}
+
+function render() {
+  const model = modelOf();
+  const kv = $("kv").value;
+  const specKey = $("spec").value;
+  const ctx = Math.max(256, Number($("ctx").value) || 0);
+
+  const pt = perToken(model, kv);
+  const fixed = fixedBytes(model, specKey);
+  const usable = usableBytes();
+
+  const haveKv = pt !== null;
+  const kvBytes = haveKv ? model.kv[kv] * ctx : 0;
+  const ovhBytes = haveKv ? model.seqFixedBytes + DATA.seqPerToken * ctx : 0;
+  const specExtra = (model.spec[specKey].weightsGiB - model.spec.none.weightsGiB) * GIB;
+  const weightsBytes = model.weightsBytes + specExtra;
+  const wsBytes = model.workspaceBytes + DATA.graphBytes;
+  const total = weightsBytes + kvBytes + ovhBytes + wsBytes;
+
+  /* Bar is drawn against the full card so the OS reserve is visible as unclaimed space. */
+  const card = DATA.cardMiB * MIB;
+  const pctOf = (b) => Math.max(0, Math.min(100, (b / card) * 100));
+  const reserveBytes = Number($("reserve").value) * MIB;
+  const freeBytes = Math.max(0, usable - total);
+  $("seg-weights").style.width   = pctOf(weightsBytes) + "%";
+  $("seg-kv").style.width        = pctOf(kvBytes) + "%";
+  $("seg-overhead").style.width  = pctOf(ovhBytes) + "%";
+  $("seg-workspace").style.width = pctOf(wsBytes) + "%";
+  $("seg-spacer").style.width    = pctOf(freeBytes) + "%";
+  $("seg-reserve").style.width   = pctOf(reserveBytes) + "%";
+
+  const rows = [
+    ["--seg-weights", "Weights" + (specExtra > 0 ? " + speculation heads" : ""), weightsBytes, true],
+    ["--seg-kv", "KV cache (" + kv + ")", kvBytes, true],
+    ["--seg-overhead", "Sequence state (fixed)", ovhBytes, true],
+    ["--seg-workspace", "Workspace + CUDA graphs", wsBytes, true],
+    ["--seg-free", "Free for more context", freeBytes, true],
+    ["--line", "Reserved for the OS", reserveBytes, false]
+  ];
+  $("legend").innerHTML = rows.map(([v, name, b, solid]) =>
+    '<div class="legend-row"><span class="swatch" style="' +
+      (solid ? "background:var(" + v + ")"
+             : "background:repeating-linear-gradient(-45deg,var(--line) 0 3px,transparent 3px 6px)") +
+    '"></span>' +
+    "<span>" + name + '</span><span class="num">' + fmtGiB(b) + '</span>' +
+    '<span class="pct">' + ((b / card) * 100).toFixed(0) + "%</span></div>").join("");
+
+  /* Verdict */
+  const verdict = $("verdict");
+  const headroom = usable - total;
+  verdict.classList.remove("is-ok", "is-warn", "is-over");
+  if (!haveKv) {
+    verdict.classList.add("is-warn");
+    $("verdict-head").textContent = "Not measured";
+    $("verdict-detail").textContent =
+      "This model/format pair has no measured figures in this file yet.";
+  } else if (headroom < 0) {
+    verdict.classList.add("is-over");
+    $("verdict-head").textContent = "Does not fit";
+    $("verdict-detail").textContent =
+      "Over budget by " + fmtGiB(-headroom) + ". " + fmtGiB(total) + " needed, " +
+      fmtGiB(usable) + " available.";
+  } else if (headroom < 0.5 * GIB) {
+    verdict.classList.add("is-warn");
+    $("verdict-head").textContent = "Tight";
+    $("verdict-detail").textContent =
+      "Fits with " + fmtGiB(headroom) + " to spare — little room for fragmentation.";
+  } else {
+    verdict.classList.add("is-ok");
+    $("verdict-head").textContent = "Fits";
+    $("verdict-detail").textContent =
+      fmtGiB(total) + " of " + fmtGiB(usable) + ", leaving " + fmtGiB(headroom) + ".";
+  }
+
+  /* Largest context that fits */
+  if (haveKv) {
+    const room = usable - fixed;
+    const maxCtx = Math.max(0, Math.floor(room / pt));
+    const capped = Math.min(maxCtx, model.nativeMaxContext);
+    $("out-maxctx").firstChild.nodeValue = fmtInt(capped);
+    $("out-maxctx-sub").textContent = maxCtx > model.nativeMaxContext
+      ? "capped at the model's " + fmtInt(model.nativeMaxContext) + " limit"
+      : "tokens at " + fmtInt(Math.round(pt)) + " B/token";
+  } else {
+    $("out-maxctx").firstChild.nodeValue = "—";
+    $("out-maxctx-sub").textContent = "";
+  }
+
+  /* Decode */
+  const dec = decodeAtDepth(model, kv, ctx);
+  const spec = model.spec[specKey];
+  if (dec) {
+    /* Speculation ratios are measured with INT8 KV; applying that ratio to another format assumes
+       the ratio carries, which is why it is labelled as scaled rather than measured. */
+    const ratio = spec.decode / model.spec.none.decode;
+    const value = dec.value * ratio;
+    $("out-speed").firstChild.nodeValue = value.toFixed(1);
+    const bits = ["tok/s"];
+    if (dec.extrapolated) bits.push("extrapolated past " + fmtInt(model.depths[model.depths.length - 1]));
+    else if (!dec.exact) bits.push("interpolated");
+    else bits.push("measured");
+    if (specKey !== "none") bits.push("speculation scaled from INT8");
+    $("out-speed-sub").textContent = bits.join(" · ");
+  } else {
+    $("out-speed").firstChild.nodeValue = "—";
+    $("out-speed-sub").textContent = "no measured series for " + kv;
+  }
+
+  /* Perplexity */
+  const ppl = DATA.perplexity[kv];
+  const base = DATA.perplexity.bf16;
+  const delta = ((ppl - base) / base) * 100;
+  $("out-ppl").firstChild.nodeValue = delta === 0 ? "baseline" : "+" + delta.toFixed(4) + "%";
+  /* Perplexity was measured once, on the 27B, across all six formats. Say so rather than let the
+     figure read as a property of whichever model is selected. */
+  $("out-ppl-sub").textContent = ppl.toFixed(6) + " vs bf16 " + base.toFixed(6) +
+    ($("model").value === "27b" ? "" : " · measured on the 27B");
+
+  $("overhead-note").textContent =
+    (model.seqFixedBytes / MIB).toFixed(1) + " MiB fixed + 1/16 B per token";
+  $("kv-hint").textContent = DATA.kvNotes[kv];
+  $("spec-hint").textContent = spec.accept !== null
+    ? "Measured draft acceptance " + (spec.accept * 100).toFixed(1) + "% on this model."
+    : "Weights " + spec.weightsGiB.toFixed(2) + " GiB at an 8k context.";
+  $("ctx-hint").textContent = haveKv
+    ? fmtGiB(kvBytes + ovhBytes) + " of sequence memory at " + fmtInt(ctx) + " tokens."
+    : "";
+
+  buildKvTable();
+  markCurrentRows(kv);
+}
+
+function buildKvTable() {
+  const model = modelOf();
+  const body = $("kv-table").querySelector("tbody");
+  const base = DATA.perplexity.bf16;
+  /* Against the real card and the chosen OS reserve rather than an arbitrary fixed budget: on the
+     35B a 6 GiB budget put every format at the 262,144 cap, so the column distinguished nothing.
+     fixedBytes already accounts for the fixed sequence block, so what is left is the cache. */
+  const budget = usableBytes() - fixedBytes(model, $("spec").value);
+
+  const deepest = model.depths[model.depths.length - 1];
+  const rows = KV_ORDER.map((kv) => {
+    const b = model.kv[kv];
+    const ppl = DATA.perplexity[kv];
+    const series = model.speed[kv];
+    const deep = series ? series[series.length - 1] : null;
+    if (b === null) return { kv, b, ppl, deep, ctx: null, capped: false };
+    const raw = Math.floor(budget / (b + DATA.seqPerToken));
+    /* Report what is actually reachable: past the model's own context limit the extra budget
+       buys nothing, and showing the uncapped figure would promise context that cannot be had. */
+    return { kv, b, ppl, deep, ctx: Math.min(raw, model.nativeMaxContext),
+             capped: raw > model.nativeMaxContext };
+  });
+  const bestCtx = Math.max(...rows.map((r) => r.ctx || 0));
+  const bestSpeed = Math.max(...rows.map((r) => r.deep || 0));
+
+  body.innerHTML = rows.map((r) => {
+    const delta = ((r.ppl - base) / base) * 100;
+    return '<tr data-kv="' + r.kv + '">' +
+      "<td>" + r.kv + "</td>" +
+      "<td>" + (r.b === null ? "—" : fmtInt(r.b)) + "</td>" +
+      '<td class="' + (r.ctx === bestCtx ? "best" : "") + '">' +
+        (r.ctx === null ? "—" : fmtInt(r.ctx) + (r.capped ? " (max)" : "")) + "</td>" +
+      "<td>" + r.ppl.toFixed(6) + "</td>" +
+      "<td>" + (delta === 0 ? "—" : "+" + delta.toFixed(4) + "%") + "</td>" +
+      '<td class="' + (r.deep && r.deep === bestSpeed ? "best" : "") + '">' +
+        (r.deep === null ? "—" : r.deep.toFixed(2)) + "</td>" +
+      "</tr>";
+  }).join("");
+
+  $("kv-caption").textContent =
+    "Largest context is what fits on the " + model.label +
+    " at the currently selected OS reserve and speculation mode, after the fixed " +
+    (model.seqFixedBytes / MIB).toFixed(1) +
+    " MiB of non-KV sequence state. Decode is at a " + fmtInt(deepest) +
+    "-token cache depth, no speculation. Perplexity was measured on the Qwen3.8-27B.";
+}
+
+function markCurrentRows(kv) {
+  document.querySelectorAll("#kv-table tbody tr").forEach((tr) => {
+    tr.classList.toggle("is-current", tr.dataset.kv === kv);
+  });
+}
+
+function buildDepthTable() {
+  const model = modelOf();
+  $("depth-head").innerHTML = "<th>Format</th>" +
+    model.depths.map((d) => "<th>" + fmtInt(d) + " tokens</th>").join("") +
+    "<th>Change</th>";
+  $("depth-table").querySelector("tbody").innerHTML = KV_ORDER.map((kv) => {
+    const s = model.speed[kv];
+    if (!s) return "<tr><td>" + kv + "</td>" +
+      model.depths.map(() => "<td>—</td>").join("") + "<td>—</td></tr>";
+    const drop = ((s[s.length - 1] - s[0]) / s[0]) * 100;
+    return "<tr><td>" + kv + "</td>" +
+      s.map((v) => "<td>" + v.toFixed(2) + "</td>").join("") +
+      '<td class="' + (drop < -10 ? "bad" : "") + '">' + drop.toFixed(1) + "%</td></tr>";
+  }).join("");
+}
+
+function buildSpecTable() {
+  const body = $("spec-table").querySelector("tbody");
+  const out = [];
+  for (const key of Object.keys(DATA.models)) {
+    const m = DATA.models[key];
+    const baseDecode = m.spec.none.decode;
+    for (const sk of Object.keys(m.spec)) {
+      const s = m.spec[sk];
+      const rel = ((s.decode - baseDecode) / baseDecode) * 100;
+      out.push("<tr><td>" + m.label + "</td><td>" + s.label + "</td>" +
+        "<td>" + s.weightsGiB.toFixed(2) + " GiB</td>" +
+        '<td class="' + (rel < 0 ? "bad" : rel > 20 ? "best" : "") + '">' +
+          s.decode.toFixed(2) + (sk === "none" ? "" : " (" + (rel > 0 ? "+" : "") +
+          rel.toFixed(0) + "%)") + "</td>" +
+        "<td>" + (s.accept === null ? "—" : (s.accept * 100).toFixed(1) + "%") + "</td></tr>");
+    }
+  }
+  body.innerHTML = out.join("");
+}
+
+function buildControls() {
+  $("model").innerHTML = Object.keys(DATA.models)
+    .map((k) => '<option value="' + k + '">' + DATA.models[k].label + "</option>").join("");
+  $("kv").innerHTML = KV_ORDER
+    .map((k) => '<option value="' + k + '">' + DATA.kvLabels[k] + "</option>").join("");
+  $("kv").value = "int8";
+  refreshSpecOptions();
+  $("scale-max").textContent = (DATA.cardMiB / 1024).toFixed(0) + " GiB";
+}
+
+function refreshSpecOptions() {
+  const model = modelOf();
+  const previous = $("spec").value;
+  $("spec").innerHTML = Object.keys(model.spec)
+    .map((k) => '<option value="' + k + '">' + model.spec[k].label + "</option>").join("");
+  $("spec").value = model.spec[previous] ? previous : "none";
+}
+
+function syncCtx(source) {
+  const v = Number(source.value);
+  if (source.id === "ctx-range") $("ctx").value = v;
+  else $("ctx-range").value = Math.min(Number($("ctx-range").max), Math.max(Number($("ctx-range").min), v));
+  render();
+}
+
+buildControls();
+$("ctx").value = 32768;
+$("ctx-range").value = 32768;
+buildDepthTable();
+buildSpecTable();
+render();
+
+$("model").addEventListener("change", () => { refreshSpecOptions(); buildDepthTable(); render(); });
+$("kv").addEventListener("change", render);
+$("spec").addEventListener("change", render);
+$("reserve").addEventListener("change", render);
+$("ctx").addEventListener("input", (e) => syncCtx(e.target));
+$("ctx-range").addEventListener("input", (e) => syncCtx(e.target));
+</script>

--- a/docs/config-calculator.test.mjs
+++ b/docs/config-calculator.test.mjs
@@ -1,0 +1,181 @@
+// Regression tests for the pure arithmetic in config-calculator.html. The page is deliberately a
+// single self-contained file (no build step, no CDN, works from an offline checkout), so this
+// harness extracts its <script> body, runs it in a sandboxed context against a minimal DOM stub,
+// and exercises the resulting top-level functions directly -- rather than restructuring the page
+// into importable modules, which would give up the "one file, no tooling" property that is the
+// whole point of it.
+//
+// Run with: node docs/config-calculator.test.mjs
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+import assert from "node:assert/strict";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const html = readFileSync(join(here, "config-calculator.html"), "utf8");
+const scriptMatch = html.match(/<script>\n([\s\S]*?)<\/script>/);
+assert.ok(scriptMatch, "could not find the <script> block in config-calculator.html");
+const source = scriptMatch[1];
+
+// --- minimal DOM stub -------------------------------------------------------------------------
+// Enough for buildControls/buildDepthTable/buildSpecTable/render to run at load without throwing.
+// Everything is deliberately permissive (any property can be set) rather than a faithful DOM.
+function makeElement() {
+  const el = {
+    value: "",
+    innerHTML: "",
+    textContent: "",
+    style: {},
+    classList: { add() {}, remove() {} },
+    firstChild: { nodeValue: "" },
+    addEventListener() {},
+  };
+  // A stable child per selector, not a fresh throwaway each call, so code that queries once to
+  // write (e.g. tbody.innerHTML = ...) and a test that queries again to read see the same object.
+  const children = new Map();
+  el.querySelector = (selector) => {
+    if (!children.has(selector)) children.set(selector, makeElement());
+    return children.get(selector);
+  };
+  return el;
+}
+const elements = new Map();
+const document = {
+  getElementById(id) {
+    if (!elements.has(id)) elements.set(id, makeElement());
+    return elements.get(id);
+  },
+  querySelectorAll() { return []; },
+};
+// A real <select> auto-selects its first <option> once populated; buildControls() only sets
+// innerHTML, relying on that browser behavior to leave "model" on the first model key. Seed it
+// explicitly since the stub does not replicate that; "27b" is DATA.models' first key.
+document.getElementById("model").value = "27b";
+document.getElementById("reserve").value = "1536";
+
+const context = { document, console };
+vm.createContext(context);
+vm.runInContext(source, context, { filename: "config-calculator.html inline script" });
+// Top-level `const`/`let` bindings in a vm context live in that context's script-level lexical
+// environment, not as properties of the context object itself -- pull the ones under test out
+// with a second expression evaluated in the same context, where they are still in scope.
+const { DATA, PAGE_TOKENS, pageRoundUp, perToken, fixedBytes, decodeAtDepth, buildKvTable } =
+  vm.runInContext(
+    "({DATA, PAGE_TOKENS, pageRoundUp, perToken, fixedBytes, decodeAtDepth, buildKvTable})",
+    context);
+
+let failures = 0;
+function check(name, fn) {
+  try {
+    fn();
+    console.log("ok   " + name);
+  } catch (err) {
+    failures++;
+    console.log("FAIL " + name + ": " + err.message);
+  }
+}
+
+// --- pageRoundUp -----------------------------------------------------------------------------
+check("pageRoundUp: exact multiple stays put", () => {
+  assert.equal(pageRoundUp(8192), 8192);
+});
+check("pageRoundUp: one token over rounds up a full page", () => {
+  assert.equal(pageRoundUp(8193), 8192 + PAGE_TOKENS);
+});
+check("pageRoundUp: one token under the boundary still rounds up to it", () => {
+  assert.equal(pageRoundUp(8191), 8192);
+});
+check("pageRoundUp: below one page rounds up to one page", () => {
+  assert.equal(pageRoundUp(1), PAGE_TOKENS);
+});
+
+// --- decodeAtDepth -----------------------------------------------------------------------------
+const model27b = DATA.models["27b"];
+check("decodeAtDepth: exact at a measured depth is not floored/interpolated/extrapolated", () => {
+  const d = decodeAtDepth(model27b, "int8", model27b.depths[0]);
+  assert.equal(d.exact, true);
+  assert.equal(d.floored, false);
+  assert.equal(d.extrapolated, false);
+  assert.equal(d.value, model27b.speed.int8[0]);
+});
+check("decodeAtDepth: below the first measured depth is floored, not interpolated", () => {
+  const d = decodeAtDepth(model27b, "int8", model27b.depths[0] - 1);
+  assert.equal(d.floored, true);
+  assert.equal(d.exact, false);
+  assert.equal(d.extrapolated, false);
+  // Held at the shallowest measurement -- not some fabricated interpolated number.
+  assert.equal(d.value, model27b.speed.int8[0]);
+});
+check("decodeAtDepth: strictly between two measured depths interpolates", () => {
+  const [d0, d1] = model27b.depths;
+  const mid = Math.round((d0 + d1) / 2);
+  const d = decodeAtDepth(model27b, "int8", mid);
+  assert.equal(d.exact, false);
+  assert.equal(d.floored, undefined);
+  assert.equal(d.extrapolated, false);
+  const [s0, s1] = model27b.speed.int8;
+  assert.ok(d.value < Math.max(s0, s1) + 1e-9 && d.value > Math.min(s0, s1) - 1e-9,
+    "interpolated value should lie between the two bracketing measurements");
+});
+check("decodeAtDepth: past the deepest measured point extrapolates", () => {
+  const deepest = model27b.depths[model27b.depths.length - 1];
+  const d = decodeAtDepth(model27b, "int8", deepest * 4);
+  assert.equal(d.extrapolated, true);
+  assert.equal(d.exact, false);
+});
+
+// --- the PR's own verified example --------------------------------------------------------------
+// From the PR description: requesting a 262,144-token INT8 context on the 27B with no speculation
+// is refused by the real engine with "minimum Engine runtime reservation requires 9197389568
+// bytes" -- an *incremental* reservation on top of already-resident weights, not the full device
+// footprint. The page's own terms (KV + fixed sequence state + per-token remainder + workspace +
+// graph allowance, excluding weights) are stated to sum to exactly that. Reproducing it here pins
+// that agreement as a regression instead of a one-off manual check.
+check("golden: 262144-token int8, no speculation, 27B matches the engine's own refusal figure", () => {
+  const model = model27b;
+  const ctx = 262144;
+  const kvBytes = model.kv.int8 * pageRoundUp(ctx);
+  const ovhBytes = model.seqFixedBytes + DATA.seqPerToken * ctx;
+  const reservation = kvBytes + ovhBytes + model.workspaceBytes + DATA.graphBytes;
+  assert.equal(reservation, 9197389568);
+});
+
+// --- max-context page alignment -----------------------------------------------------------------
+check("max-context formula (mirrored here) is always a page multiple and fits", () => {
+  const model = model27b;
+  const pt = perToken(model, "int8");
+  const fixed = fixedBytes(model, "none"); // weights + workspace + graph + seqFixedBytes, once
+  for (const reserveMiB of [0, 307, 1536, 2560]) {
+    const usable = (DATA.cardMiB - reserveMiB) * 1024 * 1024;
+    const room = usable - fixed;
+    const maxCtx = Math.max(0, PAGE_TOKENS * Math.floor(room / (PAGE_TOKENS * pt)));
+    assert.equal(maxCtx % PAGE_TOKENS, 0, "reserve=" + reserveMiB + "MiB gave a non-page-aligned max");
+    // Reconstructed the same way render()'s `total` is: seqFixedBytes counted once (inside
+    // ovhBytes), not twice (fixedBytes() already carries its own copy for the room calculation).
+    const kvBytes = model.kv.int8 * pageRoundUp(maxCtx);
+    const perTokenOverhead = DATA.seqPerToken * maxCtx;
+    assert.ok(fixed + kvBytes + perTokenOverhead <= usable + 1e-6,
+      "reserve=" + reserveMiB + "MiB: reported max-context must not exceed usable memory");
+  }
+});
+
+// buildKvTable() duplicated the same unrounded formula independently of render()'s max-context
+// box; this exercises that second copy end to end, not just the shared math above.
+check("buildKvTable: every format's Largest-Context figure is page-aligned", () => {
+  document.getElementById("kv").value = "int8";
+  document.getElementById("spec").value = "none";
+  buildKvTable();
+  const html = document.getElementById("kv-table").querySelector("tbody").innerHTML;
+  const cells = [...html.matchAll(/<tr data-kv="(\w+)">.*?<td class="[^"]*">([\d,]+|—)( \(max\))?<\/td>/gs)];
+  assert.ok(cells.length > 0, "expected at least one KV-format row to have rendered");
+  for (const [, kv, numberText] of cells) {
+    if (numberText === "—") continue; // an unmeasured format for this model
+    const ctx = Number(numberText.replace(/,/g, ""));
+    assert.equal(ctx % PAGE_TOKENS, 0, kv + "'s reported largest context is not page-aligned: " + ctx);
+  }
+});
+
+console.log(failures === 0 ? "\nPASS" : "\nFAIL (" + failures + ")");
+process.exit(failures === 0 ? 0 : 1);

--- a/docs/perplexity.md
+++ b/docs/perplexity.md
@@ -19,7 +19,10 @@ English reference text, English long-form text, Chinese reference text, and NInf
 
 The default evaluation uses a 4,096-token context and a 2,048-token stride. Use `--context` and
 `--stride` to change that protocol, or score one UTF-8 file with `--text FILE`. The available Main
-KV representations are `bf16`, `int8`, `fp8`, `nvfp4`, and `k8v4`.
+KV representations are `bf16`, `int8`, `fp8`, `rk8v4`, `nvfp4`, and `k8v4`.
+
+All six have been measured on this corpus; the results, alongside each format's size and decode
+speed, are in [`docs/config-calculator.html`](config-calculator.html).
 
 ```bash
 ./build/apps/ninfer-perplexity models/qwen3_8_27b.ninfer \


### PR DESCRIPTION
Adds `docs/config-calculator.html`: a single self-contained page (no CDN, no web
fonts, no network) that answers "will this configuration fit in 24 GiB, and what
does it cost me?" for a model, KV format, context length and speculation mode.
Called out from README and from `docs/perplexity.md`.

Every constant is measured on an RTX 3090 against this fork. Twelve
`ninfer_bench` sweeps (six KV formats x two models, decode timed at 4K/16K/32K
cache depths), plus perplexity for the three formats README had never carried
one for, plus memory probes at four context lengths per model.

### Two measurements that corrected the model

**The engine `sequence` capacity contains the KV payload** rather than sitting
beside it, so adding the two reported columns double-counts the cache.

**What remains above the cache is fixed, not per-token.** Measured at a single
context length it looks exactly like 4063.5 B/token on the 27B. Measured at
four, it resolves to a fixed block plus 1/16 byte per token:

| ctx | sequence - KV |
|---|---|
| 8,192 | 166,439,168 |
| 16,384 | 166,439,680 |
| 32,768 | 166,440,704 |
| 65,536 | 166,442,752 |

Solving gives `166,438,656 + 0.0625 x ctx`, which reproduces all four to the
byte. The per-token reading would have understated memory by 127 MiB at 8K and
overstated it by 349 MiB at 131K.

### Checked against the engine, not just itself

Asking for a 262,144-token INT8 context is refused with `minimum Engine runtime
reservation requires 9197389568 bytes`. The page own terms -- 262,144 x 33,792
cache, 166,438,656 fixed, 16,384 per-token remainder, 159,981,568 workspace,
12,582,912 graph allowance -- sum to 9,197,389,568. Exact match.

### What the measurements say

The smallest formats are not the fastest. `nvfp4` reads a third of INT8 bytes
and decodes 13% slower at a 32K depth, because the unpack outweighs the traffic
saved. `rk8v4` has the flattest curve of any format measured.

`fp8` and `k8v4` have no niche: each is beaten by `rk8v4` on size, speed and
quality together. README now says so rather than leaving people to work it out.

### Stale claims corrected along the way

- README `Current limits` said the runtime exposes three KV formats and that FP8
  is "rejected on SM86". Both untrue since the v0.7.0 nvfp4/k8v4/fp8 port -- all
  six are measured here.
- `docs/perplexity.md` omitted `rk8v4` from a list of formats its own `--help`
  advertises.

Rendered and checked in a browser in both themes and at the 35B/rk8v4/131K
configuration, not just read off the code.