### PR TITLE
perf(sweeps): make the roofline use the read set it now has, and add the decode-step profile

### DIFF
--- a/scripts/sweeps/decode-roofline.ps1
+++ b/scripts/sweeps/decode-roofline.ps1
@@ -1,20 +1,20 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
-$d = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+$d        = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$python   = if ($env:NINFER_PYTHON) { $env:NINFER_PYTHON } else { 'python' }
 
 # Reads the per-run CSVs that kv-decode-vs-depth.ps1 leaves in $NINFER_SWEEP_OUT -- run that first.
-# Pure arithmetic, no GPU needed.
+# No GPU needed.
 #
 # Note those CSVs are ninfer_bench's own full output, written by --output-file, and carry every
-# column including weights_capacity_bytes. They are NOT the six-column summary that sweep prints to
-# stdout; that summary is a convenience for reading progress and drops most of the fields. The
-# files are the artifact. (kv-decode-vs-depth.ps1 writes "<model>_<kv>.csv"; this reads the same.)
+# column. They are NOT the six-column summary that sweep prints to stdout, which drops most of the
+# fields. The files are the artifact.
 #
-# TWO denominators, because only one of them is a ceiling anything can actually reach.
+# TWO denominators, because only one of them is a ceiling anything reaches.
 #
-# 936.1 GB/s is the 3090's advertised figure: 384-bit GDDR6X at 19.5 Gbps. No kernel reaches it --
-# refresh, ECC-less but real bus turnaround, and request efficiency all cost something. Measured
-# here with tools/hbm_bandwidth_probe.cu, 4 GiB working set (683x L2), best of five trials:
+# 936.1 GB/s is the 3090's advertised figure: 384-bit GDDR6X at 19.5 Gbps. No kernel reaches it.
+# Measured here with tools/hbm_bandwidth_probe.cu, 4 GiB working set (683x L2), best of five:
 #
 #     cudaMemsetAsync (write)   863.3 GB/s   92.2% of advertised
 #     kernel uint4 read         854.2 GB/s   91.3%
@@ -22,30 +22,60 @@ $d = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweep
 #     cudaMemcpyAsync D2D       813.2 GB/s   86.9%
 #
 # Decode streams weights and KV *in*, so the read rate is its ceiling: 854.2 GB/s. Reporting
-# against the advertised number instead understates the decode path by about six points and makes
-# the headroom look larger than it is. Both columns are printed so the difference stays visible.
+# against the advertised number understates the decode path by about six points.
 #
-# Reproduce with:
-#   nvcc -O3 -std=c++17 -arch=sm_86 tools/hbm_bandwidth_probe.cu -o hbm_probe && ./hbm_probe
+# And the NUMERATOR is not weights_capacity_bytes. That counts weights the decode path never
+# streams -- the vision tower, MTP and DFlash when unselected, the draft head with speculation
+# off, and all but one row of the token embedding -- and for an MoE it is not even the right
+# shape, since one token touches 8 experts of 256 per layer. Using it returns 418% of peak on the
+# A3B, which is not a result. tools/decode_byte_accounting.py counts what is actually read, from
+# the artifact's own object directory, and this script asks it rather than hardcoding the answer.
 $ADVERTISED_GBs = 936.1
-$ACHIEVABLE_GBs = 854.2   # measured sustained read, see above
+$ACHIEVABLE_GBs = 854.2
 
