### PR TITLE
docs(todo): record what the calculator work turned up, and close two blockers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -49,15 +49,13 @@ first and check `nvidia-smi`.
 
 ### Open pull requests
 
-- **#32 — `docs/config-calculator.html`.** Open and now `APPROVED`, but **approved is not finished
-  here**: three of the six confirmed defects are fixed on that branch and two are not. The branch
-  itself says so, carrying a `KNOWN GAP (see TODO.md)` comment where speculative memory should be
-  modelled. See §2b for which is which. Merging it is a judgement call — the page is useful and
-  honest about its gap, but nothing anywhere links to it yet, deliberately, so that master carries
-  no pointer to a page that undercounts speculative configurations by ~170 MiB. **If you merge it,
-  close the speculation gap first, then add the links** (README "Choosing a KV format",
-  `docs/cli.md`, `docs/perplexity.md`, `docs/rtx-3090-windows.md`). The multiplier needed for that
-  fix is measured and recorded in §2b.
+- **#32 — `docs/config-calculator.html` — merged, but not finished.** Three of the six confirmed
+  defects were fixed before it landed and **two were not**; the file itself says so, carrying a
+  `KNOWN GAP (see TODO.md)` comment where speculative memory should be modelled. See §2b. So the
+  page is live on master, README and `docs/cli.md` link to it, and **it still undercounts any
+  speculative configuration by roughly 170 MiB.** Closing that is the top non-correctness item in
+  §0, and the multiplier it needs is already measured in §2b. Until then, treat its speculative
+  rows as optimistic.
 - **#34 — shell-script line endings.** Small and self-contained. Two launchers did not parse on
   Linux at all; see the note below. Merge this one first, it touches nothing else.
 - A worktree at `.claude/worktrees/eager-baking-cascade` exists and has been used by a second agent
@@ -101,9 +99,9 @@ question, and which one produced a wrong answer and why.
 1. **The `T=112` graph-replay failure** (§1.1). The only open item that could be a correctness
    defect in *released* code. Four hypotheses are already ruled out — read that entry first, it
    will save a day.
-2. **The calculator's speculative-memory gap** (§2b). The one remaining correctness defect on #32,
-   and the multiplier that fixes it is already measured — implementing, not investigating. Worth
-   doing before anything links to that page.
+2. **The calculator's speculative-memory gap** (§2b). Now shipped on master and linked from
+   README, so it is live: every speculative configuration it reports is roughly 170 MiB optimistic.
+   The multiplier that fixes it is already measured — implementing, not investigating.
 3. **Re-run the six real-model tests** (§1.2, §2). Their artifact blockers are gone as of #31 and
    nobody has looked since; at least one is expected to fail rather than skip.
 4. **The two test-criterion outliers** (§4). Small, the last loose ends from the §5 audit, and
@@ -280,13 +278,15 @@ recurs, and because the follow-on work below only exists now that they are gone.
 
 ## 2b. `docs/config-calculator.html` is advertised as authoritative and is not yet correct
 
-Added by #32. Six defects were raised in review and confirmed by measurement; **three are fixed on
-that branch and two are not**, so read the checkboxes rather than assuming the PR being approved
-means it is done. The evidence is kept with each entry so nobody has to re-derive it.
+Added by #32, **which merged with two of its six confirmed defects still open.** README and
+`docs/cli.md` link to the page, so those two are live rather than theoretical. Read the checkboxes
+rather than assuming a merged PR means a finished page; the file itself agrees, carrying a
+`KNOWN GAP (see TODO.md)` comment where speculative memory should be modelled.
 
-Fixed on #32 as it stands: KV page rounding, sub-4,096 decode (now labelled a lower bound held at
-the shallowest measurement rather than claimed as interpolated), and per-row weight-artifact
-labelling. The doc contradictions were fixed separately in #33.
+Closed before it landed: KV page rounding, sub-4,096 decode (now labelled a lower bound held at the
+shallowest measurement rather than claimed as interpolated), and per-row weight-artifact labelling.
+The doc contradictions were fixed separately in #33. The evidence for each is kept below so nobody
+has to re-derive it.
 
 - [ ] **Speculative modes undercount memory by roughly 170 MiB, plus a per-token term.** The page
       models speculation as a weights delta only. Measured on the 27B at `--max-ctx 40960`, INT8,

--- a/TODO.md
+++ b/TODO.md
@@ -278,12 +278,12 @@ recurs, and because the follow-on work below only exists now that they are gone.
 
 ## 2b. `docs/config-calculator.html` is advertised as authoritative and is not yet correct
 
-Added by #32, **which merged with two of its six confirmed defects still open.** README and
+Added by #32, **which merged with two of its six confirmed defects still open**, one of them only partly. README and
 `docs/cli.md` link to the page, so those two are live rather than theoretical. Read the checkboxes
 rather than assuming a merged PR means a finished page; the file itself agrees, carrying a
 `KNOWN GAP (see TODO.md)` comment where speculative memory should be modelled.
 
