### PR TITLE
docs(todo): decode runs at 66% of the card's memory bandwidth

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -97,17 +97,20 @@ question, and which one produced a wrong answer and why.
 1. **The `T=112` graph-replay failure** (§1.1). The only open item that could be a correctness
    defect in *released* code. Four hypotheses are already ruled out — read that entry first, it
    will save a day.
-2. **DFlash2 currently costs 20% on the 27B** (§2c). A shipped v0.9.0 feature that is a net loss
+2. **Decode runs at 66% of the card's memory bandwidth** (§2c). The largest single number in this
+   file, it applies to every configuration rather than one feature, and no performance work here
+   has ever been measured against an absolute ceiling. Profile one decode step first.
+3. **DFlash2 currently costs 20% on the 27B** (§2c). A shipped v0.9.0 feature that is a net loss
    on text, and the cheapest possible first test -- sweep `--draft-tokens` below 7 -- has never
    been run.
-3. **The calculator's speculative-memory gap** (§2b). Now shipped on master and linked from
+4. **The calculator's speculative-memory gap** (§2b). Now shipped on master and linked from
    README, so it is live: every speculative configuration it reports is roughly 170 MiB optimistic.
    The multiplier that fixes it is already measured — implementing, not investigating.
-4. **Re-run the six real-model tests** (§1.2, §2). Their artifact blockers are gone as of #31 and
+5. **Re-run the six real-model tests** (§1.2, §2). Their artifact blockers are gone as of #31 and
    nobody has looked since; at least one is expected to fail rather than skip.
-5. **The two test-criterion outliers** (§4). Small, the last loose ends from the §5 audit, and
+6. **The two test-criterion outliers** (§4). Small, the last loose ends from the §5 audit, and
    neither needs hardware this box lacks.
-6. **The real-model maximum-configuration decision** (§1.2). A judgement call more than a task.
+7. **The real-model maximum-configuration decision** (§1.2). A judgement call more than a task.
 
 Only one open item now needs hardware this box lacks (§2). The rest is measurement debt (§3),
 calibration (§4) or policy calls (§6).
@@ -360,6 +363,68 @@ has to re-derive it.
 
 Nothing here was in this file before 2026-09-08, which is itself the point: the KV sweeps were run
 to document formats, and these fell out of the data on the way. Ordered by size of the prize.
+
+**Read the first entry before any of the others.** The rest of this section is specific kernels and
+features. The first one says the whole decode path has room in it, and no work here has ever been
+framed against a roofline — every performance change in this repository so far has been *relative*
+("this schedule beats that one"), never *absolute* ("this is N% of what the card can do"). That is
+the gap most likely to be hiding real speed.
+
+- [ ] **Dense decode runs at 65-66% of the card's memory bandwidth, and nobody has ever checked.**
+      Decode is memory-bound: each token streams the resident weights once plus the KV it attends
+      over. Against the 3090's 936.2 GB/s, from this cycle's own measurements (single lane, **no
+      speculation**, so tokens and weight-read rounds are the same thing):
+
+      | model | KV | depth | tok/s | achieved | % of peak |
+      |---|---|---:|---:|---:|---:|
+      | 27B dense | `int8` | 4,096 | 36.15 | 623 GB/s | **66.5%** |
+      | 27B dense | `int8` | 16,384 | 35.11 | 620 GB/s | **66.2%** |
+      | 27B dense | `int8` | 32,768 | 33.86 | 616 GB/s | **65.8%** |
+      | 27B dense | `rk8v4` | 32,768 | 33.54 | 602 GB/s | **64.3%** |
+
+      Flat across depth and across KV format, which says it is a property of the decode path rather
+      than of anything the KV work touched. A well-tuned memory-bound decode generally reaches
+      75-85% of peak. Closing even half that gap is roughly **36 → 41 tok/s on the 27B**, which is
+      larger than everything else in this section combined and applies to every configuration
+      rather than one feature.
+
+      This is a headline number, not a diagnosis: it says the room exists, not where it is. Next
+      step is a profile of one decode step (`--profile-measured` exists on `ninfer_bench`) to find
+      where the stall is — occupancy, L2 behaviour, or a launch gap between the per-layer kernels.
+
+- [ ] **Nobody knows where the MoE sits at all, because the accounting does not exist.** Applying
+      the same arithmetic to the 35B returns *391% of peak*, which is not a result, it is a proof
+      that the formula does not apply: an A3B MoE activates a fraction of its 21.04 GB per token,
+      so it never reads resident weights the way the dense model does. The bytes actually touched
+      per token — shared attention weights plus whichever experts route — have never been counted,
+      so there is no denominator, and therefore no way to say whether the 35B's 174 tok/s is close
+      to its ceiling or half of it. **Do that accounting before optimising anything on the MoE
+      path**; it is arithmetic over the artifact's layer inventory, not a measurement.
+
+- [ ] **Eight lanes buy 3.2x, not 8x, and the reason is unestablished.** README's own cohort table
+      has C1 decode at 78.71 tok/s against C8 at 250.26. Batched decode amortises the weight read
+      across the whole cohort — the same bytes serve every lane in a round — so a weight-bound
+      decode should scale much closer to linearly until compute takes over. Somewhere between one
+      lane and eight, something other than weight bandwidth becomes the limit, and no document says
+      what. Worth knowing: C8 is the profile the 27B release recommends for multi-user serving.
+
+      Careful with those particular numbers, though: they are end-to-end with MTP3 enabled, so
+      tokens per round is roughly `1 + 3 x acceptance` rather than 1, and dividing them into a
+      bandwidth figure gives nonsense (144% of peak at C1, doing it naively). The comparison needs
+      re-measuring without speculation before it can be reasoned about — `ninfer_bench` can do that
+      directly and the cohort table cannot.
+
+- [ ] **Prefill has no roofline either.** Measured this cycle at 1,254 tok/s on the 27B and 5,715
+      on the 35B at a 4,096-token prompt, falling to 1,087 and 4,302 by 32,768 — a 13% and 25%
+      decay that nothing explains or has looked at. Prefill is compute-bound rather than
+      bandwidth-bound, so the denominator is FLOPs and the accounting differs from decode; it has
+      not been done. Note the route tables *are* all measured (that work is finished), but measured
+      against each other, not against the hardware's ceiling.
+
+- [ ] **Vision has essentially one performance number in the entire repository.** One acceptance
+      figure for DFlash2 on the committed image fixture, and nothing about encode throughput,
+      how it scales with resolution, or what the overlay residency costs in time rather than in
+      bytes. It is an advertised feature of both models and it is unmeasured.
 
 - [ ] **DFlash2 makes the 27B *slower*, and no document says so.** Measured on one artifact
       (`qwen3_8_27b_dflash2.ninfer`), 8,192-token context, INT8 KV, tg128, three repetitions:

--- a/scripts/sweeps/README.md
+++ b/scripts/sweeps/README.md
@@ -29,6 +29,13 @@ about three hours for twelve model/format combinations.
 | `memory-linearity-and-dflash-residency.ps1` | Is the non-KV sequence cost per-token or fixed? | 20 min |
 | `dflash-residency-and-auto-capacity.ps1` | Does carrying DFlash cost VRAM when unused? | 15 min |
 | `speculation-matrix.ps1` | What does each speculative backend cost and buy? | 1 h |
+| `decode-roofline.ps1` | What fraction of the card's 936.2 GB/s does decode reach? | instant |
+
+`decode-roofline.ps1` needs no GPU: it reads the CSVs `kv-decode-vs-depth.ps1` leaves behind and
+divides achieved bandwidth by peak. Run that sweep first. Note it only means anything for the
+**dense** model -- applied to the A3B MoE it returns 391% of peak, which is not a result but a
+demonstration that the formula does not hold there, since an MoE never reads its resident weights
+per token. See TODO section 2c.
 
 ## Things these got wrong, so you do not repeat them
 

--- a/scripts/sweeps/decode-roofline.ps1
+++ b/scripts/sweeps/decode-roofline.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = 'Continue'
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
+$d = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+
+# Reads the CSVs that kv-decode-vs-depth.ps1 leaves behind -- run that first. Pure arithmetic, no
+# GPU needed.
+#
+# RTX 3090: 384-bit GDDR6X at 19.5 Gbps = 936.2 GB/s theoretical. Decode is memory-bound: every
+# token streams the resident weights once, plus the KV it attends over. So achieved bandwidth
+# divided by peak says how much of the card the decode path is actually using -- the single number
+# that says whether there is headroom left, independent of any kernel detail.
+$PEAK_GBs = 936.2
+
+"{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6}" -f 'model','kv','depth','tok/s','weights GB','KV GB','% of peak BW'
+foreach ($model in @('27b-dense','35b-moe')) {
+  foreach ($kv in @('int8','rk8v4')) {
+    $f = "$d\${model}_$kv.csv"
+    if (-not (Test-Path $f)) { continue }
+    foreach ($r in (Import-Csv $f | Where-Object { $_.kind -eq 'pp+tg' })) {
+      $tok    = [double]$r.decode_output_tok_s_mean
+      $wGB    = [double]$r.weights_capacity_bytes / 1e9
+      $perTok = [double]$r.kv_payload_bytes / 40960          # bytes of KV per token
+      $kvGB   = ($perTok * [double]$r.n_prompt) / 1e9        # KV actually attended at this depth
+      $bw     = ($wGB + $kvGB) * $tok
+      "{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6}" -f $model, $kv, $r.n_prompt,
+        ("{0:N2}" -f $tok), ("{0:N2}" -f $wGB), ("{0:N3}" -f $kvGB),
+        ("{0:N1}% ({1:N0} GB/s)" -f (100*$bw/$PEAK_GBs), $bw)
+    }
+  }
+}
+
+"`n=== prefill, for contrast (compute-bound rather than bandwidth-bound) ==="
+"{0,-10} {1,-7} {2,-8} {3}" -f 'model','kv','prompt','prefill tok/s'
+foreach ($model in @('27b-dense','35b-moe')) {
+  $f = "$d\${model}_int8.csv"
+  if (-not (Test-Path $f)) { continue }
+  foreach ($r in (Import-Csv $f | Where-Object { $_.kind -eq 'pp+tg' })) {
+    "{0,-10} {1,-7} {2,-8} {3}" -f $model, 'int8', $r.n_prompt, ("{0:N1}" -f [double]$r.prefill_tok_s_mean)
+  }
+}

