### PR TITLE
perf(sweeps): profile a decode step, and localise the MoE's missing bandwidth

### DIFF
--- a/scripts/sweeps/decode-step-profile.ps1
+++ b/scripts/sweeps/decode-step-profile.ps1
@@ -9,6 +9,12 @@
 # window. Whatever is missing is the GPU idle between kernels, and no amount of kernel tuning
 # recovers it. Then it ranks kernels by total time so the next question has somewhere to go.
 #
+# **--cuda-graph-trace node is not optional here.** Decode replays a captured CUDA graph, and
+# nsys's default graph tracing records the replay as one opaque entity rather than its nodes. The
+# per-kernel trace then contains only the handful of kernels launched outside the graph, and the
+# arithmetic below reports 99.3% of the window as GPU idle -- which is an artifact of the
+# instrument, not a launch gap. Ask for node-level tracing and the graph's kernels appear.
+#
 # ninfer_bench's --profile-measured brackets exactly one measured repetition with
 # cudaProfilerStart/Stop, and nsys --capture-range=cudaProfilerApi records only that, so the
 # report is one clean decode run rather than model loading and warmup.
@@ -28,12 +34,18 @@ $nsys = if ($env:NINFER_NSYS) { $env:NINFER_NSYS } else {
   'C:\Program Files\NVIDIA Corporation\Nsight Systems 2024.6.2\target-windows-x64\nsys.exe' }
 if (-not (Test-Path $nsys)) { throw "nsys not found at $nsys; set NINFER_NSYS" }
 
