### PR TITLE
fix(scripts): the two -maxctx launchers do not parse on Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,22 @@
 # default whitespace checks.
 /third_party/spdlog/include/** -whitespace
 /third_party/spdlog/src/** -whitespace
+
+# Shell scripts must be LF in the repository and in every checkout, not merely normalised on
+# commit. `core.autocrlf=input` was not enough: every .sh in scripts/ had CRLF committed, and
+# scripts/run-qwen36-35b-a3b-c1-maxctx.sh and scripts/run-qwen38-c1-maxctx.sh -- the two launchers
+# the README recommends as the Linux entry point -- would not parse on Linux at all:
+#
+#     syntax error near unexpected token `$'in\r''
+#
+# A `case` block is where a stray CR becomes fatal rather than merely ugly, which is why only those
+# two failed and the rest looked fine. Git Bash strips CR on read, so a Windows box reports every
+# script healthy; the breakage only appears for the people the Linux archive ships to.
+*.sh text eol=lf
+*.bash text eol=lf
+
+# The Windows counterparts want CRLF for the same reason, and pinning both directions keeps the
+# pairs from drifting apart on whichever platform last touched them.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/scripts/check-linux-scripts.sh
+++ b/scripts/check-linux-scripts.sh
@@ -8,6 +8,20 @@ trap 'rm -rf -- "$tmp"' EXIT
 for script in "$root"/*.sh; do
   bash -n "$script"
 done
+
+# CRLF in a shell script is not cosmetic. Inside a `case` block the stray CR becomes part of the
+# `in` token and Linux bash refuses the file outright -- which is exactly what happened to
+# run-qwen36-35b-a3b-c1-maxctx.sh and run-qwen38-c1-maxctx.sh, the two launchers the README
+# recommends as the Linux entry point. `bash -n` above catches that particular shape, but a CRLF
+# script without a `case` parses and then misbehaves at runtime instead, so check the bytes.
+#
+# -U forces binary matching. Without it, Git Bash's grep translates CR away and reports every file
+# clean on a Windows checkout, which is how this survived as long as it did.
+crlf="$(LC_ALL=C grep -lU $'\r' "$root"/*.sh "$root"/*/*.sh 2>/dev/null || true)"
+if [[ -n "$crlf" ]]; then
+  printf 'Shell scripts with CRLF line endings (must be LF; see .gitattributes):\n%s\n' "$crlf" >&2
+  exit 1
+fi
 # Deliberately Windows-only, so exempt from the counterpart rule. Named individually rather than
 # pattern-matched: every other package-release-* does have a .sh sibling, and the rule is worth
 # keeping strict for the launchers and downloaders, where a missing counterpart actually strands

--- a/scripts/check-linux-scripts.sh
+++ b/scripts/check-linux-scripts.sh
@@ -17,9 +17,23 @@ done
 #
 # -U forces binary matching. Without it, Git Bash's grep translates CR away and reports every file
 # clean on a Windows checkout, which is how this survived as long as it did.
-crlf="$(LC_ALL=C grep -lU $'\r' "$root"/*.sh "$root"/*/*.sh 2>/dev/null || true)"
+#
+# Scoped to the whole repository rather than scripts/, because .gitattributes states the policy
+# repository-wide and eval/ already holds three shell scripts that a scripts/-only check would
+# never look at. Driven off `git ls-files` so a new directory is covered the day it appears
+# instead of the day someone remembers to add a glob here.
+repo_root="$(git -C "$root" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$root/..")"
+crlf=''
+while IFS= read -r candidate; do
+  [[ -f "$repo_root/$candidate" ]] || continue
+  if LC_ALL=C grep -qU $'\r' "$repo_root/$candidate"; then
+    crlf+="  $candidate"$'\n'
+  fi
+done < <(git -C "$repo_root" ls-files '*.sh' '*.bash' 2>/dev/null)
+
 if [[ -n "$crlf" ]]; then
-  printf 'Shell scripts with CRLF line endings (must be LF; see .gitattributes):\n%s\n' "$crlf" >&2
+  printf 'Shell scripts with CRLF line endings (must be LF; see .gitattributes):\n%s' "$crlf" >&2
+  printf 'Linux bash rejects these outright inside a `case` block.\n' >&2
   exit 1
 fi
 # Deliberately Windows-only, so exempt from the counterpart rule. Named individually rather than


### PR DESCRIPTION
`scripts/run-qwen36-35b-a3b-c1-maxctx.sh` and `scripts/run-qwen38-c1-maxctx.sh`
have CRLF committed -- 141 and 114 pairs -- and Linux bash refuses both:

```
run-qwen36-35b-a3b-c1-maxctx.sh: line 84: syntax error near unexpected token `$'in\r''
run-qwen38-c1-maxctx.sh:         line 65: syntax error near unexpected token `$'in\r''
```

Inside a `case` block the stray CR becomes part of the `in` token. Only these two
files contain a `case`, which is why only these two are fatal. They are also the
two the README recommends as **the** Linux entry point, and they ship in the Linux
release archive.

### Why this survived

Every tool on a Windows checkout hides it:

- Git Bash strips CR on read, so `bash -n` passes and `check-linux-scripts.sh`
  reported the whole tree healthy.
- Git Bash's `grep` translates CR away, so searching for them returns nothing --
  a loop using it reported all 26 shell scripts clean while these two were 141 and
  114 pairs deep.
- `core.autocrlf=input` is already set here and did not help, because the blobs
  were committed with CRLF before it mattered.

It is visible only from real Linux bash, or by reading the bytes. Found by running
the existing check under WSL.

### Changes

- Convert both files to LF.
- Pin the policy in `.gitattributes`: `*.sh`/`*.bash` are `eol=lf`,
  `*.bat`/`*.cmd`/`*.ps1` are `eol=crlf`, so the pairs cannot drift apart on
  whichever platform last touched them.
- Add an explicit CRLF guard to `check-linux-scripts.sh`. `bash -n` only catches
  the `case` shape; a CRLF script without one parses cleanly and misbehaves at
  runtime instead. The guard uses `grep -U` to force binary matching, since the
  default grep on a Windows checkout reports clean either way.

### Verification

Under GNU bash 5.2.21 (x86_64-pc-linux-gnu):

- all shell scripts parse, where two did not before;
- `check-linux-scripts.sh` passes there for the first time;
- reintroducing CRLF into one file makes the check fail under both Git Bash and
  Linux bash.