### PR TITLE
fix(attention): barrier between cp_wait and the shared-memory dequant in the quantized kernels

### DIFF
--- a/src/ops/softmax_attention/dense/causal_cache/prompt_fp8.cuh
+++ b/src/ops/softmax_attention/dense/causal_cache/prompt_fp8.cuh
@@ -399,6 +399,13 @@ __global__ __maxnreg__(120) void causal_attention_prompt_fp8_kernel(
         }
         if (has_next) {
             ninfer::ops::cp_wait<0>();
+            // `cp_wait<0>()` retires only the *calling thread's* cp.async group. Every thread in
+            // the block then walks the whole tile in dequant_k_tile(), reading bytes issued by
+            // other threads, so the wait has to be followed by a block barrier before the read --
+            // exactly as the prologue above does, and as the lambda's own comment requires. This
+            // one was missing it, and the same three kernels that omitted it (fp8, nvfp4, k8v4)
+            // are the three storage families recorded as not run-to-run deterministic.
+            __syncthreads();
             dequant_k_tile();
         }
         __syncthreads();

--- a/src/ops/softmax_attention/dense/causal_cache/prompt_k8v4.cuh
+++ b/src/ops/softmax_attention/dense/causal_cache/prompt_k8v4.cuh
@@ -419,6 +419,13 @@ __global__ __maxnreg__(120) void causal_attention_prompt_k8v4_kernel(
         }
         if (has_next) {
             ninfer::ops::cp_wait<0>();
+            // `cp_wait<0>()` retires only the *calling thread's* cp.async group. Every thread in
+            // the block then walks the whole tile in dequant_k_tile(), reading bytes issued by
+            // other threads, so the wait has to be followed by a block barrier before the read --
+            // exactly as the prologue above does, and as the lambda's own comment requires. This
+            // one was missing it, and the same three kernels that omitted it (fp8, nvfp4, k8v4)
+            // are the three storage families recorded as not run-to-run deterministic.
+            __syncthreads();
             dequant_k_tile();
         }
         __syncthreads();

--- a/src/ops/softmax_attention/dense/causal_cache/prompt_nvfp4.cuh
+++ b/src/ops/softmax_attention/dense/causal_cache/prompt_nvfp4.cuh
@@ -413,6 +413,13 @@ __global__ __maxnreg__(120) void causal_attention_prompt_nvfp4_kernel(
         }
         if (has_next) {
             ninfer::ops::cp_wait<0>();
+            // `cp_wait<0>()` retires only the *calling thread's* cp.async group. Every thread in
+            // the block then walks the whole tile in dequant_k_tile(), reading bytes issued by
+            // other threads, so the wait has to be followed by a block barrier before the read --
+            // exactly as the prologue above does, and as the lambda's own comment requires. This
+            // one was missing it, and the same three kernels that omitted it (fp8, nvfp4, k8v4)
+            // are the three storage families recorded as not run-to-run deterministic.
+            __syncthreads();
             dequant_k_tile();
         }
         __syncthreads();

--- a/src/ops/softmax_attention/dense/causal_cache/small_t_fp8.cuh
+++ b/src/ops/softmax_attention/dense/causal_cache/small_t_fp8.cuh
@@ -512,6 +512,13 @@ __launch_bounds__(WarpsPerCta * 32, MinBlocksPerSm) __global__
         }
         if (has_next) {
             ninfer::ops::cp_wait<0>();
+            // `cp_wait<0>()` retires only the *calling thread's* cp.async group. Every thread in
+            // the block then walks the whole tile in dequant_k_tile(), reading bytes issued by
+            // other threads, so the wait has to be followed by a block barrier before the read --
+            // exactly as the prologue above does, and as the lambda's own comment requires. This
+            // one was missing it, and the same three kernels that omitted it (fp8, nvfp4, k8v4)
+            // are the three storage families recorded as not run-to-run deterministic.
+            __syncthreads();
             dequant_k_tile();
         }
         __syncthreads();

--- a/src/ops/softmax_attention/dense/causal_cache/small_t_k8v4.cuh
+++ b/src/ops/softmax_attention/dense/causal_cache/small_t_k8v4.cuh
@@ -521,6 +521,13 @@ __launch_bounds__(WarpsPerCta * 32, MinBlocksPerSm) __global__
         }
         if (has_next) {
             ninfer::ops::cp_wait<0>();
+            // `cp_wait<0>()` retires only the *calling thread's* cp.async group. Every thread in
+            // the block then walks the whole tile in dequant_k_tile(), reading bytes issued by
+            // other threads, so the wait has to be followed by a block barrier before the read --
+            // exactly as the prologue above does, and as the lambda's own comment requires. This
+            // one was missing it, and the same three kernels that omitted it (fp8, nvfp4, k8v4)
+            // are the three storage families recorded as not run-to-run deterministic.
+            __syncthreads();
             dequant_k_tile();
         }
         __syncthreads();

--- a/tests/targets/qwen3_6_27b/test_engine_score_real.cpp
+++ b/tests/targets/qwen3_6_27b/test_engine_score_real.cpp
@@ -1,3 +1,4 @@
+#include "targets/guarded_main.h"
 #include "ninfer/engine.h"
 
 #include <algorithm>
@@ -7,7 +8,7 @@
 #include <string>
 #include <vector>
 
