### PR TITLE
test(real): report why a real-model test threw, and pin the sm_86 NVFP4 bound

### DIFF
--- a/tests/targets/guarded_main.h
+++ b/tests/targets/guarded_main.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// A real-model test that throws should say what happened.
+//
+// Four of these tests had a bare `int main()` with nothing catching, so any exception -- an
+// artifact rejection, a CUDA failure during Engine construction, a std::filesystem error --
+// unwound out of main and Windows terminated the process with 0xC0000409, printing nothing at all.
+// CTest then reported `Exit code 0xc0000409` with no line to go on, which reads like memory
+// corruption and is not: e06d7363 in a debugger is a C++ throw. Recovering the message meant
+// attaching cdb.
+//
+// Use NINFER_GUARDED_TEST_MAIN(run) in place of `int main()`, with the body in a function
+// returning int. Exit codes are unchanged, including 77 for a skip.
+
+#include <exception>
+#include <iostream>
+
+#define NINFER_GUARDED_TEST_MAIN(run_function)                                                     \
+    int main() {                                                                                   \
+        try {                                                                                      \
+            return (run_function)();                                                               \
+        } catch (const std::exception& error) {                                                    \
+            std::cerr << "FATAL: " << error.what() << std::endl;                                   \
+            return 1;                                                                              \
+        } catch (...) {                                                                            \
+            std::cerr << "FATAL: unknown exception" << std::endl;                                  \
+            return 1;                                                                              \
+        }                                                                                          \
+    }

--- a/tests/targets/qwen3_6_27b/test_load_plan.cpp
+++ b/tests/targets/qwen3_6_27b/test_load_plan.cpp
@@ -1,3 +1,4 @@
+#include "targets/guarded_main.h"
 #include "artifact/binder.h"
 #include "artifact/reader.h"
 #include "targets/qwen3_6_27b/impl/load/bindings.h"
@@ -14,6 +15,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <variant>
 
 namespace {
@@ -315,6 +317,35 @@ int verify_vision_workspace_planning() {
         return std::move(planner).finalize(pages).workspace_capacity_bytes();
     };
 
+#if defined(NINFER_SM8X_COMPAT)
+    // This case plans the *NVFP4-weight* profile at a 1,024-token prefill chunk, and on sm_86 that
+    // cannot exist. NVFP4 weights need A4 execution, whose instructions are sm_100a/sm_120a only,
+    // so the policy degrades to A16Only -- and NVFP4 A16 linear_swiglu is registered through T=16
+    // and no further (src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.cpp). Any prefill chunk
+    // above 16 tokens is therefore unroutable, which is a property of the hardware rather than a
+    // defect.
+    //
+    // Assert the refusal instead of skipping it. Pinning the message keeps the limitation a stated
+    // contract: if NVFP4 A16 ever gains a wider registration this fails, and the numeric check
+    // below becomes reachable, which is exactly when someone should look at it. Skipping silently
+    // would leave the rest of this file unrun on this box -- it already was, and it was hiding an
+    // uncaught throw that CTest reported only as `Exit code 0xc0000409`.
+    try {
+        (void)workspace_capacity(16384);
+    } catch (const std::invalid_argument& error) {
+        const std::string_view message(error.what());
+        if (message.find("nvfp4 linear_swiglu A16 is registered only through T=16") ==
+            std::string_view::npos) {
+            std::cerr << "NVFP4 planning on sm_86 failed for an unexpected reason: " << message
+                      << '\n';
+            return 1;
+        }
+        return 0;
+    }
+    std::cerr << "NVFP4 vision workspace planning succeeded on sm_86, where A4 execution does not "
+                 "exist; the A16 T<=16 registration bound must have changed\n";
+    return 1;
+#else
     const std::size_t at_item_limit    = workspace_capacity(16384);
     const std::size_t above_item_limit = workspace_capacity(131072);
     if (at_item_limit != kExpectedMaximumItemWorkspace ||
@@ -325,11 +356,12 @@ int verify_vision_workspace_planning() {
         return 1;
     }
     return 0;
+#endif
 }
 
 } // namespace
 
