### PR TITLE
perf(docs): give the decode roofline a denominator that is actually right

### DIFF
--- a/scripts/sweeps/decode-roofline.ps1
+++ b/scripts/sweeps/decode-roofline.ps1
@@ -10,15 +10,29 @@ $d = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweep
 # stdout; that summary is a convenience for reading progress and drops most of the fields. The
 # files are the artifact. (kv-decode-vs-depth.ps1 writes "<model>_<kv>.csv"; this reads the same.)
 #
-# RTX 3090: 384-bit GDDR6X at 19.5 Gbps = 936.2 GB/s theoretical. Decode is memory-bound: every
-# token streams the resident weights once, plus the KV it attends over. So achieved bandwidth
-# divided by peak says how much of the card the decode path is actually using -- the single number
-# that says whether there is headroom left, independent of any kernel detail.
-$PEAK_GBs = 936.2
+# TWO denominators, because only one of them is a ceiling anything can actually reach.
+#
+# 936.1 GB/s is the 3090's advertised figure: 384-bit GDDR6X at 19.5 Gbps. No kernel reaches it --
+# refresh, ECC-less but real bus turnaround, and request efficiency all cost something. Measured
+# here with tools/hbm_bandwidth_probe.cu, 4 GiB working set (683x L2), best of five trials:
+#
+#     cudaMemsetAsync (write)   863.3 GB/s   92.2% of advertised
+#     kernel uint4 read         854.2 GB/s   91.3%
+#     kernel uint4 write        824.1 GB/s   88.0%
+#     cudaMemcpyAsync D2D       813.2 GB/s   86.9%
+#
+# Decode streams weights and KV *in*, so the read rate is its ceiling: 854.2 GB/s. Reporting
+# against the advertised number instead understates the decode path by about six points and makes
+# the headroom look larger than it is. Both columns are printed so the difference stays visible.
+#
+# Reproduce with:
+#   nvcc -O3 -std=c++17 -arch=sm_86 tools/hbm_bandwidth_probe.cu -o hbm_probe && ./hbm_probe
+$ADVERTISED_GBs = 936.1
+$ACHIEVABLE_GBs = 854.2   # measured sustained read, see above
 