-Closed before it landed: KV page rounding, sub-4,096 decode (now labelled a lower bound held at the
+Closed before it landed: KV page rounding (with regression tests), sub-4,096 decode (now labelled a lower bound held at the
 shallowest measurement rather than claimed as interpolated), and per-row weight-artifact labelling.
 The doc contradictions were fixed separately in #33. The evidence for each is kept below so nobody
 has to re-derive it.
@@ -334,10 +334,18 @@ has to re-derive it.
       per weight profile, so `weightsBytes` is not transferable to, say, the NVFP4-weight variant.
       Either add the weight-profile dimension or label each row with its artifact.
 
-- [ ] **No regression coverage for any of the arithmetic.** Nothing references the page or its
-      functions. The memory model is small and pure — extracting it and pinning page rounding,
-      speculative reservations and the interpolation boundaries would catch all of the above
-      silently regressing.
+- [ ] **The regression tests exist but nothing runs them.** #32 landed
+      `docs/config-calculator.test.mjs`, and it is good: it extracts the page's `<script>` into a
+      `vm` sandbox against a DOM stub — keeping the one-file, no-build property rather than
+      restructuring the page into modules — and pins page rounding, the `decodeAtDepth` boundaries,
+      and a golden case asserting the 262,144-token INT8 figure still equals the engine's own
+      9,197,389,568-byte refusal. It passes (`node docs/config-calculator.test.mjs`).
+
+      What is missing is a runner. Nothing in CI, CTest or `scripts/` invokes it, so it will catch
+      a regression only if someone remembers to run it by hand. Wire it in. It needs `node`, which
+      no other test here does, so it probably belongs in the GitHub workflow rather than CTest.
+      It also does not cover the speculative path — which is the half still known to be wrong — so
+      extend it alongside that fix rather than after.
 
 - [x] **Active docs still contradict the six-format claim.** Fixed in #33, across four places. #32 fixed README's `Current limits`
       and `docs/perplexity.md`, but README's *opening* summary still says the FP8 E4M3 KV profile

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 # TODO
 
-State as of 2026-09-08, after a clearing pass that closed fourteen items.
+State as of 2026-09-08, after a clearing pass that closed fourteen items and a KV-format
+measurement pass that produced §2b.
 
 Released: **v0.9.0-rtx3090** (Windows + Linux). Full suite **125/125** on this box, now including
 upstream's DFlash2 attention sweep, which had been skipped since the catch-up merge.
@@ -9,8 +10,85 @@ upstream's DFlash2 attention sweep, which had been skipped since the catch-up me
 body of work and it is finished. What remains is correctness, coverage needing hardware this box
 does not have, and measurement debt.
 
-In flight: #21 (this file), #26 (503 during startup), #27 (q4 SwiGLU retune), #29 (housekeeping),
-#30 (DFlash2 sweep).
+---
+
+## Start here if you are new to this box
+
+Written as a handoff. Everything below is state you cannot recover by reading the code or the git
+log, and getting it wrong costs hours.
+
+### The models on disk, and which is which
+
+`C:\Ninefer-3090\models\` — 111 GiB total, and only ~38 GiB free on `C:`, so **check free space
+before downloading anything**. Nothing here is in git; `models/` is gitignored.
+
+| file | bytes | what it is |
+|---|---:|---|
+| `qwen3_8_27b.ninfer` | 18,210,531,328 | Qwen3.**8**-27B dense. The default 27B for benchmarks. |
+| `qwen3_8_27b_dflash2.ninfer` | 20,437,336,576 | Same model **with the DFlash2 bundle**. Only artifact that can run `--spec dflash2`. |
+| `qwen3_6_35b_a3b.ninfer` | 22,783,246,080 | Qwen3.6-35B-A3B MoE at revision `560f227e`, **with DFlash**. The recommended one. |
+| `qwen3_6_35b_a3b_v1_no_dflash.ninfer` | 22,373,184,256 | The superseded `c8b8c1c0` revision. **Renamed from a `.pre-dflash.bak` suffix** — the loader rejects anything not ending `.ninfer`, which is why it could not be benchmarked until it was renamed. Kept only to re-run the DFlash-residency comparison; **20.84 GiB reclaimable** if that is not needed again. |
+| `qwen3_6_27b.ninfer` | 17,495,365,888 | Qwen3.**6**-27B at `faaa0c14`. A **different model family** from `qwen3_8_27b` — having one does not satisfy tests wanting the other. |
+| `qwen3_6_27b_nvfp4.ninfer` | 18,324,064,000 | NVFP4-*weight* variant of the above. Note this is a weight profile, unrelated to `--kv-dtype nvfp4`. |
+
+The `qwen3_8_` versus `qwen3_6_` prefix is the single easiest thing to get wrong here, and the
+failure mode is a test skipping rather than erroring.
+
+### Environment for the real-model tests
+
+```
+NINFER_QWEN3_8_27B_WEIGHTS=C:\Ninefer-3090\models\qwen3_8_27b.ninfer
+NINFER_QWEN3_8_27B_DFLASH2_WEIGHTS=C:\Ninefer-3090\models\qwen3_8_27b_dflash2.ninfer
+NINFER_QWEN3_6_35B_A3B_WEIGHTS=C:\Ninefer-3090\models\qwen3_6_35b_a3b.ninfer
+NINFER_QWEN3_6_27B_WEIGHTS=C:\Ninefer-3090\models\qwen3_6_27b.ninfer
+NINFER_REAL_TEST_MAX_CONTEXT=8192      # only needed for the 35B
+```
+
+**Free VRAM decides whether these pass or skip**, not correctness — see §1.2. Close GPU clients
+first and check `nvidia-smi`.
+
+### Open pull requests
+
+- **#32 — `docs/config-calculator.html`.** Open, `CHANGES_REQUESTED`, and the review is right:
+  §2b lists its confirmed defects. Do not merge it as-is; README deliberately does **not** link to
+  it yet, precisely so master carries no pointer to a page that undercounts speculative memory.
+  Land §2b's fixes first, then add the links (README "Choosing a KV format", `docs/cli.md`,
+  `docs/perplexity.md`, `docs/rtx-3090-windows.md`).
+- **#34 — shell-script line endings.** Small and self-contained. Two launchers did not parse on
+  Linux at all; see the note below. Merge this one first, it touches nothing else.
+- A worktree at `.claude/worktrees/eager-baking-cascade` exists and has been used by a second agent
+  working the same branches. **Check `git worktree list` before assuming a branch is free**, and
+  `git fetch` before pushing: concurrent work on `fix/artifact-download-revisions` was duplicated
+  once this cycle because of exactly that.
+
+### Windows tooling hides Linux breakage, and did
+
+`scripts/run-qwen36-35b-a3b-c1-maxctx.sh` and `scripts/run-qwen38-c1-maxctx.sh` — the two launchers
+README recommends as *the* Linux entry point, both shipped in the Linux release archive — had CRLF
+committed and **would not parse on Linux at all**:
+
+```
+run-qwen36-35b-a3b-c1-maxctx.sh: line 84: syntax error near unexpected token `$'in\r''
+```
+
+Inside a `case` block the stray CR joins the `in` token. Those two files are the only ones with a
+`case`, which is why only they were fatal while the tree looked healthy. Fixed in #34, with the
+policy pinned in `.gitattributes` and a guard added to `check-linux-scripts.sh`.
+
+**The lesson is the part worth keeping.** Every tool on this box reported the tree clean: Git Bash
+strips CR on read so `bash -n` passed, `check-linux-scripts.sh` passed, and Git Bash's `grep`
+translates CR away so searching for them returned nothing — a loop using it called all 26 shell
+scripts clean while two were 141 and 114 CRLF pairs deep. `core.autocrlf=input` was already set and
+did not help, because the blobs predate it. It was visible only from **real Linux bash under WSL**,
+or by reading bytes with .NET. When something is claimed to work on Linux and has only been checked
+here, run it under `wsl -e bash` before believing it.
+
+### Measurement scripts
+
+`scripts/sweeps/` holds the PowerShell that produced every number in §2b, README's KV table and the
+calculator. They are committed because §2b asks for re-measurement and reconstructing them is an
+hour of work. Read `scripts/sweeps/README.md` first — it records which of them answer which
+question, and which one produced a wrong answer and why.
 
 ---
 
@@ -213,10 +291,24 @@ listed with the evidence so nobody has to re-derive it.
       | CUDA graph allowance | 12,582,912 | 90,177,536 | +74 MiB | **no** |
       | workspace | 159,981,568 | 159,981,568 | 0 | n/a |
 
-      `graphBytes` is hardcoded at 12,582,912, which is only right with speculation off. The
-      sequence delta contains an extra KV component that appears to scale with capacity rather than
-      being constant, so this cannot be patched as a flat per-mode offset — measure whether the
-      speculative KV term is per-token before choosing a shape for it.
+      `graphBytes` is hardcoded at 12,582,912, which is only right with speculation off.
+
+      **The speculative KV term is per-token, and it is one constant.** Measured across all six
+      formats on the 27B, MTP3 + draft head raises KV bytes/token by the same **6.26%** every time:
+
+      | format | none | mtp3+head | ratio |
+      |---|---:|---:|---:|
+      | `bf16` | 65,536 | 69,638.4 | 1.0626 |
+      | `int8` | 33,792 | 35,907.3 | 1.0626 |
+      | `fp8` | 33,024 | 35,091.2 | 1.0626 |
+      | `rk8v4` | 26,112 | 27,746.6 | 1.0626 |
+      | `k8v4` | 25,728 | 27,338.5 | 1.0626 |
+      | `nvfp4` | 18,432 | 19,585.8 | 1.0626 |
+
+      So the fix is a per-token multiplier on the cache plus a per-mode constant for the graph
+      allowance and sequence delta, not a flat offset. Only MTP3 + draft head was swept; DFlash and
+      DFlash2 need the same treatment before their rows can be trusted. Raw CSVs come from
+      `scripts/sweeps/kv-decode-with-speculation.ps1`.
 
 - [ ] **KV is allocated in 64-token pages; the page charges exact tokens.** `KV page groups
       4096 / 4096` at a 262,144 context is 64 tokens per group. A context just past a page boundary
@@ -285,6 +377,17 @@ doing:
 ---
 
 ## 5. Reproducibility
+
+- [ ] **The speculative decode sweep measures acceptance, not depth, and cannot be read like the
+      non-speculative one.** `scripts/sweeps/kv-decode-with-speculation.ps1` produced 35B INT8 at
+      212.19 tok/s on a 4,096-token cache and **316.83 tok/s on a 32,768-token one** — faster
+      deeper, which is not physical. Acceptance went 58.3% → 100% between those two points, and on
+      the fixed `bench_corpus.ids` a draft can simply be right every time on a repetitive stretch.
+      Several rows sit at exactly 100%. So those tok/s figures describe what the corpus does to the
+      draft, not what depth does to attention, and none of them are in README or the calculator for
+      that reason. Speculative throughput needs a corpus with realistic diversity, or many more
+      repetitions, before it means anything. The memory columns from the same run **are** sound —
+      they are read at load and do not depend on the corpus.
 
 - [ ] **The published perplexity figures for fp8, k8v4 and nvfp4 are single runs of a
       non-deterministic path.** README's six-format table and the calculator both carry

--- a/TODO.md
+++ b/TODO.md
@@ -19,11 +19,17 @@ In flight: #21 (this file), #26 (503 during startup), #27 (q4 SwiGLU retune), #2
 1. **The `T=112` graph-replay failure** (§1.1). The only open item that could be a correctness
    defect in *released* code. Four hypotheses are already ruled out — read that entry first, it
    will save a day.
-2. **The two test-criterion outliers** (§4). Small, the last loose ends from the §5 audit, and
+2. **The calculator's speculative and page-rounding errors** (§2b). README now points people at
+   that page to size configurations, so it being wrong is a live defect rather than documentation
+   debt. The two memory ones are measured and specified; they need implementing, not investigating.
+3. **Re-run the six real-model tests** (§1.2, §2). Their artifact blockers are gone as of #31 and
+   nobody has looked since; at least one is expected to fail rather than skip.
+4. **The two test-criterion outliers** (§4). Small, the last loose ends from the §5 audit, and
    neither needs hardware this box lacks.
-3. **The real-model maximum-configuration decision** (§1.2). A judgement call more than a task.
+5. **The real-model maximum-configuration decision** (§1.2). A judgement call more than a task.
 
-Everything else is blocked on hardware/artifacts (§2) or is measurement debt (§3).
+Only one open item now needs hardware this box lacks (§2). The rest is measurement debt (§3),
+calibration (§4) or policy calls (§6).
 
 **Keep `investigate/small-t-upstream` until the next catch-up.** It is merged, but it is the clean
 record of how upstream's small-T was adopted and what had to be fixed (`19c7617c` and its parents).
@@ -104,6 +110,12 @@ The next merge from `neroued/master` will touch the same subsystem.
       `35b_a3b_dflash_load_plan`. Some fail environmentally on this host rather than from a defect
       — see `ninfer-3090-35b-real-tests-environmental` in memory.
 
+      **The artifact half of this is now gone** (2026-09-08): the Qwen3.6 27B artifact and a
+      DFlash-carrying 35B are both local and pinned, per §2. Nobody has re-run the six since. Do
+      that before treating any of them as blocked, and expect at least one real failure rather than
+      a skip — `27b_score_real` was last seen reporting *a repeated score window inherited prior
+      State/KV*, which is a defect the missing artifact was masking.
+
 #### Running the real-model tests here (verified 2026-09-07, idle GPU)
 
 ```
@@ -147,29 +159,91 @@ once the 20.8 GiB of weights are resident.
 
 ## 2. Genuinely blocked, and what by
 
-This section previously read "blocked on hardware or artifacts" and lumped three items together.
-That was wrong on one of them and imprecise on another — **only one needs hardware this box does
-not have.** Check before assuming an entry here is unreachable.
+This section once read "blocked on hardware or artifacts" and lumped three items together. Two of
+those three were not blocked at all, and both have since been closed by going and looking. **Exactly
+one open item needs hardware this box does not have.** Check before assuming an entry here is
+unreachable — this section has a poor record of being right about that.
 
-### Needs a second GPU — one item
+### Needs a second GPU — one item, and it is the only one
 
 - [ ] **DFlash2 + multi-GPU expert offload.** `nvidia-smi` reports exactly one device here, so the
       offload path degenerates to the single-rank identity mapping and there is nothing to
       exercise. Needs the two-card box or a second local GPU. More interesting now that PR #15 has
       landed and the offload path is no longer hypothetical.
 
-### Needs an artifact we do not have — not a hardware limit
+### Needs an artifact we do not have — nothing is left here
 
-- [ ] **`--spec dflash` (v1) on 35B-A3B.** Refused by the 27B artifact ("selected masked draft
-      backend is not supported by this target") because v1 is a 35B backend — correct behaviour.
-      The local `qwen3_6_35b_a3b.ninfer` (20.84 GB, revision `c8b8c1c0`) carries **no DFlash
-      bundle**: `ninfer_qwen3_6_35b_a3b_dflash_load_plan_test` skips with "this artifact carries no
-      DFlash bundle". So this needs a DFlash-carrying 35B artifact, not a bigger card. Worth
-      checking whether `neroued/Qwen3.6-35B-A3B-NInfer` publishes one at another revision before
-      treating it as out of reach.
-The six skipping real-model tests in §1.2 are mostly this same shape — four of them want a
-Qwen3.6 27B artifact, a different model family from the `qwen3_8_27b` held locally. Tracked there
-rather than duplicated here.
+Both entries are closed. The suggestion one of them carried — "check whether
+`neroued/Qwen3.6-35B-A3B-NInfer` publishes one at another revision before treating it as out of
+reach" — was the right instinct and paid off: it did. Kept rather than deleted because the pattern
+recurs, and because the follow-on work below only exists now that they are gone.
+
+- [x] **`--spec dflash` (v1) on 35B-A3B** — resolved 2026-09-08. Revision `560f227e` (now `main`)
+      carries the DFlash bundle; `c8b8c1c0` predates it. `scripts/download-qwen36-35b-a3b.{sh,bat}`
+      and `flake.nix` are pinned to it as of #31. Loading with `--spec dflash --draft-tokens 3`
+      reports 21,448,523,264 bytes of weights against 21,038,469,632 with `--spec` unset — exactly
+      the 410,053,632-byte on-disk difference between the two revisions, so **carrying DFlash costs
+      nothing resident unless it is selected**, and the published 24 GB profiles still apply.
+- [x] **The Qwen3.6 27B artifact** — downloaded and pinned at `faaa0c14` (#31), so the four tests
+      in §1.2 that wanted it are no longer artifact-blocked.
+
+### Unblocked, and now owed work
+
+- [ ] **Re-run the six real-model tests now that both artifacts exist** (§1.2). Their skip reasons
+      are gone; what actually passes on this box is unknown. `27b_score_real` in particular was
+      last seen failing with *a repeated score window inherited prior State/KV* — a genuine defect
+      the missing artifact was hiding, not an environmental skip.
+
+---
+
+## 2b. `docs/config-calculator.html` is advertised as authoritative and is not yet correct
+
+Added by #32, and README now points people at it to size configurations, which raises the bar for
+its arithmetic. Three of these were found by review and then confirmed by measurement; they are
+listed with the evidence so nobody has to re-derive it.
+
+- [ ] **Speculative modes undercount memory by roughly 170 MiB, plus a per-token term.** The page
+      models speculation as a weights delta only. Measured on the 27B at `--max-ctx 40960`, INT8,
+      `none` against `mtp3 + --lm-head-draft`:
+
+      | component | none | mtp3+head | delta | modelled? |
+      |---|---:|---:|---:|---|
+      | weights | 17,093,490,688 | 17,901,798,400 | +771 MiB | yes |
+      | sequence | 1,550,561,536 | 1,646,461,184 | +91.5 MiB | **no** |
+      | CUDA graph allowance | 12,582,912 | 90,177,536 | +74 MiB | **no** |
+      | workspace | 159,981,568 | 159,981,568 | 0 | n/a |
+
+      `graphBytes` is hardcoded at 12,582,912, which is only right with speculation off. The
+      sequence delta contains an extra KV component that appears to scale with capacity rather than
+      being constant, so this cannot be patched as a flat per-mode offset — measure whether the
+      speculative KV term is per-token before choosing a shape for it.
+
+- [ ] **KV is allocated in 64-token pages; the page charges exact tokens.** `KV page groups
+      4096 / 4096` at a 262,144 context is 64 tokens per group. A context just past a page boundary
+      reserves a whole further page, so both the memory figure and the largest-context result
+      should round to a page. Every context measured so far happens to be page-aligned, which is
+      why this never showed up in the validation against the engine's own refusal message.
+
+- [ ] **Sub-4,096 decode is reported at the wrong depth.** `decodeAtDepth` returns the 4,096-token
+      measurement for every context from 256 up, and the UI then labels it `interpolated` when no
+      interpolation happened. The honest fix is to measure: 1,024 and 2,048 are cheap, and short
+      contexts are exactly where a casual user starts.
+
+- [ ] **The model selector does not name the artifact each row was measured against.** `27b` means
+      `qwen3_8_27b.ninfer` specifically; the runtime has separate load plans and device capacities
+      per weight profile, so `weightsBytes` is not transferable to, say, the NVFP4-weight variant.
+      Either add the weight-profile dimension or label each row with its artifact.
+
+- [ ] **No regression coverage for any of the arithmetic.** Nothing references the page or its
+      functions. The memory model is small and pure — extracting it and pinning page rounding,
+      speculative reservations and the interpolation boundaries would catch all of the above
+      silently regressing.
+
+- [ ] **Active docs still contradict the six-format claim.** #32 fixed README's `Current limits`
+      and `docs/perplexity.md`, but README's *opening* summary still says the FP8 E4M3 KV profile
+      "is not" admitted on SM86, and `docs/cli.md` and `docs/serving.md` were not touched. All six
+      formats are measured and working; the Blackwell restriction applies to FP8/NVFP4 *weights and
+      activations*, not KV storage. Fix them together so the claim is consistent everywhere.
 
 ---
 
@@ -212,6 +286,22 @@ doing:
 
 ## 5. Reproducibility
 
+- [ ] **The published perplexity figures for fp8, k8v4 and nvfp4 are single runs of a
+      non-deterministic path.** README's six-format table and the calculator both carry
+      `fp8 4.347181` and `k8v4 4.347596`, a gap of 0.0096%, and those two formats are named in the
+      entry directly below as not run-to-run deterministic. 261,167 scored tokens should average
+      most of that away, but nobody has checked, so **the fp8-versus-k8v4 ordering may not be
+      real** — and it is currently the stated reason for preferring one over the other. One repeat
+      run of each settles it; if the spread is comparable to the gap, say so beside the numbers
+      rather than ranking them. `bf16`, `int8` and `rk8v4` are unaffected: the same entry records
+      those as byte-identical across runs.
+
+- [ ] **fp8 and k8v4 are dominated on all three axes and nothing says so structurally.** Each is
+      beaten by `rk8v4` on size, decode-at-depth and perplexity simultaneously (README's table).
+      That is a documentation statement today; decide whether it should be more — de-emphasised in
+      `--help`, or left fully available on the grounds that upstream parity is worth more than
+      steering. Not a defect either way, but the measurement is in and the decision is not.
+
 - [ ] **fp8, k8v4 and nvfp4 causal attention are not run-to-run deterministic.** Running
       `ninfer_softmax_attention_test` twice from the *same binary* produces ~36 differing
       `OP_ERROR_STATS` lines, always in those three storage families (plus a couple of bf16 geometry
@@ -231,6 +321,20 @@ doing:
       VRAM, and names `--host-kv-mib` and `--no-prefix-reuse`. It did not change the sizing, which
       is a policy question needing its own measurement: what "available" means differs by OS, and
       shrinking it silently would regress prefix reuse for people who have the memory.
+- [ ] **The unpinned downloaders cannot verify anything they fetch.** #31 gave the pinned
+      downloaders revision-scoped staging plus size and SHA-256 verification. `download-qwen38-27b`
+      (both the script and the flake entry) and `flake.nix`'s `download-qwen36-35b-v2` deliberately
+      track upstream `main`, so they have no expected size or hash to check against: a truncated or
+      corrupt 17 GB download is accepted silently and, because `main` can move between runs, they
+      cannot safely resume either. Pinning `qwen3_8_27b` would close it at the cost of freezing
+      people to a revision that goes stale — a policy call, not a bug. Whatever is decided, the
+      asymmetry should be stated where people choose a downloader.
+
+- [ ] **`package-release-rtx4090-early1.ps1` has no Linux counterpart.** `check-linux-scripts.sh`
+      requires every `.bat`/`.ps1` to have one, and #31 exempted this file by name so the check
+      could run at all. Either write the counterpart or leave the exemption, but it is a list that
+      will rot silently if release packaging grows another Windows-only script.
+
 - [ ] **Binaries embed their build directory.** `/home/ash/ninfer-rel/src/...` appears 200 times in
       the Linux binaries and `C:\ninfer-fork\ninfer-3090\...` about 466 times in the Windows ones,
       via `__FILE__` and nvcc source paths. Pre-existing (v0.8.1 embedded `/mnt/c/ninfer-fork/...`
@@ -292,6 +396,46 @@ hardcoded chain. `w8_pair` k=2048 had a table that *was* read, but whose distinc
 on this hardware. So `grep resolve_plan` is necessary and not sufficient — also grep the launchers
 for `NINFER_SM8X_COMPAT`, and confirm in the sweep, where identical schedules print *identical*
 times.
+
+---
+
+## Measuring memory and capacity, because two of these were dead ends
+
+**`ninfer_bench` cannot tell you the automatic-sizing context.** Running it with `-n 1` and no
+`-p` and letting `--kv-capacity` default resolves `max_context` to **3**: auto-sizing follows the
+*workload*, not the card. It looks like a plausible answer in the CSV and is nothing of the sort.
+Use the serving path instead — `apps/ninfer --prompt hi --max-new 1 --kv-capacity auto` prints
+`KV capacity` in its summary — and note the answer moves with free VRAM, so it is a property of
+the box at that moment, not of the format.
+
+**Never derive a per-token cost from a single context length.** `sequence_capacity_bytes` minus
+`kv_payload_bytes` divided by one context looks exactly like 4,063.5 B/token on the 27B. Measured
+at 8K/16K/32K/64K it resolves to `166,438,656 + 0.0625 × ctx` — a *fixed* 158.7 MiB block plus a
+sixteenth of a byte per token. The single-point reading understates memory by 127 MiB at 8K and
+overstates it by 349 MiB at 131K. Two points distinguish the shapes; four confirm it.
+
+**`sequence_capacity_bytes` contains `kv_payload_bytes`.** They are not additive. Summing the two
+columns double-counts the whole cache.
+
+**The engine will check your arithmetic for you.** Ask for a context that does not fit and the
+refusal names the exact requirement: `minimum Engine runtime reservation requires 9197389568 bytes
+in addition to 1073741824 bytes of automatic headroom`. That figure is
+`kv_per_token × ctx + fixed sequence block + 0.0625 × ctx + workspace + graph allowance`, to the
+byte, and `--kv-capacity auto` holds back a further 1 GiB on top. Cheaper than any probe, and it
+is the number the runtime actually applies.
+
+---
+
+## Guards that exit early can silently disable everything after them
+
+`scripts/check-linux-scripts.sh` had been failing on master for some time, at a counterpart rule
+near the top, so none of its downloader coverage below had been running — which is how the curl
+fixture in it went stale unnoticed. A check that exits non-zero *is* visible in CI, but only as
+"the check failed", and the failing line was unrelated to the part that mattered. When a guard
+script grows sections, either make it accumulate failures and report them all at the end, or be
+suspicious when the first failure is something cosmetic: everything downstream is then untested,
+not passing. Same shape as the dead route table in the note above — the thing that looked live
+was not running.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -49,11 +49,15 @@ first and check `nvidia-smi`.
 
 ### Open pull requests
 
-- **#32 — `docs/config-calculator.html`.** Open, `CHANGES_REQUESTED`, and the review is right:
-  §2b lists its confirmed defects. Do not merge it as-is; README deliberately does **not** link to
-  it yet, precisely so master carries no pointer to a page that undercounts speculative memory.
-  Land §2b's fixes first, then add the links (README "Choosing a KV format", `docs/cli.md`,
-  `docs/perplexity.md`, `docs/rtx-3090-windows.md`).
+- **#32 — `docs/config-calculator.html`.** Open and now `APPROVED`, but **approved is not finished
+  here**: three of the six confirmed defects are fixed on that branch and two are not. The branch
+  itself says so, carrying a `KNOWN GAP (see TODO.md)` comment where speculative memory should be
+  modelled. See §2b for which is which. Merging it is a judgement call — the page is useful and
+  honest about its gap, but nothing anywhere links to it yet, deliberately, so that master carries
+  no pointer to a page that undercounts speculative configurations by ~170 MiB. **If you merge it,
+  close the speculation gap first, then add the links** (README "Choosing a KV format",
+  `docs/cli.md`, `docs/perplexity.md`, `docs/rtx-3090-windows.md`). The multiplier needed for that
+  fix is measured and recorded in §2b.
 - **#34 — shell-script line endings.** Small and self-contained. Two launchers did not parse on
   Linux at all; see the note below. Merge this one first, it touches nothing else.
 - A worktree at `.claude/worktrees/eager-baking-cascade` exists and has been used by a second agent
@@ -97,9 +101,9 @@ question, and which one produced a wrong answer and why.
 1. **The `T=112` graph-replay failure** (§1.1). The only open item that could be a correctness
    defect in *released* code. Four hypotheses are already ruled out — read that entry first, it
    will save a day.
-2. **The calculator's speculative and page-rounding errors** (§2b). README now points people at
-   that page to size configurations, so it being wrong is a live defect rather than documentation
-   debt. The two memory ones are measured and specified; they need implementing, not investigating.
+2. **The calculator's speculative-memory gap** (§2b). The one remaining correctness defect on #32,
+   and the multiplier that fixes it is already measured — implementing, not investigating. Worth
+   doing before anything links to that page.
 3. **Re-run the six real-model tests** (§1.2, §2). Their artifact blockers are gone as of #31 and
    nobody has looked since; at least one is expected to fail rather than skip.
 4. **The two test-criterion outliers** (§4). Small, the last loose ends from the §5 audit, and
@@ -276,9 +280,13 @@ recurs, and because the follow-on work below only exists now that they are gone.
 
 ## 2b. `docs/config-calculator.html` is advertised as authoritative and is not yet correct
 
-Added by #32, and README now points people at it to size configurations, which raises the bar for
-its arithmetic. Three of these were found by review and then confirmed by measurement; they are
-listed with the evidence so nobody has to re-derive it.
+Added by #32. Six defects were raised in review and confirmed by measurement; **three are fixed on
+that branch and two are not**, so read the checkboxes rather than assuming the PR being approved
+means it is done. The evidence is kept with each entry so nobody has to re-derive it.
+
+Fixed on #32 as it stands: KV page rounding, sub-4,096 decode (now labelled a lower bound held at
+the shallowest measurement rather than claimed as interpolated), and per-row weight-artifact
+labelling. The doc contradictions were fixed separately in #33.
 
 - [ ] **Speculative modes undercount memory by roughly 170 MiB, plus a per-token term.** The page
       models speculation as a weights delta only. Measured on the 27B at `--max-ctx 40960`, INT8,
@@ -310,18 +318,18 @@ listed with the evidence so nobody has to re-derive it.
       DFlash2 need the same treatment before their rows can be trusted. Raw CSVs come from
       `scripts/sweeps/kv-decode-with-speculation.ps1`.
 
-- [ ] **KV is allocated in 64-token pages; the page charges exact tokens.** `KV page groups
+- [x] **KV is allocated in 64-token pages; the page charges exact tokens.** Fixed on #32. `KV page groups
       4096 / 4096` at a 262,144 context is 64 tokens per group. A context just past a page boundary
       reserves a whole further page, so both the memory figure and the largest-context result
       should round to a page. Every context measured so far happens to be page-aligned, which is
       why this never showed up in the validation against the engine's own refusal message.
 
-- [ ] **Sub-4,096 decode is reported at the wrong depth.** `decodeAtDepth` returns the 4,096-token
+- [x] **Sub-4,096 decode is reported at the wrong depth.** Fixed on #32, by labelling rather than by measuring — it now reads "lower bound, held at the 4,096-token measurement". Measuring 1,024 and 2,048 would still be better and is cheap. `decodeAtDepth` returns the 4,096-token
       measurement for every context from 256 up, and the UI then labels it `interpolated` when no
       interpolation happened. The honest fix is to measure: 1,024 and 2,048 are cheap, and short
       contexts are exactly where a casual user starts.
 
-- [ ] **The model selector does not name the artifact each row was measured against.** `27b` means
+- [x] **The model selector does not name the artifact each row was measured against.** Fixed on #32. `27b` means
       `qwen3_8_27b.ninfer` specifically; the runtime has separate load plans and device capacities
       per weight profile, so `weightsBytes` is not transferable to, say, the NVFP4-weight variant.
       Either add the weight-profile dimension or label each row with its artifact.
@@ -331,7 +339,7 @@ listed with the evidence so nobody has to re-derive it.
       speculative reservations and the interpolation boundaries would catch all of the above
       silently regressing.
 
-- [ ] **Active docs still contradict the six-format claim.** #32 fixed README's `Current limits`
+- [x] **Active docs still contradict the six-format claim.** Fixed in #33, across four places. #32 fixed README's `Current limits`
       and `docs/perplexity.md`, but README's *opening* summary still says the FP8 E4M3 KV profile
       "is not" admitted on SM86, and `docs/cli.md` and `docs/serving.md` were not touched. All six
       formats are measured and working; the Blackwell restriction applies to FP8/NVFP4 *weights and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -247,9 +247,15 @@ Use `--kv-dtype int8` for the recommended large-context quality profile; BF16 is
 Artifact identity selects the weight profile; `--kv-dtype` selects runtime KV storage. All six
 formats — `bf16`, `int8`, `fp8`, `rk8v4`, `k8v4`, `nvfp4` — are accepted on SM86; measured size,
 decode speed and perplexity for each are in
-[`docs/config-calculator.html`](config-calculator.html). `rk8v4` (RotorQuant: rotated INT8 keys
-with a packed signed int4 value plane) is the best all-round choice — about 23% smaller than int8
-with the flattest decode falloff measured, for about 0.08% perplexity. The prepared prompt must fit
+[`docs/config-calculator.html`](config-calculator.html). The Blackwell-only
+`mma.sync...kind::f8f6f4` restriction applies to FP8/NVFP4 *weights and activations*, not to KV
+storage, which is why this paragraph used to say `fp8` KV was rejected here.
+
+`rk8v4` is the best all-round choice: rotated INT8 keys with a packed signed int4 value plane,
+about 23% smaller than INT8 for about 0.082% perplexity, and the flattest decode curve of any
+format measured. `nvfp4` buys the most context — 45% smaller than INT8 — at about 13% of decode
+speed at a 32K cache depth. `fp8` and `k8v4` are each beaten by `rk8v4` on size, speed and quality
+together, so neither has a niche. The prepared prompt must fit
 `--max-context`; generation stops at the remaining context capacity when necessary.
 `--kv-capacity N` controls the shared physical Main Text KV pool independently and is rounded up to
 the 64-token page size. `--kv-capacity auto` loads the selected weights, measures the remaining GPU

--- a/docs/rtx-3090-windows.md
+++ b/docs/rtx-3090-windows.md
@@ -97,7 +97,8 @@ top-level field `"reasoning_effort": "xhigh"`; Responses uses
 `"reasoning": {"effort": "xhigh"}`. The CLI accepts
 `--reasoning-effort low|medium|xhigh`.
 
-The paged cache supports BF16, INT8, and experimental opt-in `rk8v4` storage. INT8 remains the
+The paged cache supports six KV formats — `bf16`, `int8`, `fp8`, `rk8v4`, `k8v4` and `nvfp4`.
+INT8 remains the
 recommended default. On the development RTX 3090, `rk8v4` raises the measured automatic-sizing
 boundary from 171,648 to 226,560 tokens at 1 GiB headroom, for 5.51 GiB of KV against INT8's
 5.40 GiB.

--- a/scripts/sweeps/README.md
+++ b/scripts/sweeps/README.md
@@ -1,0 +1,67 @@
+# KV and speculation sweeps
+
+The PowerShell behind every number in TODO §2b, README's "Choosing a KV format" table, and
+`docs/config-calculator.html`. Committed because §2b asks for re-measurement and reconstructing
+these is an hour of work, not because they are polished tooling.
+
+All of them expect a Release `build-ninja` and run from the repository root:
+
+```powershell
+$env:NINFER_MODEL_DIR = 'C:\Ninefer-3090\models'   # default; override for another box
+$env:NINFER_SWEEP_OUT = 'profiles\sweeps'          # default; gitignored
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\kv-decode-vs-depth.ps1
+```
+
+They print a CSV summary to stdout and leave per-run `ninfer_bench` CSVs and logs under
+`$NINFER_SWEEP_OUT`. **Read the CSVs, not the console summary** — the summary is a convenience and
+has been wrong before (see the note at the bottom).
+
+Each takes a while and holds the GPU exclusively. Run one at a time; `kv-decode-vs-depth.ps1` took
+about three hours for twelve model/format combinations.
+
+## Which script answers which question
+
+| script | question | roughly |
+|---|---|---|
+| `kv-decode-vs-depth.ps1` | How does each KV format's decode rate change with cache depth? | 3 h |
+| `kv-decode-with-speculation.ps1` | Same, with MTP3 + draft head, capturing acceptance | 2 h |
+| `kv-perplexity.ps1` | What does each KV format cost in perplexity? | 1 h |
+| `memory-linearity-and-dflash-residency.ps1` | Is the non-KV sequence cost per-token or fixed? | 20 min |
+| `dflash-residency-and-auto-capacity.ps1` | Does carrying DFlash cost VRAM when unused? | 15 min |
+| `speculation-matrix.ps1` | What does each speculative backend cost and buy? | 1 h |
+
+## Things these got wrong, so you do not repeat them
+
+**Decode must be measured at depth.** A `tg128` run seeds one token, so the cache is ~128 deep and
+every KV format looks identical. Use `-pg P,128`: prefill *P* tokens, then time 128 decode steps on
+top of that cache. Prefill and decode are timed separately, so the result is decode-only at a real
+depth. This is the whole reason the sweeps take hours.
+
+**`sequence_capacity_bytes` contains `kv_payload_bytes`.** They are not additive. Summing them
+double-counts the entire cache.
+
+**Never derive a per-token cost from one context length.** `sequence - kv_payload` at a single
+context looks exactly like 4,063.5 B/token on the 27B. Measured at 8K/16K/32K/64K it resolves to
+`166,438,656 + 0.0625 × ctx` — a *fixed* 158.7 MiB block plus a sixteenth of a byte per token. The
+single-point reading understates memory by 127 MiB at 8K and overstates it by 349 MiB at 131K.
+That is what `memory-linearity-and-dflash-residency.ps1` exists to settle.
+
+**`ninfer_bench` cannot measure the automatic-sizing context.** With `-n 1` and no `-p`, auto-sizing
+follows the *workload* and resolves `max_context` to **3**. It lands in the CSV looking like a real
+answer. Use the serving path instead: `apps\ninfer --prompt hi --max-new 1 --kv-capacity auto`
+prints `KV capacity` in its summary. Note the answer moves with free VRAM, so it describes the box
+at that moment, not the format.
+
+**The loader rejects any file not ending `.ninfer`.** The pre-DFlash 35B artifact was kept as
+`.ninfer.pre-dflash.bak` and silently could not be loaded at all — "NInfer accepts only .ninfer
+artifacts". It now lives as `qwen3_6_35b_a3b_v1_no_dflash.ninfer`.
+
+**`kind` is `pp+tg`, not `prefill_decode`.** The original summary filter matched nothing, so these
+scripts printed an empty table while writing perfectly good CSVs. Fixed here, but it is why the
+advice above is to trust the CSVs.
+
+**The engine will check your arithmetic.** Ask for a context that does not fit and the refusal names
+the exact requirement: `minimum Engine runtime reservation requires 9197389568 bytes in addition to
+1073741824 bytes of automatic headroom`. That equals
+`kv_per_token × ctx + fixed sequence block + 0.0625 × ctx + workspace + graph allowance`, to the
+byte. Cheaper than any probe, and it is the number the runtime actually applies.

--- a/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
+++ b/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
@@ -1,9 +1,14 @@
 $ErrorActionPreference = 'Continue'
-Set-Location 'C:\ninfer-fork\ninfer-3090'
+# Run from the repository root regardless of where this is invoked from, rather than a hardcoded
+# path: these are committed, and the next person's checkout will not be at C:\ninfer-fork.
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-# Model directory, overridable so these are not welded to one machine.
+# Both overridable so this is not welded to one machine. The output directory is created here
+# because it does not exist in a clean checkout -- profiles/ is gitignored.
 $modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
-$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
 $mdir = $modelDir
 
 # The loader rejects anything not named *.ninfer, which is why the first attempt at the DFlash

--- a/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
+++ b/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
@@ -52,7 +52,11 @@ foreach ($m in @(@{k='27b-dense'; p="$mdir\qwen3_8_27b.ninfer"},
         --kv-dtype $d --max-context 262144 --kv-capacity auto > $log 2>&1
     $code = $LASTEXITCODE
     $txt = Get-Content $log -Raw
-    $cap = if ($txt -match '(?m)^.*KV capacity.*$') { $Matches[0].Trim() }
+    # Require digits. The summary prints three lines containing "KV capacity" -- "KV capacity
+    # policy  auto", "KV capacity  262144" and "KV capacity headroom  1.00 GiB" -- and a match on
+    # the phrase alone takes the first, reporting the string "auto" as though it were the measured
+    # capacity. Only the numeric line has a bare integer after it.
+    $cap = if ($txt -match '(?m)^\s*summary\s+KV capacity\s+(\d+)\s*$') { $Matches[1] }
            else { "exit=$code no-kv-line" }
     "$($m.k),$d,$cap"
   }

--- a/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
+++ b/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
@@ -1,0 +1,55 @@
+$ErrorActionPreference = 'Continue'
+Set-Location 'C:\ninfer-fork\ninfer-3090'
+
+# Model directory, overridable so these are not welded to one machine.
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+$mdir = $modelDir
+
+# The loader rejects anything not named *.ninfer, which is why the first attempt at the DFlash
+# residency probe failed on the .pre-dflash.bak backup. Rename rather than copy: this artifact is
+# 20.84 GB and a copy would cost real disk for no reason. The new name is also clearer than a .bak
+# suffix about what the file actually is.
+$oldBak = "$mdir\qwen3_6_35b_a3b.ninfer.pre-dflash.bak"
+$v1     = "$mdir\qwen3_6_35b_a3b_v1_no_dflash.ninfer"
+if ((Test-Path $oldBak) -and -not (Test-Path $v1)) { Move-Item -LiteralPath $oldBak -Destination $v1 }
+"v1 artifact present: $(Test-Path $v1)"
+
+"== dflash residency =="
+"artifact,spec,weights_bytes,host_to_device_bytes,artifact_bytes"
+foreach ($a in @(@{k='v1-no-dflash'; p=$v1},
+                 @{k='v2-dflash';    p="$mdir\qwen3_6_35b_a3b.ninfer"})) {
+  if (-not (Test-Path $a.p)) { "$($a.k),,MISSING,,"; continue }
+  $sz = (Get-Item $a.p).Length
+  foreach ($s in @(@{l='none';a=@()}, @{l='dflash-3';a=@('--spec','dflash','--draft-tokens','3')})) {
+    $csv = "$out\dfc2_$($a.k)_$($s.l).csv"
+    $argv = @('--weights',$a.p,'--kv-dtype','int8','--max-ctx','8192',
+              '-n','1','-r','1','--warmup','0','-o','csv','--output-file',$csv) + $s.a
+    & .\build-ninja\bench\ninfer_bench.exe @argv > "$out\dfc2_$($a.k)_$($s.l).log" 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $csv)) {
+      "$($a.k),$($s.l),FAILED,,$sz"
+      Get-Content "$out\dfc2_$($a.k)_$($s.l).log" -Tail 2 | ForEach-Object { "    $_" }
+      continue
+    }
+    $r = Import-Csv $csv | Select-Object -First 1
+    "$($a.k),$($s.l),$($r.weights_capacity_bytes),$($r.load_host_to_device_bytes),$sz"
+  }
+}
+
+# Automatic-sizing context per format, via the serving path rather than the bench harness.
+"== auto capacity =="
+"model,kv,kv_capacity_line"
+foreach ($m in @(@{k='27b-dense'; p="$mdir\qwen3_8_27b.ninfer"},
+                 @{k='35b-moe';   p="$mdir\qwen3_6_35b_a3b.ninfer"})) {
+  foreach ($d in @('bf16','int8','fp8','rk8v4','k8v4','nvfp4')) {
+    $log = "$out\cap_$($m.k)_$d.log"
+    & .\build-ninja\apps\ninfer.exe $m.p --prompt hi --max-new 1 --greedy `
+        --kv-dtype $d --max-context 262144 --kv-capacity auto > $log 2>&1
+    $code = $LASTEXITCODE
+    $txt = Get-Content $log -Raw
+    $cap = if ($txt -match '(?m)^.*KV capacity.*$') { $Matches[0].Trim() }
+           else { "exit=$code no-kv-line" }
+    "$($m.k),$d,$cap"
+  }
+}
+"== done =="

