### PR TITLE
fix(downloaders): pin and verify the Qwen3.8-27B fetch, and state the one that cannot be

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ Both platforms ship a prebuilt archive; building from source is optional and cov
 1. Download and unpack the latest
    [Linux release](https://github.com/ashalliants/ninfer-3090/releases/latest)
    (`ninfer-rtx3090-linux-x64-*.tar.gz`).
-2. Run `./download-qwen36-35b-a3b.sh` or `./download-qwen38-27b.sh` to fetch a model. Interrupted
-   downloads resume.
+2. Run `./download-qwen36-35b-a3b.sh` or `./download-qwen38-27b.sh` to fetch a model. Both pin a
+   HuggingFace revision, stage under a revision-scoped name so a resume can only ever continue the
+   same artifact, and verify size and SHA-256 before promoting it. Interrupted downloads resume.
 3. Run a launcher — `./run-qwen36-35b-a3b-c1-maxctx.sh` is the recommended one.
 
 If you would rather build, the Dockerfile is the shortest path on Bazzite and other distributions:
@@ -199,7 +200,9 @@ The Linux guide covers the GPU check, the native Ubuntu build, model mounts and 
    [Windows release](https://github.com/ashalliants/ninfer-3090/releases/latest)
    (`ninfer-rtx3090-windows-x64-*.zip`).
 2. Double-click `download-qwen36-35b-a3b.bat` or `download-qwen38-27b.bat` to download a model.
-   Interrupted downloads resume.
+   Both pin a HuggingFace revision, stage under a revision-scoped name so a resume can only ever
+   continue the same artifact, and verify size and SHA-256 before promoting it. Interrupted
+   downloads resume.
 3. Double-click one launcher:
 
 | Launcher | Best for |
@@ -510,8 +513,18 @@ Linux users build the applications from source or use the Docker image. Windows 
 prebuilt archive, which includes the applications and required DLLs. Both platforms require an
 RTX 3090 or RTX 3090 Ti and a recent NVIDIA driver.
 
-Download the [official Qwen3.8 artifact](https://huggingface.co/neroued/Qwen3.8-27B-NInfer) as
-`models/qwen3_8_27b.ninfer`. Windows users can run `download-qwen38-27b.bat` instead.
+Download the
+[pinned Qwen3.8 artifact](https://huggingface.co/neroued/Qwen3.8-27B-NInfer/tree/18dfc887423fa5aabf3cb56fac41490e462b3fab)
+as `models/qwen3_8_27b.ninfer`, or run `download-qwen38-27b.sh`/`.bat`, which verifies size and
+SHA-256 before putting the file in place. `18dfc887` is the revision every 27B number in this
+repository was measured against.
+
+**Every downloader shipped here is pinned and verified, with one deliberate exception.** The Nix
+app `download-qwen36-35b-v2` tracks upstream `main`, which is what it is for — trying a newer
+artifact than the measured one — and that is exactly why it cannot verify anything: a moving
+reference has no size or hash to state, and no partial file can be safely resumed against it. It
+writes to its own filename, refuses to resume, and is not the artifact the tests or the published
+figures use. Prefer a pinned downloader unless you specifically want a newer upstream build.
 
 For Qwen3.6-35B-A3B, download the
 [pinned container-v2 artifact](https://huggingface.co/neroued/Qwen3.6-35B-A3B-NInfer/tree/560f227e5a7104756d1a108201a8aa75654ea688)

--- a/flake.nix
+++ b/flake.nix
@@ -153,11 +153,19 @@
           echo "Model ready: $model"
         '';
 
-      # Qwen3.8-27B (official artifact; validated at C1/C2/C4/C8 on RTX 3090).
+      # Qwen3.8-27B (official artifact; validated at C1/C2/C4/C8 on RTX 3090), pinned to match
+      # scripts/download-qwen38-27b.{sh,bat}. Those two already pinned this revision in their URL
+      # while this entry tracked main, so the same `nix run` and shell script could fetch different
+      # artifacts -- and neither verified what arrived. 18dfc887 is the revision every published
+      # 27B measurement in this repository was taken against: the local artifact hashes to the
+      # sha256 below, which is also what HuggingFace reports for it.
       download-qwen38-27b = mkDownload {
         name = "download-qwen38-27b";
         filename = "qwen3_8_27b.ninfer";
-        url = "https://huggingface.co/neroued/Qwen3.8-27B-NInfer/resolve/main/qwen3_8_27b.ninfer";
+        revision = "18dfc887423fa5aabf3cb56fac41490e462b3fab";
+        url = "https://huggingface.co/neroued/Qwen3.8-27B-NInfer/resolve/18dfc887423fa5aabf3cb56fac41490e462b3fab/qwen3_8_27b.ninfer";
+        expectedSize = 18210531328;
+        expectedSha256 = "eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e";
         description = "Qwen3.8-27B NInfer model";
       };
 
@@ -192,6 +200,14 @@
       # upstream artifact, so it is deliberately unpinned and deliberately writes to its own
       # filename: it is not the measured profile and it is not what the tests expect. Now that
       # download-qwen36-35b carries DFlash, this no longer exists to supply it.
+      #
+      # It is now the only downloader in the tree that cannot verify what it fetches, and that is
+      # inherent rather than an oversight: `main` can move between runs, so there is no size or
+      # hash to state and no safe way to resume a partial file. mkDownload therefore refuses to
+      # resume this one at all (see `resumable` above) -- an interrupted fetch restarts from zero
+      # rather than being spliced. A truncated download that still reaches the end of the stream
+      # cannot be detected here. Prefer download-qwen36-35b unless you are specifically testing a
+      # newer upstream artifact.
       download-qwen36-35b-v2 = mkDownload {
         name = "download-qwen36-35b-v2";
         filename = "qwen3_6_35b_a3b_v2.ninfer";

--- a/scripts/check-linux-scripts.sh
+++ b/scripts/check-linux-scripts.sh
@@ -121,20 +121,38 @@ if [[ -n "${NINFER_TEST_FAKE_SIZE:-}" ]]; then
 fi
 CURL
 chmod +x "$tmp/bin/curl"
-PATH="$tmp/bin:$PATH" NINFER_MODEL_DIR="$tmp/models" "$root/download-qwen38-27b.sh" >/dev/null
-qwen36_35b_expected_size="$(sed -n 's/^expected_size=\([0-9]\+\)$/\1/p' "$root/download-qwen36-35b-a3b.sh")"
-PATH="$tmp/bin:$PATH" NINFER_MODEL_DIR="$tmp/models" NINFER_SKIP_SHA256=1   NINFER_TEST_FAKE_SIZE="$qwen36_35b_expected_size" "$root/download-qwen36-35b-a3b.sh" >/dev/null
-[[ -f "$tmp/models/qwen3_8_27b.ninfer" ]]
-[[ -f "$tmp/models/qwen3_6_35b_a3b.ninfer" ]]
+# Every downloader now pins a revision and verifies size and sha256 before promoting, so they are
+# all driven the same way: hand the fixture the script's own expected_size and skip the hash, which
+# proves the promotion path without needing a real 17 GB payload.
+expected_size_of() { sed -n 's/^expected_size=\([0-9]\+\)$/\1/p' "$root/$1.sh"; }
+for downloader in download-qwen38-27b download-qwen36-27b download-qwen36-35b-a3b; do
+  case "$downloader" in
+    download-qwen38-27b) model='qwen3_8_27b.ninfer' ;;
+    download-qwen36-27b) model='qwen3_6_27b.ninfer' ;;
+    download-qwen36-35b-a3b) model='qwen3_6_35b_a3b.ninfer' ;;
+  esac
+  size="$(expected_size_of "$downloader")"
+  if [[ -z "$size" ]]; then
+    printf '%s has no expected_size to verify against\n' "$downloader" >&2
+    exit 1
+  fi
+  PATH="$tmp/bin:$PATH" NINFER_MODEL_DIR="$tmp/models" NINFER_SKIP_SHA256=1 \
+    NINFER_TEST_FAKE_SIZE="$size" "$root/$downloader.sh" >/dev/null
+  if [[ ! -f "$tmp/models/$model" ]]; then
+    printf '%s did not promote a payload matching its pin to %s\n' "$downloader" "$model" >&2
+    exit 1
+  fi
+done
 
 # The other half of the contract. Above proves a payload matching the pin is promoted; this proves
 # one that does not is refused, which is the property the staging and checksum work exists for and
 # the one a regression would silently remove. Without NINFER_TEST_FAKE_SIZE the fixture writes an
 # empty file, so every pinned downloader should reject it, leave the real artifact path alone, and
 # keep the revision-scoped .part it was told to delete.
-rm -f -- "$tmp/models/qwen3_6_35b_a3b.ninfer"
-for downloader in download-qwen36-35b-a3b download-qwen36-27b; do
+rm -f -- "$tmp/models"/*.ninfer
+for downloader in download-qwen38-27b download-qwen36-35b-a3b download-qwen36-27b; do
   case "$downloader" in
+    download-qwen38-27b) model='qwen3_8_27b.ninfer' ;;
     download-qwen36-35b-a3b) model='qwen3_6_35b_a3b.ninfer' ;;
     download-qwen36-27b) model='qwen3_6_27b.ninfer' ;;
   esac

--- a/scripts/download-qwen38-27b.bat
+++ b/scripts/download-qwen38-27b.bat
@@ -1,14 +1,74 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
+
+rem The Qwen3.8-27B dense artifact -- the default 27B for every benchmark in this repository, and
+rem the one docs\config-calculator.html's "27b" rows are measured against.
+rem
+rem This script pinned the revision in its URL but verified nothing it received, and resumed
+rem straight onto the final path: a truncated or corrupt 17 GB download was accepted silently. The
+rem size and hash below are what HuggingFace reports for this revision. Structure matches
+rem download-qwen36-27b.bat deliberately, so the two cannot drift.
+set "REVISION=18dfc887423fa5aabf3cb56fac41490e462b3fab"
+set "EXPECTED_SIZE=18210531328"
+set "EXPECTED_SHA256=eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e"
+
 set "ROOT=%~dp0"
 set "MODEL_DIR=%ROOT%models"
+if defined NINFER_MODEL_DIR set "MODEL_DIR=%NINFER_MODEL_DIR%"
 set "MODEL=%MODEL_DIR%\qwen3_8_27b.ninfer"
 
+rem Staged under a revision-scoped name so that curl -C - can only ever resume the same artifact.
+rem Resuming straight onto the final path appends at the current length without checking what
+rem wrote those bytes, so a leftover partial from a different revision would be spliced into this
+rem one and produce a plausibly sized, wholly corrupt file.
+set "PART=%MODEL%.%REVISION%.part"
+
 if not exist "%MODEL_DIR%" mkdir "%MODEL_DIR%"
-echo Downloading Qwen3.8-27B NInfer model...
-curl.exe -L -C - --fail --output "%MODEL%" "https://huggingface.co/neroued/Qwen3.8-27B-NInfer/resolve/18dfc887423fa5aabf3cb56fac41490e462b3fab/qwen3_8_27b.ninfer"
+
+if exist "%MODEL%" (
+  call :verify "%MODEL%"
+  if "!VERIFY_OK!"=="1" (
+    echo Model already present: %MODEL%
+    exit /b 0
+  )
+  echo Existing %MODEL% did not verify against revision %REVISION%; fetching the pinned one.
+)
+
+echo Downloading the Qwen3.8-27B model (17.0 GiB)...
+curl.exe -L -C - --fail --output "%PART%" "https://huggingface.co/neroued/Qwen3.8-27B-NInfer/resolve/%REVISION%/qwen3_8_27b.ninfer"
 if errorlevel 1 (
   echo Download failed. Run this file again to resume.
   exit /b 1
 )
+
+call :verify "%PART%"
+if not "!VERIFY_OK!"=="1" (
+  echo Downloaded file at "%PART%" failed verification against revision %REVISION%. Delete it and run this file again.
+  exit /b 1
+)
+
+move /y "%PART%" "%MODEL%" >nul
 echo Model ready: %MODEL%
+echo Point the tests at it with:  set NINFER_QWEN3_8_27B_WEIGHTS=%MODEL%
+exit /b 0
+
+rem Verifies %1 against EXPECTED_SIZE and, unless NINFER_SKIP_SHA256=1, EXPECTED_SHA256, setting
+rem VERIFY_OK to 1 or 0. ACTUAL_SHA256 is cleared before the for /f loop: setlocal inherits
+rem existing environment variables, so a stale value from outside this script would otherwise
+rem survive "if not defined" and be compared unchanged.
+:verify
+set "VERIFY_OK=0"
+set "VERIFY_PATH=%~1"
+for %%A in ("%VERIFY_PATH%") do set "VERIFY_SIZE=%%~zA"
+if not "!VERIFY_SIZE!"=="%EXPECTED_SIZE%" exit /b 0
+if "%NINFER_SKIP_SHA256%"=="1" (
+  set "VERIFY_OK=1"
+  exit /b 0
+)
+set "ACTUAL_SHA256="
+for /f "skip=1 delims=" %%H in ('certutil -hashfile "%VERIFY_PATH%" SHA256') do (
+  if not defined ACTUAL_SHA256 set "ACTUAL_SHA256=%%H"
+)
+set "ACTUAL_SHA256=!ACTUAL_SHA256: =!"
+if /i "!ACTUAL_SHA256!"=="%EXPECTED_SHA256%" set "VERIFY_OK=1"
+exit /b 0

--- a/scripts/download-qwen38-27b.sh
+++ b/scripts/download-qwen38-27b.sh
@@ -1,15 +1,72 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The Qwen3.8-27B dense artifact -- the default 27B for every benchmark in this repository, and the
+# one docs/config-calculator.html's "27b" rows are measured against.
+#
+# This script pinned the revision in its URL but verified nothing it received, and resumed straight
+# onto the final path: a truncated or corrupt 17 GB download was accepted silently, and a leftover
+# partial from any other fetch would be appended to rather than replaced. The size and hash below
+# are what HuggingFace reports for this revision (X-Linked-Size and X-Linked-ETag on the resolve
+# URL), which is also what the local artifact every published measurement was taken against hashes
+# to. Structure matches download-qwen36-27b.sh deliberately, so the two cannot drift.
+revision='18dfc887423fa5aabf3cb56fac41490e462b3fab'
+expected_size=18210531328
+expected_sha256='eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e'
+
 root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 model_dir="${NINFER_MODEL_DIR:-$root/models}"
 model="$model_dir/qwen3_8_27b.ninfer"
 
+# Staged under a revision-scoped name so that curl -C - can only ever resume the same artifact.
+# Resuming straight onto the final path appends at the current length without checking what wrote
+# those bytes, so a leftover partial from a different revision would be spliced into this one and
+# produce a plausibly sized, wholly corrupt file.
+part="$model.$revision.part"
+
+file_size() { wc -c < "$1" | tr -d '[:space:]'; }
+
+# Verifies a file against expected_size and, unless NINFER_SKIP_SHA256=1, expected_sha256. Used
+# both for an existing "$model" and for a freshly downloaded "$part", so the two cannot disagree.
+# A missing sha256sum/shasum fails closed rather than silently promoting an unverified file.
+verify() {
+  [ "$(file_size "$1")" = "$expected_size" ] || return 1
+  [ "${NINFER_SKIP_SHA256:-0}" = '1' ] && return 0
+  local actual
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum -- "$1" | cut -d' ' -f1)"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 -- "$1" | cut -d' ' -f1)"
+  else
+    printf 'No sha256sum or shasum found; cannot verify %s. Set NINFER_SKIP_SHA256=1 to accept it unverified.\n' "$1" >&2
+    return 1
+  fi
+  [ "$actual" = "$expected_sha256" ]
+}
+
 mkdir -p -- "$model_dir"
-printf '%s\n' 'Downloading Qwen3.8-27B NInfer model...'
-if ! curl -L -C - --fail --output "$model" \
-  'https://huggingface.co/neroued/Qwen3.8-27B-NInfer/resolve/18dfc887423fa5aabf3cb56fac41490e462b3fab/qwen3_8_27b.ninfer'; then
+
+if [ -f "$model" ]; then
+  if verify "$model"; then
+    printf 'Model already present: %s\n' "$model"
+    exit 0
+  fi
+  printf '%s\n' "Existing $model did not verify against revision $revision; fetching the pinned one." >&2
+fi
+
+printf '%s\n' 'Downloading the Qwen3.8-27B model (17.0 GiB)...'
+if ! curl -L -C - --fail --output "$part" \
+  "https://huggingface.co/neroued/Qwen3.8-27B-NInfer/resolve/$revision/qwen3_8_27b.ninfer"; then
   printf '%s\n' 'Download failed. Run this script again to resume.' >&2
   exit 1
 fi
+
+if ! verify "$part"; then
+  printf 'Downloaded file at %s failed verification against revision %s. Delete it and run this script again.\n' \
+    "$part" "$revision" >&2
+  exit 1
+fi
+
+mv -f -- "$part" "$model"
 printf 'Model ready: %s\n' "$model"
+printf 'Point the tests at it with:  export NINFER_QWEN3_8_27B_WEIGHTS=%s\n' "$model"


### PR DESCRIPTION
Closes `TODO.md` §6's "the unpinned downloaders cannot verify anything they fetch".

The entry describes `download-qwen38-27b` as tracking upstream `main`. The shell and batch
scripts had in fact already pinned `18dfc887` in their URL — they just verified nothing they
received, and resumed straight onto the final path. `curl -C -` appends at the current length
without checking what wrote those bytes, so a leftover partial from any other fetch would be
spliced in and produce a plausibly sized, wholly corrupt 17 GB artifact.

They now stage under a revision-scoped name and verify size and SHA-256 before promoting,
matching `download-qwen36-27b.{sh,bat}` line for line so the two cannot drift.

The expected values are what HuggingFace reports for that revision (`X-Linked-Size` and
`X-Linked-ETag` on the resolve URL):

```
18,210,531,328 bytes
eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e
```

The local artifact every published 27B measurement in this repository was taken against
hashes to exactly that, so the pin also documents which bytes those numbers describe.

**`flake.nix` disagreed with the scripts.** Its `download-qwen38-27b` tracked `main` while the
shell and batch scripts pinned `18dfc887`, so `nix run` and `./download-qwen38-27b.sh` could
fetch different artifacts, and neither checked what arrived. Now pinned and verified to match.

**One downloader remains unverifiable, by design.** `download-qwen36-35b-v2` tracks upstream
`main`, which is what it is *for* — trying a newer artifact than the measured one. A moving
reference has no size or hash to state and no partial that can safely be resumed against it,
which is why `mkDownload` already refuses to resume that one. README now says so where people
choose a downloader, rather than leaving the asymmetry implicit.

`check-linux-scripts.sh` drives all three pinned downloaders through the same fixture now,
both promotion and refusal, instead of treating qwen38-27b as the one with nothing to check.
This hunk is in this PR rather than #41 because the generalised fixture requires an
`expected_size` that only exists after this change — keeping each commit self-consistent.