-"{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6}" -f 'model','kv','depth','tok/s','weights GB','KV GB','% of peak BW'
+"{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6,-14} {7}" -f 'model','kv','depth','tok/s','weights GB','KV GB','% advertised','% achievable'
 foreach ($model in @('27b-dense','35b-moe')) {
-  foreach ($kv in @('int8','rk8v4')) {
+  foreach ($kv in @('int8','rk8v4','fp8','k8v4','nvfp4','bf16')) {
     $f = "$d\${model}_$kv.csv"
     if (-not (Test-Path $f)) { continue }
     foreach ($r in (Import-Csv $f | Where-Object { $_.kind -eq 'pp+tg' })) {
@@ -27,9 +41,10 @@ foreach ($model in @('27b-dense','35b-moe')) {
       $perTok = [double]$r.kv_payload_bytes / 40960          # bytes of KV per token
       $kvGB   = ($perTok * [double]$r.n_prompt) / 1e9        # KV actually attended at this depth
       $bw     = ($wGB + $kvGB) * $tok
-      "{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6}" -f $model, $kv, $r.n_prompt,
+      "{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6,-14} {7}" -f $model, $kv, $r.n_prompt,
         ("{0:N2}" -f $tok), ("{0:N2}" -f $wGB), ("{0:N3}" -f $kvGB),
-        ("{0:N1}% ({1:N0} GB/s)" -f (100*$bw/$PEAK_GBs), $bw)
+        ("{0:N1}%" -f (100*$bw/$ADVERTISED_GBs)),
+        ("{0:N1}% ({1:N0} GB/s)" -f (100*$bw/$ACHIEVABLE_GBs), $bw)
     }
   }
 }

--- a/scripts/sweeps/kv-decode-vs-depth.ps1
+++ b/scripts/sweeps/kv-decode-vs-depth.ps1
@@ -20,7 +20,14 @@ $models = @(
   @{ key='27b-dense'; path="$modelDir\qwen3_8_27b.ninfer" },
   @{ key='35b-moe';   path="$modelDir\qwen3_6_35b_a3b.ninfer" }
 )
-$dtypes = @('bf16','int8','fp8','rk8v4','k8v4','nvfp4')
+# All six by default. NINFER_SWEEP_DTYPES narrows it -- three hours is a lot to spend when a
+# change touched three of the six kernels and the other three are only a control. Comma-separated,
+# e.g. NINFER_SWEEP_DTYPES=int8,fp8,k8v4,nvfp4.
+$dtypes = if ($env:NINFER_SWEEP_DTYPES) {
+  $env:NINFER_SWEEP_DTYPES -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+} else {
+  @('bf16','int8','fp8','rk8v4','k8v4','nvfp4')
+}
 
 "model,kv,depth,decode_tok_s,stddev,kv_payload_bytes"
 foreach ($m in $models) {

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,6 +15,8 @@ for the selected tool.
 | Build the Qwen3.8-27B artifact | [`convert/qwen3_8_27b/`](convert/qwen3_8_27b/) |
 | Build the 35B-A3B artifact | [`convert/qwen3_6_35b_a3b/`](convert/qwen3_6_35b_a3b/) |
 | Inspect artifact metadata and objects | [`artifact/inspect.py`](artifact/inspect.py) |
+| Count the bytes one decoded token reads (roofline denominator) | [`decode_byte_accounting.py`](decode_byte_accounting.py) |
+| Measure the card's sustained memory bandwidth | [`hbm_bandwidth_probe.cu`](hbm_bandwidth_probe.cu) |
 | Run benchmark matrices | [`bench/`](bench/README.md) |
 | Measure external Serve TTFT | [`bench/ttft/`](bench/ttft/README.md) |
 | Exercise a resident HTTP server | [`smoke/serve_contract.py`](smoke/serve_contract.py) |

--- a/tools/decode_byte_accounting.py
+++ b/tools/decode_byte_accounting.py
@@ -1,0 +1,155 @@
+"""How many bytes does one decoded token actually read?
+
+Decode is memory-bound: the step time is set by how much of the card's bandwidth the path can
+use, so "% of peak" is the one number that says whether there is headroom left. That needs a
+denominator, and this repository did not have one.
+
+Two things were wrong with the arithmetic used before.
+
+**Resident is not read.** Dividing throughput into `weights_capacity_bytes` counts weights the
+decode path never streams: the vision tower, the DFlash and MTP bundles when they are not
+selected, the draft head with speculation off, and all but one row of the token embedding. On
+the Qwen3.8-27B that is 1.12 GB of the 16.86 GB resident -- reporting against the resident
+figure overstates the achieved bandwidth by about six points.
+
+**An MoE never reads its resident weights at all.** Applying the dense formula to the
+Qwen3.6-35B-A3B returns 391% of peak, which is not a result, it is a proof that the formula
+does not apply: 18.56 GB of its weights are routed experts, and one token touches 8 of 256 per
+layer. Counting the routed tensors at top_k/experts is what makes the MoE comparable to the
+dense model at all.
+
+Both counts come from the artifact's own object directory -- names, shapes and byte lengths --
+so this is arithmetic over what was actually shipped rather than a model card. Only the header
+is read; the payload is never touched, so it runs in milliseconds on a 21 GB file and needs no
+GPU and no torch.
+
+    python tools/decode_byte_accounting.py models/qwen3_6_35b_a3b.ninfer\
+        --kv-bytes-per-token 10560 --depth 4096 --tok-s 173.83
+
+Pass --tok-s to get the roofline; without it you get the byte counts alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+from collections import defaultdict
+from pathlib import Path
+
+PREFIX = struct.Struct("<8sQ")
+MAGIC = b"NINFER\x00\x02"
+
+# src/ops/sparse_moe/sparse_moe_route.cuh. Every shipped MoE target uses these; if a future one
+# does not, this is the constant to plumb through rather than to edit.
+SPARSE_MOE_EXPERTS = 256
+SPARSE_MOE_TOP_K = 8
+
+# Advertised 384-bit GDDR6X at 19.5 Gbps, and the sustained read rate measured on this card with
+# tools/hbm_bandwidth_probe.cu (4 GiB working set, best of five). Decode streams weights and KV
+# *in*, so the read rate is its ceiling; the advertised number is printed beside it because it is
+# the one people quote.
+ADVERTISED_GB_S = 936.1
+ACHIEVABLE_READ_GB_S = 854.2
+
+# Towers a plain text decode never touches. `mtp` and `dflash` become live when the matching
+# --spec is selected, which is why they are named rather than pattern-matched.
+UNREAD_TOWERS = ("vision", "dflash", "mtp", "frontend")
+
+# Read only when the optimized proposal head is selected.
+UNREAD_TEXT_OBJECTS = ("text/draft_head", "text/draft_head_token_ids")
+
+
+def read_directory(path: Path) -> list[dict]:
+    with path.open("rb") as handle:
+        magic, json_bytes = PREFIX.unpack(handle.read(PREFIX.size))
+        if magic != MAGIC:
+            raise SystemExit(f"{path} is not a v2 .ninfer artifact")
+        directory = json.loads(handle.read(json_bytes))
+    return directory["objects"] if isinstance(directory, dict) else directory
+
+
+def account(objects: list[dict]) -> dict[str, int | float]:
+    dense = 0
+    routed_total = 0
+    embedding_row = 0
+    unread: dict[str, int] = defaultdict(int)
+
+    for obj in objects:
+        name = str(obj.get("name", ""))
+        size = int(obj.get("bytes", 0))
+        tower = name.split("/", 1)[0]
+        if tower in UNREAD_TOWERS or name in UNREAD_TEXT_OBJECTS:
+            unread[tower] += size
+            continue
+        if name.endswith("token_embedding"):
+            # One row per token, not the table.
+            rows = int(obj["shape"][0])
+            embedding_row = size // rows
+            unread[tower] += size - embedding_row
+            continue
+        if "/moe/routed_" in name:
+            routed_total += size
+            continue
+        dense += size
+
+    routed_read = routed_total * SPARSE_MOE_TOP_K / SPARSE_MOE_EXPERTS
+    return {
+        "dense": dense,
+        "embedding_row": embedding_row,
+        "routed_total": routed_total,
+        "routed_read": routed_read,
+        "per_token": dense + embedding_row + routed_read,
+        "unread": dict(unread),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("artifact", type=Path)
+    parser.add_argument("--kv-bytes-per-token", type=int, default=0,
+                        help="from ninfer_bench's kv_payload_bytes / max_context")
+    parser.add_argument("--depth", type=int, action="append", default=[],
+                        help="cache depth in tokens; repeatable")
+    parser.add_argument("--tok-s", type=float, action="append", default=[],
+                        help="measured decode tok/s at the matching --depth; repeatable")
+    args = parser.parse_args()
+
+    if len(args.tok_s) != len(args.depth):
+        raise SystemExit("--depth and --tok-s must be given the same number of times")
+
+    result = account(read_directory(args.artifact))
+    per_token = float(result["per_token"])
+
+    print(f"{args.artifact.name}: bytes read per decoded token, one lane, no speculation")
+    print(f"  dense weights, every token          : {result['dense']:>15,} B")
+    print(f"  one token_embedding row             : {result['embedding_row']:>15,} B")
+    if result["routed_total"]:
+        print(f"  routed experts, all {SPARSE_MOE_EXPERTS}             : "
+              f"{result['routed_total']:>15,} B")
+        print(f"  routed experts read ({SPARSE_MOE_TOP_K}/{SPARSE_MOE_EXPERTS})        : "
+              f"{result['routed_read']:>15,.0f} B")
+    print(f"  {'-' * 56}")
+    print(f"  per token                           : {per_token:>15,.0f} B "
+          f"({per_token / 1e9:.3f} GB)")
+    if result["unread"]:
+        print("  resident but not read by a text decode:")
+        for tower, size in sorted(result["unread"].items(), key=lambda kv: -kv[1]):
+            print(f"    {tower:<10} {size:>15,} B")
+
+    if not args.depth:
+        return
+    print()
+    print(f"  {'depth':>8} {'tok/s':>8} {'KV GB':>8} {'GB/s':>8} {'advertised':>11} "
+          f"{'achievable':>11}")
+    for depth, tok_s in zip(args.depth, args.tok_s):
+        kv = args.kv_bytes_per_token * depth
+        achieved = (per_token + kv) * tok_s
+        print(f"  {depth:>8} {tok_s:>8.2f} {kv / 1e9:>8.3f} {achieved / 1e9:>8.1f} "
+              f"{100 * achieved / (ADVERTISED_GB_S * 1e9):>10.1f}% "
+              f"{100 * achieved / (ACHIEVABLE_READ_GB_S * 1e9):>10.1f}%")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes two of `TODO.md` §2c's entries: the roofline one, and *"nobody knows where the MoE sits
at all, because the accounting does not exist"*.

§2c's headline was that dense decode runs at 65-66% of the card's memory bandwidth. Two things
were wrong with that arithmetic. Fixing both moves the dense number, and creates the missing
MoE one.

### 936.2 GB/s is not a ceiling anything reaches

It is the advertised 384-bit GDDR6X at 19.5 Gbps. `tools/hbm_bandwidth_probe.cu` was already
in the tree and had never been pointed at this card. 4 GiB working set (683× L2), best of five:

| method | GB/s | of advertised |
|---|---:|---:|
| `cudaMemsetAsync` (write) | 863.3 | 92.2% |
| **kernel uint4 read** | **854.2** | **91.3%** |
| kernel uint4 write | 824.1 | 88.0% |
| `cudaMemcpyAsync` D2D | 813.2 | 86.9% |

Decode streams weights and KV **in**, so 854.2 GB/s is its ceiling.

### Resident is not read

Dividing throughput into `weights_capacity_bytes` counts weights the decode path never
streams — the vision tower, the MTP and DFlash bundles when unselected, the draft head with
speculation off, and all but one row of the token embedding. On the 27B that is 2.47 GB of
resident weight that never moves per token.

`tools/decode_byte_accounting.py` reads the artifact's own object directory and counts what a
token actually touches. Header only: milliseconds on a 21 GB file, no GPU, no torch.

```
Qwen3.8-27B dense    15.743 GB per token
Qwen3.6-35B-A3B       2.522 GB per token
                      1.943 GB dense + 0.580 GB of routed experts (8 of 256 per layer),
                      out of 18.556 GB of experts resident
```

### The result

| model | depth | tok/s | achieved | % advertised | % achievable |
|---|---:|---:|---:|---:|---:|
| 27B dense | 4,096 | 36.15 | 574 GB/s | 61.3% | **67.2%** |
| 27B dense | 32,768 | 33.86 | 571 GB/s | 60.9% | **66.8%** |
| 35B-A3B MoE | 4,096 | 173.83 | 446 GB/s | 47.6% | **52.2%** |
| 35B-A3B MoE | 32,768 | 154.90 | 444 GB/s | 47.5% | **52.0%** |

Dense sits at about two-thirds of what the card can deliver; **the MoE at about half** — the
larger gap of the two, on the model the release recommends. Flat across depth in both cases,
so it is a property of the path rather than of the cache.

This reverses the shape of §2c's first entry. It framed dense decode as the biggest single
number in the file; on this accounting the MoE has roughly thirty points of headroom against
the dense path's thirteen, and neither has ever been profiled. A gather of 8 scattered expert
blocks per layer is the obvious suspect for the MoE half, and is what I would look at next.

### Also here

- `decode-roofline.ps1` prints both denominators instead of only the advertised one.
- `kv-decode-vs-depth.ps1` gains `NINFER_SWEEP_DTYPES`, so a re-measurement concerning three of
  the six formats need not spend three hours on all six.

No new GPU measurement beyond the bandwidth probe — the tok/s figures are the ones already
in §2c. They are being re-measured separately, because #49's barrier lands on three of the six
KV formats.