--- a/scripts/sweeps/kv-decode-vs-depth.ps1
+++ b/scripts/sweeps/kv-decode-vs-depth.ps1
@@ -1,10 +1,14 @@
 $ErrorActionPreference = 'Continue'
-Set-Location 'C:\ninfer-fork\ninfer-3090'
+# Run from the repository root regardless of where this is invoked from, rather than a hardcoded
+# path: these are committed, and the next person's checkout will not be at C:\ninfer-fork.
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-# Model directory, overridable so these are not welded to one machine.
+# Both overridable so this is not welded to one machine. The output directory is created here
+# because it does not exist in a clean checkout -- profiles/ is gitignored.
 $modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
-$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
+
 
 # Decode cost of a KV dtype scales with cache DEPTH: attention re-reads the whole cache every
 # step, so a tg128 run seeded with one token (~128 deep) cannot show the effect at all. Each

--- a/scripts/sweeps/kv-decode-vs-depth.ps1
+++ b/scripts/sweeps/kv-decode-vs-depth.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = 'Continue'
+Set-Location 'C:\ninfer-fork\ninfer-3090'
+
+# Model directory, overridable so these are not welded to one machine.
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+# Decode cost of a KV dtype scales with cache DEPTH: attention re-reads the whole cache every
+# step, so a tg128 run seeded with one token (~128 deep) cannot show the effect at all. Each
+# -pg P,128 case prefills P tokens and then times 128 decode steps on top of that cache, which
+# is the number a user at P tokens of context actually feels. Depths share one process per
+# dtype so the model loads once. --max-ctx is pinned across every run so capacity is a control
+# rather than a variable.
+$models = @(
+  @{ key='27b-dense'; path="$modelDir\qwen3_8_27b.ninfer" },
+  @{ key='35b-moe';   path="$modelDir\qwen3_6_35b_a3b.ninfer" }
+)
+$dtypes = @('bf16','int8','fp8','rk8v4','k8v4','nvfp4')
+
+"model,kv,depth,decode_tok_s,stddev,kv_payload_bytes"
+foreach ($m in $models) {
+  foreach ($d in $dtypes) {
+    $csv = "$out\$($m.key)_$d.csv"
+    $log = "$out\$($m.key)_$d.log"
+    & .\build-ninja\bench\ninfer_bench.exe `
+        --weights $m.path --kv-dtype $d --max-ctx 40960 `
+        -pg '4096,128;16384,128;32768,128' -r 3 --warmup 1 `
+        -o csv --output-file $csv > $log 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $csv)) {
+      "$($m.key),$d,ALL,FAILED,,"
+      Get-Content $log -Tail 3 | ForEach-Object { "    $_" }
+      continue
+    }
+    foreach ($r in Import-Csv $csv) {
+      if ($r.kind -ne 'pp+tg') { continue }
+      "$($m.key),$d,$($r.n_prompt),$($r.decode_output_tok_s_mean),$($r.decode_output_tok_s_stddev),$($r.kv_payload_bytes)"
+    }
+  }
+}

--- a/scripts/sweeps/kv-decode-with-speculation.ps1
+++ b/scripts/sweeps/kv-decode-with-speculation.ps1
@@ -1,10 +1,14 @@
 $ErrorActionPreference = 'Continue'
-Set-Location 'C:\ninfer-fork\ninfer-3090'
+# Run from the repository root regardless of where this is invoked from, rather than a hardcoded
+# path: these are committed, and the next person's checkout will not be at C:\ninfer-fork.
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-# Model directory, overridable so these are not welded to one machine.
+# Both overridable so this is not welded to one machine. The output directory is created here
+# because it does not exist in a clean checkout -- profiles/ is gitignored.
 $modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
-$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
+
 
 # The second channel by which KV dtype moves decode speed. README already records that rk8v4 drops
 # MTP acceptance 71.27% -> 65.86% on the 27B: a coarser value plane changes which tokens the draft

--- a/scripts/sweeps/kv-decode-with-speculation.ps1
+++ b/scripts/sweeps/kv-decode-with-speculation.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = 'Continue'
+Set-Location 'C:\ninfer-fork\ninfer-3090'
+
+# Model directory, overridable so these are not welded to one machine.
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+# The second channel by which KV dtype moves decode speed. README already records that rk8v4 drops
+# MTP acceptance 71.27% -> 65.86% on the 27B: a coarser value plane changes which tokens the draft
+# proposes, and acceptance turns on exact token agreement rather than mean error. That effect is
+# larger than the memory-traffic one, so a speed table built only from unspeculated runs would
+# recommend the wrong dtype to anyone running MTP. Captures acceptance alongside tok/s so the two
+# channels can be told apart rather than conflated.
+$models = @(
+  @{ key='27b-dense'; path="$modelDir\qwen3_8_27b.ninfer" },
+  @{ key='35b-moe';   path="$modelDir\qwen3_6_35b_a3b.ninfer" }
+)
+$dtypes = @('bf16','int8','fp8','rk8v4','k8v4','nvfp4')
+
+"model,kv,depth,decode_tok_s,stddev,spec_acceptance,kv_payload_bytes"
+foreach ($m in $models) {
+  foreach ($d in $dtypes) {
+    $csv = "$out\spec_$($m.key)_$d.csv"
+    $log = "$out\spec_$($m.key)_$d.log"
+    & .\build-ninja\bench\ninfer_bench.exe `
+        --weights $m.path --kv-dtype $d --max-ctx 40960 `
+        --spec mtp --draft-tokens 3 --lm-head-draft `
+        -pg '4096,128;32768,128' -r 3 --warmup 1 `
+        -o csv --output-file $csv > $log 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $csv)) {
+      "$($m.key),$d,ALL,FAILED,,,"
+      Get-Content $log -Tail 3 | ForEach-Object { "    $_" }
+      continue
+    }
+    foreach ($r in Import-Csv $csv) {
+      # kind_string() emits "pp+tg" for a PrefillDecode test, not "prefill_decode".
+      if ($r.kind -ne 'pp+tg') { continue }
+      "$($m.key),$d,$($r.n_prompt),$($r.decode_output_tok_s_mean),$($r.decode_output_tok_s_stddev),$($r.spec_acceptance_rate),$($r.kv_payload_bytes)"
+    }
+  }
+}

--- a/scripts/sweeps/kv-perplexity.ps1
+++ b/scripts/sweeps/kv-perplexity.ps1
@@ -1,0 +1,30 @@
+$ErrorActionPreference = 'Continue'
+Set-Location 'C:\ninfer-fork\ninfer-3090'
+
+# Model directory, overridable so these are not welded to one machine.
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+
+# Same corpus, mode and window as the three already recorded in README.md, so the new rows are
+# directly comparable rather than a separate experiment: ninfer-ppl-1m-v1, --quick, 4096/2048.
+$dtypes = @('fp8','nvfp4','k8v4')
+$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+foreach ($d in $dtypes) {
+    $log = "$out\$d.log"
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    & .\build-ninja\apps\ninfer-perplexity.exe `
+        "$modelDir\qwen3_8_27b.ninfer" `
+        --corpus 'eval\corpora\perplexity-1m\manifest.json' --quick `
+        --context 4096 --stride 2048 --kv-dtype $d `
+        --output "$out\$d" --log-level warning > $log 2>&1
+    $code = $LASTEXITCODE
+    $report = Get-ChildItem -Recurse -Filter report.json "$out\$d" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($report) {
+        $j = Get-Content $report.FullName -Raw | ConvertFrom-Json
+        "{0,-7} ppl={1}  tokens={2}  {3}s" -f $d, $j.overall.perplexity, $j.overall.scored_tokens, [math]::Round($sw.Elapsed.TotalSeconds,0)
+    } else {
+        "{0,-7} FAILED (exit {1})" -f $d, $code
+        Get-Content $log -Tail 3 | ForEach-Object { "        $_" }
+    }
+}

--- a/scripts/sweeps/kv-perplexity.ps1
+++ b/scripts/sweeps/kv-perplexity.ps1
@@ -16,6 +16,11 @@ $dtypes = @('fp8','nvfp4','k8v4')
 
 foreach ($d in $dtypes) {
     $log = "$out\$d.log"
+    # Clear any previous run's output first. ninfer-perplexity writes report.json under a
+    # timestamped subdirectory of --output, so a rerun that fails leaves the earlier report in
+    # place and the check below would pick it up and print it as a fresh result -- a stale number
+    # reported as a new measurement, which is the one failure mode a sweep must not have.
+    Remove-Item -Recurse -Force "$out\$d" -ErrorAction SilentlyContinue
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     & .\build-ninja\apps\ninfer-perplexity.exe `
         "$modelDir\qwen3_8_27b.ninfer" `
@@ -24,7 +29,9 @@ foreach ($d in $dtypes) {
         --output "$out\$d" --log-level warning > $log 2>&1
     $code = $LASTEXITCODE
     $report = Get-ChildItem -Recurse -Filter report.json "$out\$d" -ErrorAction SilentlyContinue | Select-Object -First 1
-    if ($report) {
+    # Exit code as well as the report's existence: a run that produced a report and then failed
+    # should be reported as a failure, not quietly read.
+    if ($code -eq 0 -and $report) {
         $j = Get-Content $report.FullName -Raw | ConvertFrom-Json
         "{0,-7} ppl={1}  tokens={2}  {3}s" -f $d, $j.overall.perplexity, $j.overall.scored_tokens, [math]::Round($sw.Elapsed.TotalSeconds,0)
     } else {

--- a/scripts/sweeps/kv-perplexity.ps1
+++ b/scripts/sweeps/kv-perplexity.ps1
@@ -1,14 +1,18 @@
 $ErrorActionPreference = 'Continue'
-Set-Location 'C:\ninfer-fork\ninfer-3090'
+# Run from the repository root regardless of where this is invoked from, rather than a hardcoded
+# path: these are committed, and the next person's checkout will not be at C:\ninfer-fork.
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-# Model directory, overridable so these are not welded to one machine.
+# Both overridable so this is not welded to one machine. The output directory is created here
+# because it does not exist in a clean checkout -- profiles/ is gitignored.
 $modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
 
 # Same corpus, mode and window as the three already recorded in README.md, so the new rows are
 # directly comparable rather than a separate experiment: ninfer-ppl-1m-v1, --quick, 4096/2048.
 $dtypes = @('fp8','nvfp4','k8v4')
-$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
-New-Item -ItemType Directory -Force -Path $out | Out-Null
 
 foreach ($d in $dtypes) {
     $log = "$out\$d.log"

--- a/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
+++ b/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
@@ -14,30 +14,14 @@ $models = @(
   @{ key='27b-dense'; path="$modelDir\qwen3_8_27b.ninfer" },
   @{ key='35b-moe';   path="$modelDir\qwen3_6_35b_a3b.ninfer" }
 )
-$dtypes = @('bf16','int8','fp8','rk8v4','k8v4','nvfp4')
 
-# ---------------------------------------------------------------------------------------------
-# 1. Automatic-sizing context per dtype. README publishes this for int8 and rk8v4 only; the engine
-#    resolves it against a headroom boundary rather than a fixed byte budget, so it cannot be
-#    derived from bytes-per-token and has to be read off a real load. No --max-ctx = auto.
-# ---------------------------------------------------------------------------------------------
-"== auto capacity =="
-"model,kv,auto_max_context,kv_payload_bytes"
-foreach ($m in $models) {
-  foreach ($d in $dtypes) {
-    $csv = "$out\auto_$($m.key)_$d.csv"
-    & .\build-ninja\bench\ninfer_bench.exe --weights $m.path --kv-dtype $d `
-        -n 1 -r 1 --warmup 0 -o csv --output-file $csv > "$out\auto_$($m.key)_$d.log" 2>&1
-    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $csv)) {
-      "$($m.key),$d,FAILED,"
-      Get-Content "$out\auto_$($m.key)_$d.log" -Tail 2 | ForEach-Object { "    $_" }
-      continue
-    }
-    $r = Import-Csv $csv | Select-Object -First 1
-    "$($m.key),$d,$($r.max_context),$($r.kv_payload_bytes)"
-  }
-}
-
+# This script used to open with an "automatic-sizing context per dtype" probe that ran
+# ninfer_bench with no -p and -n 1 and read max_context back out of the CSV. It does not measure
+# that. With no prompt lengths and a one-token generation, auto-sizing follows the *workload*, and
+# the answer comes back as 3 -- a number that lands in the CSV looking entirely legitimate. It has
+# been removed rather than fixed, because ninfer_bench cannot answer the question at all: use the
+# serving path, which dflash-residency-and-auto-capacity.ps1 does.
+#
 # ---------------------------------------------------------------------------------------------
 # 2. Does carrying DFlash cost anything when DFlash is not selected? docs/rtx-3090-windows.md
 #    recommends the older, 0.38 GiB smaller pin on the grounds that it is what qualified the 24 GB