-int main() {
+int run_score_checks() {
     const char* artifact = std::getenv("NINFER_QWEN3_6_27B_WEIGHTS");
     if (artifact == nullptr || *artifact == '\0') {
         std::cout << "SKIP: NINFER_QWEN3_6_27B_WEIGHTS is not set\n";
@@ -50,6 +51,9 @@ int main() {
         return 1;
     }
     float maximum_overlap_error = 0.0F;
+    float maximum_repeat_error  = 0.0F;
+    std::size_t repeat_differences = 0;
+    std::size_t first_repeat_index = suffix.size();
     for (std::size_t i = 0; i < suffix.size(); ++i) {
         if (!std::isfinite(all[i + 512]) || !std::isfinite(suffix[i])) {
             std::cerr << "causal scoring returned a non-finite logprob\n";
@@ -57,9 +61,24 @@ int main() {
         }
         maximum_overlap_error = std::max(maximum_overlap_error, std::abs(all[i + 512] - suffix[i]));
         if (suffix[i] != repeated[i]) {
-            std::cerr << "a repeated score window inherited prior State/KV\n";
-            return 1;
+            ++repeat_differences;
+            if (first_repeat_index == suffix.size()) { first_repeat_index = i; }
+            maximum_repeat_error =
+                std::max(maximum_repeat_error, std::abs(suffix[i] - repeated[i]));
         }
+    }
+    // Two windows scored identically must agree, but "disagree" has two very different causes and
+    // the old message asserted the worse one without measuring. State/KV leaking between windows
+    // moves logprobs by a visible amount; the reduction order varying between two runs of the same
+    // fp8 kernel moves them in the last bits. Print enough to tell them apart -- how many elements
+    // moved, by how much, and where the first one is -- instead of one sentence naming a cause.
+    if (repeat_differences != 0) {
+        std::cerr << "a repeated score window did not reproduce: " << repeat_differences << " of "
+                  << suffix.size() << " logprobs differ, worst |delta|=" << maximum_repeat_error
+                  << " first at index " << first_repeat_index << " (suffix="
+                  << suffix[first_repeat_index] << " repeated=" << repeated[first_repeat_index]
+                  << ")\n";
+        return 1;
     }
     if (maximum_overlap_error > 0.25F) {
         std::cerr << "overlapping target suffix changed by " << maximum_overlap_error << '\n';
@@ -68,3 +87,5 @@ int main() {
     std::cout << "OK causal_score_real max_overlap_error=" << maximum_overlap_error << '\n';
     return 0;
 }
+
+NINFER_GUARDED_TEST_MAIN(run_score_checks)


### PR DESCRIPTION
Closes `TODO.md` §5's "fp8, k8v4 and nvfp4 causal attention are not run-to-run
deterministic", and the `27b_score_real` failure in §1.2. The two are the same bug, and it is
considerably worse than "stays well inside tolerance".

### The defect

Five quantized causal-attention kernels call `dequant_k_tile()` immediately after
`cp_wait<0>()` with no `__syncthreads()` between them:

```cpp
if (has_next) {
    ninfer::ops::cp_wait<0>();
    dequant_k_tile();
}
__syncthreads();
```

`cp_wait<0>()` retires only the **calling thread's** cp.async group. `dequant_k_tile()` then
walks the whole tile with every thread strided across it
(`for chunk = tid; chunk < Bc*(D/8); chunk += Threads`), so each thread reads bytes another
thread issued. Without a block barrier between the wait and the read, that is a plain data
race.

The prologue in the same files does it correctly, and the lambda's own comment states the
requirement — *"callers must cp_wait<0>() first and `__syncthreads()` after"*. Only the
steady-state loop omitted it, and it omitted it in exactly the three storage families §5
records as non-deterministic. bf16 and int8 pair the two everywhere and were always
byte-identical. `has_next` is block-uniform, so the barrier is safe where it sits.

### What it was costing

Measured on Qwen3.6-27B with `EnginePurpose::CausalScoring`:

| KV | `score_tokens` on the same window, twice |
|---|---|
| `int8`, `bf16` | identical checksum every call, and across processes |
| `fp8`, `nvfp4`, `k8v4` | **all 1024** logprobs differ; median 0.2, mean 3.2, worst ~26 |

A worst case is a token at `-0.0013` in one run and `-22.61` in the next — p≈1 becoming
p≈1e-10. Total logprob over a 200-token window ranged from -352 to -588 across five calls.

Generation was unaffected and looked fine, which is why this survived: greedy decode reads
only the last column's hidden state, and prefill's *other* columns — the ones scoring and
perplexity consume — are discarded there.

### After

| | before | after |
|---|---:|---:|
| `ninfer_softmax_attention_test`, 3 runs of one binary, differing `OP_ERROR_STATS` lines | 15 | **0** |
| `27b_score_real`, `max_overlap_error` | fails | **0** for fp8, nvfp4, k8v4 *and* int8 |

The prompt-kernel barrier alone took 15 → 8 and cleared every `T=65 keys=128` case; the two
small_t barriers cleared the rest.

### Ruled out on the way

The `split >= active_split_count` early return in the small_t partial kernels skips
`write_neutral()`, which §2c flags as safe only by coincidence. Writing the merge identity
there changed nothing — 15 differing lines before and after — so it is a latent hazard, not
this defect, and is left alone. Recorded so it is not re-investigated.

### Follow-up this forces

README's perplexity figures for fp8, k8v4 and nvfp4 were measured through this path and need
re-measuring; §5 suspected the fp8-vs-k8v4 ordering might not be real, and now we know why.
The decode-rate tables for those three formats need re-measuring too, since the barrier is a
per-key-tile cost. Both are queued behind this PR.