### PR TITLE
build: keep the builder's absolute paths out of the Linux binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,28 @@ else()
   add_compile_options(
     $<$<COMPILE_LANGUAGE:C,CXX>:-Wimplicit-fallthrough>
     $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=implicit-fallthrough>)
+
+  # Keep the builder's absolute paths out of the shipped binaries. `__FILE__` and nvcc's own source
+  # references otherwise embed wherever the tree happened to sit: the v0.9.0 Linux binaries carry
+  # `/home/ash/ninfer-rel/src/...` about 200 times, and v0.8.1 carried `/mnt/c/ninfer-fork/...` 405
+  # times. Not a secret -- the file names are public and no path contains a home directory -- but
+  # it makes every assertion message shorter and more readable, and it makes two builds of the same
+  # commit from different directories produce closer output.
+  #
+  # Verified on this box under real Linux g++: `/tmp/ftest/sub/a.cpp` becomes `./sub/a.cpp`, and
+  # the absolute prefix disappears from `strings` entirely.
+  #
+  # **There is no working MSVC equivalent, and this was measured rather than assumed.** MSVC takes
+  # `__FILE__` from the path as written on the command line, and CMake writes absolute paths;
+  # `/d1trimfile:`, the usual suggestion, is undocumented and had *no effect* on `__FILE__` when
+  # tested against 14.44.35207 with an absolute source path. So the Windows binaries keep their
+  # ~466 occurrences until something better turns up.
+  #
+  # -Xcompiler reaches the host half of a .cu translation unit. Device-side `__FILE__` comes from
+  # nvcc's own frontend and has no documented remapping flag, so it is not covered here.
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:C,CXX>:-ffile-prefix-map=${PROJECT_SOURCE_DIR}=.>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-ffile-prefix-map=${PROJECT_SOURCE_DIR}=.>)
 endif()
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/TODO.md
+++ b/TODO.md
@@ -749,14 +749,21 @@ doing:
       which immediately found four scripts committed at 644, including
       `scripts/package-release-v090.sh`, the current release's own Linux packager.
 
-- [ ] **Binaries embed their build directory.** `/home/ash/ninfer-rel/src/...` appears 200 times in
-      the Linux binaries and `C:\ninfer-fork\ninfer-3090\...` about 466 times in the Windows ones,
-      via `__FILE__` and nvcc source paths. Pre-existing (v0.8.1 embedded `/mnt/c/ninfer-fork/...`
-      405 times) and not a secret — the file names are already public and no Windows binary
-      contains a `C:\Users\...` path. `-ffile-prefix-map=` plus `--compiler-options` for nvcc would
-      rewrite them to relative paths, which also makes assertion messages more readable. MSVC has
-      no documented equivalent; `/d1trimfile:` is the usual answer and is undocumented. Cosmetic;
-      do it with a release build, not on its own.
+- [x] **Binaries embed their build directory.** Half fixed, and the other half measured as not
+      fixable. Closed 2026-09-09.
+
+      `-ffile-prefix-map=${PROJECT_SOURCE_DIR}=.` is now set for C, C++ and (via `-Xcompiler`) the
+      host half of CUDA translation units on GCC/Clang, which covers the Linux binaries and their
+      ~200 occurrences of `/home/ash/ninfer-rel/src/...`. Verified under real Linux g++ on this
+      box: `/tmp/ftest/sub/a.cpp` becomes `./sub/a.cpp` and the absolute prefix leaves `strings`
+      entirely.
+
+      **MSVC has no working equivalent and that is measured, not assumed.** It takes `__FILE__`
+      from the path as written on the command line and CMake writes absolute ones; the usual
+      suggestion, the undocumented `/d1trimfile:`, had *no effect* on `__FILE__` when tested
+      against 14.44.35207 with an absolute source path. The Windows binaries keep their ~466
+      occurrences. Device-side `__FILE__` from nvcc's own frontend is not covered either -- there
+      is no documented flag for it.
 
 ## 7. Closed this cycle, and what it taught
 


### PR DESCRIPTION
build: keep the builder's absolute paths out of the Linux binaries

TODO.md section 6: `/home/ash/ninfer-rel/src/...` appears about 200 times in the v0.9.0 Linux
binaries and `C:\ninfer-fork\ninfer-3090\...` about 466 times in the Windows ones, via `__FILE__`
and nvcc source paths. Cosmetic -- the file names are already public and no path contains a home
directory -- but it shortens every assertion message and makes two builds of one commit from
different directories agree.

`-ffile-prefix-map=${PROJECT_SOURCE_DIR}=.` is set for C, C++ and, through `-Xcompiler`, the host
half of CUDA translation units, on GCC and Clang.

Verified rather than assumed, three ways:

  * bare g++ under real Linux: `/tmp/ftest/sub/a.cpp` becomes `./sub/a.cpp`, and `strings` goes
    from one match on the absolute prefix to zero;
  * the same through a minimal CMake project using this exact generator expression, which is what
    proves the syntax as written here is valid -- this box builds the MSVC branch, so the new lines
    are never compiled locally and shipping them unexercised would have been a guess;
  * the Windows build still configures and builds, unchanged.

**MSVC gets nothing, and that is measured.** It takes `__FILE__` from the path as written on the
command line and CMake writes absolute paths, so no flag on the compile line changes it. The usual
suggestion is the undocumented `/d1trimfile:`; tested against 14.44.35207 with an absolute source
path it had **no effect** on `__FILE__` at all. The Windows binaries keep their ~466 occurrences
until something better turns up, and the comment in CMakeLists says so rather than leaving the next
person to rediscover it.

Device-side `__FILE__` comes from nvcc's own frontend and has no documented remapping flag, so it
is not covered either. `-Xcompiler` reaches only the host half.