--- a/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
+++ b/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
@@ -1,0 +1,85 @@
+$ErrorActionPreference = 'Continue'
+Set-Location 'C:\ninfer-fork\ninfer-3090'
+
+# Model directory, overridable so these are not welded to one machine.
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+$models = @(
+  @{ key='27b-dense'; path="$modelDir\qwen3_8_27b.ninfer" },
+  @{ key='35b-moe';   path="$modelDir\qwen3_6_35b_a3b.ninfer" }
+)
+$dtypes = @('bf16','int8','fp8','rk8v4','k8v4','nvfp4')
+
+# ---------------------------------------------------------------------------------------------
+# 1. Automatic-sizing context per dtype. README publishes this for int8 and rk8v4 only; the engine
+#    resolves it against a headroom boundary rather than a fixed byte budget, so it cannot be
+#    derived from bytes-per-token and has to be read off a real load. No --max-ctx = auto.
+# ---------------------------------------------------------------------------------------------
+"== auto capacity =="
+"model,kv,auto_max_context,kv_payload_bytes"
+foreach ($m in $models) {
+  foreach ($d in $dtypes) {
+    $csv = "$out\auto_$($m.key)_$d.csv"
+    & .\build-ninja\bench\ninfer_bench.exe --weights $m.path --kv-dtype $d `
+        -n 1 -r 1 --warmup 0 -o csv --output-file $csv > "$out\auto_$($m.key)_$d.log" 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $csv)) {
+      "$($m.key),$d,FAILED,"
+      Get-Content "$out\auto_$($m.key)_$d.log" -Tail 2 | ForEach-Object { "    $_" }
+      continue
+    }
+    $r = Import-Csv $csv | Select-Object -First 1
+    "$($m.key),$d,$($r.max_context),$($r.kv_payload_bytes)"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------
+# 2. Does carrying DFlash cost anything when DFlash is not selected? docs/rtx-3090-windows.md
+#    recommends the older, 0.38 GiB smaller pin on the grounds that it is what qualified the 24 GB
+#    profiles. If those bytes are only resident when --spec dflash is chosen, that objection is
+#    moot and the DFlash-bearing revision is strictly the better default.
+# ---------------------------------------------------------------------------------------------
+"== dflash residency =="
+"artifact,spec,weights_bytes,host_to_device_bytes"
+$artifacts = @(
+  @{ key='v1-no-dflash'; path="$modelDir\qwen3_6_35b_a3b_v1_no_dflash.ninfer" },
+  @{ key='v2-dflash';    path="$modelDir\qwen3_6_35b_a3b.ninfer" }
+)
+foreach ($a in $artifacts) {
+  if (-not (Test-Path $a.path)) { "$($a.key),,MISSING,"; continue }
+  foreach ($s in @(@{l='none';a=@()}, @{l='dflash-3';a=@('--spec','dflash','--draft-tokens','3')})) {
+    $csv = "$out\dfc_$($a.key)_$($s.l).csv"
+    $argv = @('--weights',$a.path,'--kv-dtype','int8','--max-ctx','8192',
+              '-n','1','-r','1','--warmup','0','-o','csv','--output-file',$csv) + $s.a
+    & .\build-ninja\bench\ninfer_bench.exe @argv > "$out\dfc_$($a.key)_$($s.l).log" 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $csv)) {
+      "$($a.key),$($s.l),FAILED,"
+      Get-Content "$out\dfc_$($a.key)_$($s.l).log" -Tail 2 | ForEach-Object { "    $_" }
+      continue
+    }
+    $r = Import-Csv $csv | Select-Object -First 1
+    "$($a.key),$($s.l),$($r.weights_capacity_bytes),$($r.load_host_to_device_bytes)"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------
+# 3. Confirm the per-token model has no fixed intercept. The speed sweeps all pin --max-ctx 40960,
+#    so they show the slope at one point only; if sequence capacity has a constant term, every
+#    context estimate in the calculator is biased by it.
+# ---------------------------------------------------------------------------------------------
+"== per-token linearity =="
+"model,kv,max_ctx,kv_payload_bytes,sequence_bytes"
+foreach ($m in $models) {
+  foreach ($d in @('int8','nvfp4')) {
+    foreach ($c in @(8192, 16384, 32768, 65536)) {
+      $csv = "$out\mem_$($m.key)_$($d)_$c.csv"
+      & .\build-ninja\bench\ninfer_bench.exe --weights $m.path --kv-dtype $d --max-ctx $c `
+          -n 1 -r 1 --warmup 0 -o csv --output-file $csv > "$out\mem_$($m.key)_$($d)_$c.log" 2>&1
+      if ($LASTEXITCODE -ne 0 -or -not (Test-Path $csv)) { "$($m.key),$d,$c,FAILED,"; continue }
+      $r = Import-Csv $csv | Select-Object -First 1
+      "$($m.key),$d,$c,$($r.kv_payload_bytes),$($r.sequence_capacity_bytes)"
+    }
+  }
+}
+"== done =="