-int main() {
+int run_load_plan_checks() {
     const std::filesystem::path groupwise =
         artifact_path("NINFER_QWEN3_6_27B_WEIGHTS", "qwen3_6_27b.ninfer");
     const std::filesystem::path nvfp4 =
@@ -386,3 +418,5 @@ int main() {
     }
     return 0;
 }
+
+NINFER_GUARDED_TEST_MAIN(run_load_plan_checks)

--- a/tests/targets/qwen3_6_27b/test_visual_scatter.cpp
+++ b/tests/targets/qwen3_6_27b/test_visual_scatter.cpp
@@ -1,3 +1,4 @@
+#include "targets/guarded_main.h"
 #include "ops/op_tester.h"
 #include "targets/qwen3_6_27b/impl/config.h"
 #include "targets/qwen3_6/impl/runtime/visual_scatter.h"
@@ -10,7 +11,7 @@
 using namespace ninfer;
 using namespace ninfer::test;
 
-int main() {
+int run_visual_scatter_checks() {
     if (cuda_unavailable()) {
         std::cout << "SKIP: no usable CUDA device\n";
         return 77;
@@ -67,3 +68,5 @@ int main() {
     std::cout << (failures ? "FAIL" : "OK") << " shifted visual composition\n";
     return failures ? 1 : 0;
 }
+
+NINFER_GUARDED_TEST_MAIN(run_visual_scatter_checks)

--- a/tests/targets/qwen3_6_35b_a3b/test_dflash_load_plan.cpp
+++ b/tests/targets/qwen3_6_35b_a3b/test_dflash_load_plan.cpp
@@ -1,3 +1,4 @@
+#include "targets/guarded_main.h"
 #include "artifact/binder.h"
 #include "artifact/reader.h"
 #include "targets/qwen3_6_35b_a3b/impl/load/bindings.h"
@@ -27,7 +28,7 @@ ninfer::targets::qwen3_6::StartupFeatures load_features(bool vision,
 
 } // namespace
 
-int main() {
+int run_dflash_load_plan_checks() {
     const std::filesystem::path path = artifact_path();
     if (!std::filesystem::is_regular_file(path)) {
         std::cerr << "skip: real 35B artifact is unavailable at " << path << '\n';
@@ -102,3 +103,5 @@ int main() {
     }
     return 0;
 }
+
+NINFER_GUARDED_TEST_MAIN(run_dflash_load_plan_checks)


### PR DESCRIPTION
Part of re-running the six real-model tests (`TODO.md` §1.2 / §2, "expect at least one real
failure rather than a skip").

### A test that crashes should say why

Four real-model tests had a bare `int main()` with nothing catching. Any exception — an
artifact rejection, a CUDA failure during `Engine` construction, a filesystem error — unwound
out of `main` and Windows terminated the process printing nothing at all. CTest reported

```
Exit code 0xc0000409
```

which reads like memory corruption and is not: `e06d7363` in a debugger is a C++ throw.
Recovering the message meant attaching `cdb`.

`NINFER_GUARDED_TEST_MAIN` wraps the body and prints `what()`. Exit codes are unchanged,
including 77 for a skip.

### What it immediately found

`27b_load_plan` had been skipping for want of the NVFP4 27B artifact. That artifact is on
disk; pointed at it through `NINFER_QWEN3_6_27B_NVFP4_WEIGHTS` the test crashed silently.
With the guard:

```
FATAL: nvfp4 linear_swiglu A16 is registered only through T=16
```

That is hardware, not a defect. NVFP4 weights need A4 execution, whose instructions are
sm_100a/sm_120a only, so on sm_86 the policy degrades to `A16Only` — and NVFP4 A16
`linear_swiglu` is registered through T=16 and no further
(`src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.cpp`). The case plans a 1,024-token
prefill chunk, so it is unroutable here.

**Assert the refusal rather than skip it.** Pinning the message keeps the limitation a stated
contract: if NVFP4 A16 ever gains a wider registration this fails, and the numeric check
below it becomes reachable — which is exactly when someone should look. Skipping would leave
the rest of the file unrun on this box, and it already was: that is what hid the crash.

`27b_load_plan` now passes here with both 27B artifacts supplied, skipping only the DFlash2
binding matrix, which needs the *old* Qwen3.8 artifacts nobody has.

`NINFER_QWEN3_6_27B_NVFP4_WEIGHTS` is missing from `TODO.md`'s environment block; that lands
with the TODO update.