### PR TITLE
perf(attention): drop the SmallTMaximumSplits bump; more splits at depth is worse

### DIFF
--- a/src/ops/softmax_attention/dense/causal_cache/small_t.cu
+++ b/src/ops/softmax_attention/dense/causal_cache/small_t.cu
@@ -46,11 +46,26 @@ std::int32_t causal_small_t_split_upper_bound(std::int32_t window) {
 template <typename Geometry>
 std::int32_t causal_small_t_split_count(std::int32_t window, std::int32_t tokens,
                                         KvCacheStorage storage) {
-    if constexpr (Geometry::SmallTSplitScale == 1) {
-        if (storage == KvCacheStorage::Fp8E4M3Row256 && tokens == 1 && window > 8198) {
-            return Geometry::SmallTMaximumSplits;
-        }
-    }
+    // There used to be a SmallTMaximumSplits bump here for Fp8E4M3Row256 at tokens==1 and
+    // window>8198, and the device asked for that bump for *every* quantized storage while only
+    // fp8 was granted it. TODO.md section 2c read the asymmetry as the host shortchanging nvfp4
+    // and k8v4 -- 69 splits where their kernels asked for 85 -- and proposed extending the grant.
+    //
+    // Measured on this 3090, and it is the other way round: more splits at depth is worse.
+    // Extending the grant to nvfp4 and k8v4 cost them 2.3-3.1% on the 35B at every depth, against
+    // an fp8 control that moved 0.3%. Removing it from fp8 as well gained 0.4/0.5/1.2% at
+    // 4,096/16,384/32,768 over two samples per variant, with within-variant spread well under the
+    // difference at the two deeper points.
+    //
+    // So the bump is gone from both sides -- here, and from
+    // causal_small_t_quantized_active_splits -- and every quantized storage now takes the same
+    // default tier. That also retires the invariant section 2c flagged as held by coincidence:
+    // the partial kernel and the reducer no longer depend on two call sites happening to agree
+    // about a special case, because there is no special case.
+    //
+    // The 27B was not conclusive either way (its fp8 control moved +-3% between identical runs,
+    // which is worth knowing before trusting any single-sample result on that model).
+
     // A 64-key default split just above a 32-key boundary makes the partial kernel execute a
     // nearly empty second tile. T=5 uses one 32-key tile per split; the short T>=6 profile keeps
     // all newly appended rows in one tail split while retaining a useful B=8 grid.

--- a/src/ops/softmax_attention/dense/causal_cache/small_t.cuh
+++ b/src/ops/softmax_attention/dense/causal_cache/small_t.cuh
@@ -119,13 +119,17 @@ __device__ __forceinline__ int causal_small_t_active_splits(int window, int laun
     return splits < launch_capacity ? splits : launch_capacity;
 }
 
+// Quantized storages take the plain default tier. This used to ask for SmallTMaximumSplits at
+// tokens==1 and window>8198 while the host granted that capacity to fp8 only, so nvfp4 and k8v4
+// silently ran fewer splits than this function returned and the two sides disagreed about intent.
+// Measurement said the host's default was the better number for all of them (see
+// causal_small_t_split_count in small_t.cu), so the request is gone rather than the grant
+// extended, and this now agrees with the host by construction.
 template <typename Geometry>
 __device__ __forceinline__ int
 causal_small_t_quantized_active_splits(int window, int launch_capacity, int tokens) {
-    int splits = causal_small_t_default_splits<Geometry>(window);
-    if constexpr (Geometry::SmallTSplitScale == 1) {
-        if (tokens == 1 && window > 8198) { splits = Geometry::SmallTMaximumSplits; }
-    }
+    (void)tokens;
+    const int splits = causal_small_t_default_splits<Geometry>(window);
     return splits < launch_capacity ? splits : launch_capacity;
 }
 


### PR DESCRIPTION
perf(attention): drop the SmallTMaximumSplits bump; more splits at depth is worse

TODO.md section 2c found that the device asked for `SmallTMaximumSplits` for every quantized
storage while the host granted that capacity to `Fp8E4M3Row256` only, so at a 32,768-token decode
nvfp4 and k8v4 ran the default 69 splits where their own kernels asked for 85. It read that as the
host shortchanging them at exactly the depths where they measure worst, and proposed extending the
grant.

Measured, and it is the other way round.

**Extending the grant to nvfp4 and k8v4 made them slower.** 35B-A3B, decode tok/s, with fp8 as an
unchanged control:

    kv       role        4,096    16,384   32,768
    fp8      CONTROL     +0.3%     -0.0%    +0.1%
    nvfp4    changed     -3.1%     -2.5%    -2.3%
    k8v4     changed     -2.5%     -2.8%    -2.4%

**Removing it from fp8 as well made fp8 faster.** Two samples per variant, 35B-A3B:

    depth     bump (85)        no bump (69)     delta
     4,096   164.14 +-0.24    164.86 +-0.39     +0.4%
    16,384   146.92 +-0.02    147.72 +-0.09     +0.5%
    32,768   129.04 +-0.04    130.54 +-0.62     +1.2%

Within-variant spread is an order of magnitude below the difference at the two deeper points.

So the bump is removed from both sides -- the host grant in `causal_small_t_split_count` and the
device request in `causal_small_t_quantized_active_splits` -- and every quantized storage now
takes the same default tier. fp8 moves onto the path nvfp4 and k8v4 already ran, which is the
better-tested one.

That also retires the invariant section 2c flagged as "held by coincidence of two separate call
sites rather than by construction": the partial kernel skips `write_neutral()` for splits past
`active_split_count` on the assumption that the reducer computes the same bound, and the two now
agree because neither has a special case left to disagree about.

**The 27B is not evidence either way and that is worth recording.** Its fp8 control moved
+2.5%/+2.9%/+0.3% between two runs of identical code, so nothing on that model is readable at this
sample size; the deltas there came out +3.8%/+1.9%/-1.1% and mean nothing. Any future single-sample
claim on the 27B decode sweep should be treated the same way.

This does not touch the falloff itself. fp8 still decays about 21% from 4,096 to 32,768 on the 35B
against int8's 9%, and section 2c's remaining candidate for that -- `KeyBlock` pinned to 32 because
sm_86's shared-memory budget cannot hold dequantized BF16 copies of both K and V -- is untested.

`ninfer_softmax_attention_test`, `context_softmax_attention` and `packed_softmax_attention` all
pass.