-# Both models, because the two sit at very different fractions of the achievable ceiling and the
-# reason is expected to differ: the dense one streams 15.7 GB per token in long contiguous runs,
-# the MoE 2.5 GB of which 0.58 GB is a gather of 8 expert blocks out of 256 per layer.
+# Two workloads per model, because the first attempt at this conflated them and the answer is
+# different for each. `-pg 4096,128` prefills 4,096 tokens and then decodes 128, and the prefill
+# dominates the capture completely -- the 27B's top kernel came back as 256 launches of
+# q4a8_swiglu, which is 4 prefill chunks x 64 layers, and causal_attention_*prompt*_i8 sat in the
+# top eight. None of that is decode. `-n 128` decodes only, on a shallow cache, which is the
+# workload the roofline question is actually about: decode streams the resident weights whatever
+# the cache depth, so a shallow cache is fine for asking where the time goes.
 $configs = @(
-  @{ key='27b-dense'; path="$modelDir\qwen3_8_27b.ninfer";      depth=4096 }
-  @{ key='35b-moe';   path="$modelDir\qwen3_6_35b_a3b.ninfer";  depth=4096 }
+  @{ key='27b-dense-decode';  path="$modelDir\qwen3_8_27b.ninfer";     args=@('-n','128') }
+  @{ key='35b-moe-decode';    path="$modelDir\qwen3_6_35b_a3b.ninfer"; args=@('-n','128') }
+  @{ key='27b-dense-prefill'; path="$modelDir\qwen3_8_27b.ninfer";     args=@('-pg','4096,128') }
+  @{ key='35b-moe-prefill';   path="$modelDir\qwen3_6_35b_a3b.ninfer"; args=@('-pg','4096,128') }
 )
 
 foreach ($c in $configs) {
@@ -42,10 +54,10 @@ foreach ($c in $configs) {
   Remove-Item "$stem.nsys-rep","$stem.sqlite" -ErrorAction SilentlyContinue
 
   & $nsys profile --force-overwrite true --output $stem `
-      --trace cuda --capture-range cudaProfilerApi --capture-range-end stop `
+      --trace cuda --cuda-graph-trace node --capture-range cudaProfilerApi --capture-range-end stop `
       .\build-ninja\bench\ninfer_bench.exe `
       --weights $c.path --kv-dtype int8 --max-ctx 8192 `
-      -pg "$($c.depth),128" -r 1 --warmup 1 --profile-measured `
+      @($c.args) -r 1 --warmup 1 --profile-measured `
       > "$stem.log" 2>&1
   if (-not (Test-Path "$stem.nsys-rep")) {
     "$($c.key): profile FAILED"
@@ -71,7 +83,7 @@ foreach ($c in $configs) {
   $wall   = ($ends | Measure-Object -Maximum).Maximum - ($starts | Measure-Object -Minimum).Minimum
 
   ""
-  "== $($c.key) at depth $($c.depth), int8, one measured repetition =="
+  "== $($c.key), int8, one measured repetition =="
   "  kernel launches        : {0:N0}" -f $rows.Count
   "  GPU busy               : {0:N3} ms" -f ($busy / 1e6)
   "  window wall            : {0:N3} ms" -f ($wall / 1e6)


### PR DESCRIPTION
perf(sweeps): profile a decode step, and localise the MoE's missing bandwidth

TODO.md section 2c asked for a profile of one decode step to find where the stall is --
"occupancy, L2 behaviour, or a launch gap between the per-layer kernels". This is that profile,
and it answers the question: on the MoE the gap is inside the expert kernels.

**Two instrument bugs first, because both produced confident nonsense.**

`-pg 4096,128` puts prefill and decode in one capture and prefill dominates it completely: the
27B's top kernel came back as 256 launches of q4a8_swiglu -- 4 prefill chunks x 64 layers -- with
causal_attention_*prompt*_i8 in the top eight. Almost none of it was decode. The script now runs
`-n 128` for decode alone and keeps `-pg` as a separately labelled prefill row.

Then decode reported **99.3% of the window as GPU idle**, from 807 launches over 128 steps of a
64-layer model -- about six kernels per step, which cannot be a forward pass. Decode replays a
captured CUDA graph and nsys's default `--cuda-graph-trace=graph` records the replay as one opaque
entity, so the trace held only the kernels launched outside the graph. `--cuda-graph-trace=node`
is mandatory here and the script now says so.

**With the instrument fixed:**

    workload                 launches   GPU busy    wall     idle
    27B dense  decode          83,623   3,368 ms   3,528 ms   4.5%
    35B-A3B    decode          57,770     708 ms     811 ms  12.6%
    27B dense  prefill         87,110   6,524 ms   6,684 ms   2.4%
    35B-A3B    prefill         60,715   1,397 ms   1,504 ms   7.1%

So launch gaps are **not** the dense path's problem, and only a third of the MoE's. Dividing the
read set (tools/decode_byte_accounting.py) into busy time alone:

    27B dense  26.314 ms/token busy -> 598 GB/s = 70.0% of achievable while busy
    35B-A3B     5.532 ms/token busy -> 456 GB/s = 53.4% of achievable while busy

Both shortfalls are inside the kernels, not between them.

**And on the MoE the shortfall has an address.** Attributing bytes from the artifact inventory,
using instance counts to fix the mapping (129 rounds, 40 text layers, 8 of 256 experts):

    kernel                                     bytes     time    achieved  % achievable
    sparse_moe_d3  (routed gate_up, 8/256)    8.91 MB   23.4 us   381 GB/s     44.6%
    sparse_moe_d4  (routed down, 8/256)       5.58 MB   16.4 us   340 GB/s     39.9%
    w8_k2048_decode (gdn qkv_z)              26.74 MB   38.2 us   700 GB/s     81.9%
    q6_rowsplit_gemm_simt (output head)     397.31 MB  595.6 us   667 GB/s     78.1%

The expert kernels run at 40-45% of what the card can read, while the *contiguous* weight kernels
in the same model on the same step reach 78-82%. That is the gather of eight scattered expert
blocks per layer, measured rather than suspected, and it is where the MoE's thirty points of
headroom live. The four sparse_moe stages together are 38% of decode busy time.

The 27B is a different shape: 86% of its busy time is four GEMV kernels that *are* the weight
streaming, so its remaining thirty points are inside those, not in overhead or scheduling.

Nothing here changes behaviour -- the script is new and the findings are for section 2c.