--- a/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
+++ b/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
@@ -1,10 +1,14 @@
 $ErrorActionPreference = 'Continue'
-Set-Location 'C:\ninfer-fork\ninfer-3090'
+# Run from the repository root regardless of where this is invoked from, rather than a hardcoded
+# path: these are committed, and the next person's checkout will not be at C:\ninfer-fork.
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-# Model directory, overridable so these are not welded to one machine.
+# Both overridable so this is not welded to one machine. The output directory is created here
+# because it does not exist in a clean checkout -- profiles/ is gitignored.
 $modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
-$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
+
 
 $models = @(
   @{ key='27b-dense'; path="$modelDir\qwen3_8_27b.ninfer" },

--- a/scripts/sweeps/speculation-matrix.ps1
+++ b/scripts/sweeps/speculation-matrix.ps1
@@ -1,0 +1,45 @@
+$ErrorActionPreference = 'Continue'
+Set-Location 'C:\ninfer-fork\ninfer-3090'
+
+# Model directory, overridable so these are not welded to one machine.
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+$models = @(
+  @{ key='27b-dense';   path="$modelDir\qwen3_8_27b.ninfer" },
+  @{ key='27b-dflash2'; path="$modelDir\qwen3_8_27b_dflash2.ninfer" },
+  @{ key='35b-moe';     path="$modelDir\qwen3_6_35b_a3b.ninfer" }
+)
+
+# spec label -> extra args. dflash2 only exists on the dflash2 artifact; dflash v1 only on the 35B.
+$configs = @(
+  @{ label='none';            args=@();                                                  models=@('27b-dense','27b-dflash2','35b-moe') },
+  @{ label='mtp3';            args=@('--spec','mtp','--draft-tokens','3');               models=@('27b-dense','27b-dflash2','35b-moe') },
+  @{ label='mtp3+head';       args=@('--spec','mtp','--draft-tokens','3','--lm-head-draft'); models=@('27b-dense','27b-dflash2','35b-moe') },
+  @{ label='dflash2-7';       args=@('--spec','dflash2','--draft-tokens','7');           models=@('27b-dflash2') },
+  @{ label='dflash2-7+head';  args=@('--spec','dflash2','--draft-tokens','7','--lm-head-draft'); models=@('27b-dflash2') },
+  @{ label='dflash-3';        args=@('--spec','dflash','--draft-tokens','3');            models=@('35b-moe') },
+  @{ label='dflash-3+head';   args=@('--spec','dflash','--draft-tokens','3','--lm-head-draft'); models=@('35b-moe') }
+)
+
+"model,spec,kv,decode_tok_s,stddev,weights_gib,sequence_mib,workspace_mib,kv_payload_mib,spec_acc,spec_round"
+foreach ($m in $models) {
+  foreach ($c in $configs) {
+    if ($c.models -notcontains $m.key) { continue }
+    $log = "$out\$($m.key)_$($c.label).log"
+    $a = @('--weights', $m.path, '--kv-dtype','int8','--max-ctx','8192','-n','128','-r','3','--warmup','1') + $c.args
+    & .\build-ninja\bench\ninfer_bench.exe @a > $log 2>&1
+    if ($LASTEXITCODE -ne 0) { "$($m.key),$($c.label),int8,FAILED,,,,,,,"; continue }
+
+    $txt = Get-Content $log -Raw
+    $dec = if ($txt -match 'tg128\s+\S+\s+\S+\s+\S+\s+([\d.]+)\s*±\s*([\d.]+)') { $Matches[1],$Matches[2] } else { '','' }
+    $wt  = if ($txt -match 'weights ([\d.]+) GiB')      { $Matches[1] } else { '' }
+    $seq = if ($txt -match 'sequence ([\d.]+) MiB')     { $Matches[1] } else { '' }
+    $wsp = if ($txt -match 'workspace ([\d.]+) MiB')    { $Matches[1] } else { '' }
+    $kvp = if ($txt -match 'KV payload ([\d.]+) MiB')   { $Matches[1] } else { '' }
+    $acc = if ($txt -match 'tg128.*?(\d+\.\d+)%')       { $Matches[1] } else { '' }
+    $rnd = if ($txt -match '(\d+\.\d+)\s+[\d.]+ MiB\s*$') { $Matches[1] } else { '' }
+    "$($m.key),$($c.label),int8,$($dec[0]),$($dec[1]),$wt,$seq,$wsp,$kvp,$acc,$rnd"
+  }
+}

--- a/scripts/sweeps/speculation-matrix.ps1
+++ b/scripts/sweeps/speculation-matrix.ps1
@@ -1,10 +1,14 @@
 $ErrorActionPreference = 'Continue'
-Set-Location 'C:\ninfer-fork\ninfer-3090'
+# Run from the repository root regardless of where this is invoked from, rather than a hardcoded
+# path: these are committed, and the next person's checkout will not be at C:\ninfer-fork.
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-# Model directory, overridable so these are not welded to one machine.
+# Both overridable so this is not welded to one machine. The output directory is created here
+# because it does not exist in a clean checkout -- profiles/ is gitignored.
 $modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
-$out = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { "profiles\sweeps" }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
+
 
 $models = @(
   @{ key='27b-dense';   path="$modelDir\qwen3_8_27b.ninfer" },


### PR DESCRIPTION
Nine new items, two closures and three notes, from building the fit calculator and
the KV sweeps behind it.

### New: §2b, the calculator is advertised as authoritative and is not yet correct

README now points people at `docs/config-calculator.html` to size configurations,
so its arithmetic is load-bearing. Three errors are confirmed by measurement, not
suspected, and each entry carries the numbers:

| component | none | mtp3+head | delta | modelled? |
|---|---:|---:|---:|---|
| weights | 17,093,490,688 | 17,901,798,400 | +771 MiB | yes |
| sequence | 1,550,561,536 | 1,646,461,184 | +91.5 MiB | **no** |
| CUDA graph | 12,582,912 | 90,177,536 | +74 MiB | **no** |

Plus: KV is allocated in 64-token pages (`KV page groups 4096 / 4096` at 262,144)
while the page charges exact tokens, and every context below 4,096 is reported at
the 4,096 measurement and labelled `interpolated` when no interpolation happened.

### Closed: both artifact blockers in §2

`--spec dflash` on the 35B closed exactly the way its own note suggested it might
-- by checking whether another revision published what we needed. It had. Loading
`560f227e` with `--spec dflash --draft-tokens 3` reports 21,448,523,264 bytes
against 21,038,469,632 with `--spec` unset, so carrying DFlash costs nothing
resident unless selected.

Two of the three items that section once called blocked turned out not to be,
which is now said in the section intro.

### A caveat on numbers this cycle published

README's six-format perplexity table is single runs, and three of those formats
are named two sections below as not run-to-run deterministic. The fp8-versus-k8v4
gap is 0.0096% and is currently the stated reason to prefer one over the other.
That ordering needs one repeat run before it can be trusted.

### Three notes, each a dead end that cost time

- `ninfer_bench` cannot measure automatic-sizing context: with `-n 1` and no `-p`
  it resolves to the workload, returning a plausible-looking 3.
- A per-token cost derived from a single context length is indistinguishable from
  a fixed block, and was wrong by 127-349 MiB depending on direction.
- `check-linux-scripts.sh` had been exiting at an unrelated cosmetic rule, so
  everything below it was untested rather than passing -- the same shape as the
  dead route table already recorded further down.