-"{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6,-14} {7}" -f 'model','kv','depth','tok/s','weights GB','KV GB','% advertised','% achievable'
+$artifacts = @{ '27b-dense' = 'qwen3_8_27b.ninfer'; '35b-moe' = 'qwen3_6_35b_a3b.ninfer' }
+$perToken  = @{}
+foreach ($model in $artifacts.Keys) {
+  $path = Join-Path $modelDir $artifacts[$model]
+  if (-not (Test-Path $path)) { continue }
+  $json = & $python tools\decode_byte_accounting.py $path --json 2>$null
+  if ($LASTEXITCODE -eq 0 -and $json) { $perToken[$model] = [double](($json | ConvertFrom-Json).per_token) }
+}
+if ($perToken.Count -eq 0) { throw "decode_byte_accounting.py produced nothing; is python on PATH?" }
+
+"{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6,-13} {7}" -f 'model','kv','depth','tok/s','read GB','KV GB','% advertised','% achievable'
 foreach ($model in @('27b-dense','35b-moe')) {
+  if (-not $perToken.ContainsKey($model)) { continue }
+  $wGB = $perToken[$model] / 1e9
   foreach ($kv in @('int8','rk8v4','fp8','k8v4','nvfp4','bf16')) {
     $f = "$d\${model}_$kv.csv"
     if (-not (Test-Path $f)) { continue }
     foreach ($r in (Import-Csv $f | Where-Object { $_.kind -eq 'pp+tg' })) {
       $tok    = [double]$r.decode_output_tok_s_mean
-      $wGB    = [double]$r.weights_capacity_bytes / 1e9
       $perTok = [double]$r.kv_payload_bytes / 40960          # bytes of KV per token
       $kvGB   = ($perTok * [double]$r.n_prompt) / 1e9        # KV actually attended at this depth
       $bw     = ($wGB + $kvGB) * $tok
-      "{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6,-14} {7}" -f $model, $kv, $r.n_prompt,
-        ("{0:N2}" -f $tok), ("{0:N2}" -f $wGB), ("{0:N3}" -f $kvGB),
+      "{0,-10} {1,-7} {2,-8} {3,-9} {4,-11} {5,-11} {6,-13} {7}" -f $model, $kv, $r.n_prompt,
+        ("{0:N2}" -f $tok), ("{0:N3}" -f $wGB), ("{0:N3}" -f $kvGB),
         ("{0:N1}%" -f (100*$bw/$ADVERTISED_GBs)),
         ("{0:N1}% ({1:N0} GB/s)" -f (100*$bw/$ACHIEVABLE_GBs), $bw)
     }
+  }
+}
+
+"`n=== decode falloff, 4,096 -> 32,768 tokens of cache ==="
+"{0,-10} {1,-7} {2,-10} {3,-10} {4}" -f 'model','kv','4096','32768','falloff'
+foreach ($model in @('27b-dense','35b-moe')) {
+  foreach ($kv in @('int8','rk8v4','fp8','k8v4','nvfp4','bf16')) {
+    $f = "$d\${model}_$kv.csv"
+    if (-not (Test-Path $f)) { continue }
+    $rows = Import-Csv $f | Where-Object { $_.kind -eq 'pp+tg' }
+    $a = $rows | Where-Object { [int]$_.n_prompt -eq 4096 }  | Select-Object -First 1
+    $b = $rows | Where-Object { [int]$_.n_prompt -eq 32768 } | Select-Object -First 1
+    if (-not $a -or -not $b) { continue }
+    $x = [double]$a.decode_output_tok_s_mean; $y = [double]$b.decode_output_tok_s_mean
+    "{0,-10} {1,-7} {2,-10} {3,-10} {4}" -f $model, $kv, ("{0:N2}" -f $x), ("{0:N2}" -f $y),
+      ("{0:N1}%" -f (100*($y-$x)/$x))
   }
 }
 

