### PR TITLE
fix(test): restore the capture DFlash2's sweep lambda needs to compile

### DIFF
--- a/tests/ops/softmax_attention/causal_cache.cpp
+++ b/tests/ops/softmax_attention/causal_cache.cpp
@@ -3309,7 +3309,11 @@ int run_dflash2_cases() {
     // run_batch_case/run_a1_case/run_a3_case are each overloaded on KvCacheStorage and CachePlan,
     // so one generic sweep body covers every registered profile -- including rk8v4, which the
     // public KvCacheStorage enum cannot select and only the CachePlan overload builds.
-    const auto sweep = [](auto storage) {
+    // `order` has to be captured explicitly: reading `order[b]` at a runtime index odr-uses it,
+    // and a lambda with no default capture cannot reach an automatic variable of the enclosing
+    // function however constant it is. Introducing this lambda without the capture is why this
+    // translation unit stopped compiling.
+    const auto sweep = [&order](auto storage) {
         int failures = 0;
         const auto run = [&](int width, int batch, int base) {
             BatchAttentionCase c{width, {}, {}, {}, MappingPattern::Fragmented,


### PR DESCRIPTION
`master` does not build.

`ac7d1191` (the review-feedback commit on #30) wrapped `run_dflash2_cases`' loop body in a
generic lambda so the sweep could run once more against the `CachePlan` overload for rk8v4.
The lambda was written with no capture list, and the body reads `order[b]` at a runtime
index — an odr-use of an automatic variable of the enclosing function, which a lambda with
no default capture cannot reach.

```
tests/ops/softmax_attention/causal_cache.cpp(3323): error C3493: 'order' cannot be implicitly
captured because no default capture mode has been specified
```
plus five follow-on errors.

**Why nobody noticed.** Nothing rebuilt that translation unit after the merge: its object
file predates the change, and every test run since measured the binary produced *before* it.
This is the stale-binary trap `TODO.md`'s build notes describe, in its most direct form — the
suite was reported 125/125 against a binary the tree can no longer produce.

Capturing `order` by reference is the whole fix. The sweep's behaviour is unchanged.

Everything else in flight depends on this one, so it goes first.