--- a/scripts/sweeps/decode-roofline.ps1
+++ b/scripts/sweeps/decode-roofline.ps1
@@ -2,8 +2,13 @@ $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 $d = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 
-# Reads the CSVs that kv-decode-vs-depth.ps1 leaves behind -- run that first. Pure arithmetic, no
-# GPU needed.
+# Reads the per-run CSVs that kv-decode-vs-depth.ps1 leaves in $NINFER_SWEEP_OUT -- run that first.
+# Pure arithmetic, no GPU needed.
+#
+# Note those CSVs are ninfer_bench's own full output, written by --output-file, and carry every
+# column including weights_capacity_bytes. They are NOT the six-column summary that sweep prints to
+# stdout; that summary is a convenience for reading progress and drops most of the fields. The
+# files are the artifact. (kv-decode-vs-depth.ps1 writes "<model>_<kv>.csv"; this reads the same.)
 #
 # RTX 3090: 384-bit GDDR6X at 19.5 Gbps = 936.2 GB/s theoretical. Decode is memory-bound: every
 # token streams the resident weights once, plus the KV it attends over. So achieved bandwidth


### PR DESCRIPTION
The performance section added earlier today listed specific kernels and features. It
missed the more useful question: **what fraction of the hardware does the decode path
use at all?** Every performance change in this repository so far has been *relative* --
this schedule beats that one -- and none absolute.

### The number

Single lane, **no speculation**, so tokens and weight-read rounds are the same thing.
Against the 3090's 936.2 GB/s:

| model | KV | depth | tok/s | achieved | % of peak |
|---|---|---:|---:|---:|---:|
| 27B dense | `int8` | 4,096 | 36.15 | 623 GB/s | **66.5%** |
| 27B dense | `int8` | 16,384 | 35.11 | 620 GB/s | **66.2%** |
| 27B dense | `int8` | 32,768 | 33.86 | 616 GB/s | **65.8%** |
| 27B dense | `rk8v4` | 32,768 | 33.54 | 602 GB/s | **64.3%** |

Flat across depth and KV format, so it is a property of the decode path rather than of
anything the KV work touched. Well-tuned memory-bound decode generally reaches 75-85%.
Half that gap is roughly **36 → 41 tok/s**, larger than everything else in section 2c
combined and applying to every configuration rather than one feature.

A headline, not a diagnosis. Next step is `ninfer_bench --profile-measured` on one
decode step to find whether it is occupancy, L2, or launch gaps between per-layer
kernels.

### Four things nobody has a number for, recorded as unknowns rather than guesses

- **The MoE has no denominator.** The same arithmetic returns *391% of peak* on the
  35B, which proves only that the formula does not apply -- an A3B activates a fraction
  of its 21.04 GB per token. Nobody has counted the bytes actually touched, so nobody
  can say whether 174 tok/s is near its ceiling or half of it. Do that counting before
  optimising anything on the MoE path.
- **Eight lanes buy 3.2x, not 8x** (README's own cohort table: C1 78.71, C8 250.26).
  Batched decode amortises the weight read across the cohort, so it should scale far
  closer to linearly. What becomes the limit is undocumented, and C8 is the recommended
  multi-user profile. Those numbers cannot answer it -- they bundle MTP3, so tokens per
  round is not 1 and dividing them into a bandwidth figure yields 144% of peak.
- **Prefill has no roofline**, and its 13-25% decay from 4K to 32K is unexplained.
- **Vision has one performance number in the entire repository.**

### Also

Commits `scripts/sweeps/decode-roofline.ps1`. Needs no GPU -- it reads the CSVs the
decode sweep leaves behind and divides achieved by peak. Verified reproducing the table
above from them.