--- a/scripts/sweeps/decode-step-profile.ps1
+++ b/scripts/sweeps/decode-step-profile.ps1
@@ -1,0 +1,87 @@
+# Where does a decode step's time actually go?
+#
+# TODO.md section 2c says decode reaches only part of the card's memory bandwidth and that the
+# next step is "a profile of one decode step to find where the stall is -- occupancy, L2
+# behaviour, or a launch gap between the per-layer kernels". This is that profile.
+#
+# It answers the cheapest question first, which is the launch-gap one: add up the time the GPU
+# spends inside kernels during the captured window and compare it with the wall time of the
+# window. Whatever is missing is the GPU idle between kernels, and no amount of kernel tuning
+# recovers it. Then it ranks kernels by total time so the next question has somewhere to go.
+#
+# ninfer_bench's --profile-measured brackets exactly one measured repetition with
+# cudaProfilerStart/Stop, and nsys --capture-range=cudaProfilerApi records only that, so the
+# report is one clean decode run rather than model loading and warmup.
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\decode-step-profile.ps1
+#
+# A few minutes per configuration. Reports land under $NINFER_SWEEP_OUT as .nsys-rep plus the
+# exported CSVs, which are the artifact -- the console summary below is a convenience.
+$ErrorActionPreference = 'Continue'
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
+
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+$nsys = if ($env:NINFER_NSYS) { $env:NINFER_NSYS } else {
+  'C:\Program Files\NVIDIA Corporation\Nsight Systems 2024.6.2\target-windows-x64\nsys.exe' }
+if (-not (Test-Path $nsys)) { throw "nsys not found at $nsys; set NINFER_NSYS" }
+
+# Both models, because the two sit at very different fractions of the achievable ceiling and the
+# reason is expected to differ: the dense one streams 15.7 GB per token in long contiguous runs,
+# the MoE 2.5 GB of which 0.58 GB is a gather of 8 expert blocks out of 256 per layer.
+$configs = @(
+  @{ key='27b-dense'; path="$modelDir\qwen3_8_27b.ninfer";      depth=4096 }
+  @{ key='35b-moe';   path="$modelDir\qwen3_6_35b_a3b.ninfer";  depth=4096 }
+)
+
+foreach ($c in $configs) {
+  if (-not (Test-Path $c.path)) { "$($c.key): MISSING $($c.path)"; continue }
+  $stem = "$out\prof_$($c.key)"
+  Remove-Item "$stem.nsys-rep","$stem.sqlite" -ErrorAction SilentlyContinue
+
+  & $nsys profile --force-overwrite true --output $stem `
+      --trace cuda --capture-range cudaProfilerApi --capture-range-end stop `
+      .\build-ninja\bench\ninfer_bench.exe `
+      --weights $c.path --kv-dtype int8 --max-ctx 8192 `
+      -pg "$($c.depth),128" -r 1 --warmup 1 --profile-measured `
+      > "$stem.log" 2>&1
+  if (-not (Test-Path "$stem.nsys-rep")) {
+    "$($c.key): profile FAILED"
+    Get-Content "$stem.log" -Tail 5 | ForEach-Object { "    $_" }
+    continue
+  }
+
+  & $nsys stats --report cuda_gpu_kern_sum,cuda_gpu_trace --format csv `
+      --output "$stem" "$stem.nsys-rep" > "$stem.stats.log" 2>&1
+
+  $trace = "$stem`_cuda_gpu_trace.csv"
+  $kern  = "$stem`_cuda_gpu_kern_sum.csv"
+  if (-not (Test-Path $trace)) { "$($c.key): no trace CSV"; continue }
+
+  # Busy time is the union of kernel intervals; wall time is first start to last end. The
+  # difference is the GPU sitting idle waiting for the host to launch the next kernel, which on a
+  # per-layer decode with dozens of small launches is the failure mode worth ruling out first.
+  $rows = Import-Csv $trace | Where-Object { $_.'Start (ns)' -and $_.'Duration (ns)' }
+  if (-not $rows) { "$($c.key): trace CSV had no kernel rows"; continue }
+  $starts = $rows | ForEach-Object { [double]$_.'Start (ns)' }
+  $ends   = $rows | ForEach-Object { [double]$_.'Start (ns)' + [double]$_.'Duration (ns)' }
+  $busy   = ($rows | Measure-Object -Property 'Duration (ns)' -Sum).Sum
+  $wall   = ($ends | Measure-Object -Maximum).Maximum - ($starts | Measure-Object -Minimum).Minimum
+
+  ""
+  "== $($c.key) at depth $($c.depth), int8, one measured repetition =="
+  "  kernel launches        : {0:N0}" -f $rows.Count
+  "  GPU busy               : {0:N3} ms" -f ($busy / 1e6)
+  "  window wall            : {0:N3} ms" -f ($wall / 1e6)
+  "  idle between kernels   : {0:N3} ms  ({1:N1}% of the window)" -f `
+      (($wall - $busy) / 1e6), (100 * ($wall - $busy) / $wall)
+  if (Test-Path $kern) {
+    "  top kernels by total time:"
+    Import-Csv $kern | Select-Object -First 8 | ForEach-Object {
+      "    {0,8:N2} ms  {1,6} x  {2}" -f ([double]$_.'Total Time (ns)' / 1e6), $_.Instances, $_.Name
+    }
+  }
+}
+"== done =="

--- a/scripts/sweeps/kv-perplexity.ps1
+++ b/scripts/sweeps/kv-perplexity.ps1
@@ -12,7 +12,15 @@ New-Item -ItemType Directory -Force -Path $out | Out-Null
 
 # Same corpus, mode and window as the three already recorded in README.md, so the new rows are
 # directly comparable rather than a separate experiment: ninfer-ppl-1m-v1, --quick, 4096/2048.
-$dtypes = @('fp8','nvfp4','k8v4')
+# The three that were measured through the attention race #49 fixed. Override to add a control:
+# NINFER_SWEEP_DTYPES=int8,fp8,nvfp4,k8v4 checks that this harness still reproduces README's int8
+# figure, which is the only way to know a changed fp8 number means the kernel changed rather than
+# the corpus, window or build having drifted underneath it.
+$dtypes = if ($env:NINFER_SWEEP_DTYPES) {
+  $env:NINFER_SWEEP_DTYPES -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+} else {
+  @('fp8','nvfp4','k8v4')
+}
 
 foreach ($d in $dtypes) {
     $log = "$out\$d.log"

--- a/tools/decode_byte_accounting.py
+++ b/tools/decode_byte_accounting.py
@@ -114,6 +114,8 @@ def main() -> None:
                         help="cache depth in tokens; repeatable")
     parser.add_argument("--tok-s", type=float, action="append", default=[],
                         help="measured decode tok/s at the matching --depth; repeatable")
+    parser.add_argument("--json", action="store_true",
+                        help="emit the byte counts as JSON, for scripts that need the denominator")
     args = parser.parse_args()
 
     if len(args.tok_s) != len(args.depth):
@@ -121,6 +123,10 @@ def main() -> None:
 
     result = account(read_directory(args.artifact))
     per_token = float(result["per_token"])
+
+    if args.json:
+        print(json.dumps({k: v for k, v in result.items() if k != "unread"}))
+        return
 
     print(f"{args.artifact.name}: bytes read per decoded token, one lane, no speculation")
     print(f"  dense weights, every token          : {result['dense']:>15,} B")


### PR DESCRIPTION
perf(sweeps): make the roofline use the read set it now has, and add the decode-step profile

#50 added tools/decode_byte_accounting.py and updated decode-roofline.ps1's comment, but left the
script dividing throughput into `weights_capacity_bytes`. That is the number that returns 418% of
peak on the A3B -- the non-result TODO.md section 2c already called out. The script now asks the
tool (new --json) for the per-token read set instead of hardcoding a denominator, so there is one
source of truth and it is derived from the artifact rather than typed in.

Re-run against the post-barrier sweep, RTX 3090, achievable read ceiling 854.2 GB/s:

    model        kv      depth    tok/s    % achievable
    27b dense    int8     4,096   37.44        69.6%
    27b dense    int8    32,768   33.56        66.2%
    35b MoE      int8     4,096  169.55        50.9%
    35b MoE      int8    32,768  153.62        51.6%

The MoE number is flat to within a point across an eightfold change in cache depth, which is a
much cleaner signal than the dense model's gentle decay: whatever limits it is not the cache.

Also adds a falloff table to the same script, because the comparison that matters for section 2c
is between formats rather than between depths, and computing it by hand from twelve rows invites
arithmetic slips.

    model        kv      4096     32768    falloff
    27b dense    int8    37.44    33.56    -10.4%
    27b dense    rk8v4   36.11    33.24     -7.9%
    27b dense    fp8     34.83    30.48    -12.5%
    27b dense    k8v4    34.32    28.97    -15.6%
    27b dense    nvfp4   35.52    29.14    -18.0%
    35b MoE      int8   169.55   153.62     -9.4%
    35b MoE      rk8v4  169.99   157.71     -7.2%
    35b MoE      fp8    163.90   129.00    -21.3%
    35b MoE      k8v4   165.50   122.51    -26.0%
    35b MoE      nvfp4  169.37   133.06    -21.4%

**This is measured after #49, and it settles something.** Section 2c observed that the three
formats with the worst falloff are exactly the three that were not run-to-run deterministic, and
wondered whether one explained the other. It does not: the non-determinism is fixed and the
falloff is unchanged -- fp8/k8v4/nvfp4 still decay two to three times as fast as int8/rk8v4. The
correlation is real and still wants its own explanation. #49 also costs essentially nothing:
27B fp8 reads 34.83/32.18/30.48 against 35.28/32.57/30.13 before, inside run-to-run spread.

`scripts/sweeps/decode-step-profile.ps1` is the next step section 2c asks for and had no tooling
for: nsys with --capture-range=cudaProfilerApi around ninfer_bench --profile-measured, which
records exactly one measured decode repetition rather than load and warmup. It reports GPU busy
time against the window's wall time first -- the launch-gap question, which no kernel tuning
recovers -- and then ranks kernels.

`kv-perplexity.ps1` gains the same NINFER_SWEEP_DTYPES override kv-decode-vs-depth.ps1 has, so the
re-measurement #49 forces can include int8 as a control: without one, a changed fp8 figure cannot
be attributed to the kernel rather than to the corpus or build drifting.

