### PR TITLE
fix(runtime): stop losing pending CUDA errors and stop misreporting the host KV clamp

### DIFF
--- a/.github/workflows/host-checks.yml
+++ b/.github/workflows/host-checks.yml
@@ -13,6 +13,11 @@
 #     launchers once shipped with CRLF that made them unparseable on Linux, and every tool on the
 #     Windows box called the tree clean because Git Bash strips CR on read. Only real Linux bash
 #     saw it.
+#
+#   * tests/host/test_host_kv_clamp.cpp -- pins the pinned-host-KV-cache clamp arithmetic
+#     (src/core/host_kv_clamp.h) used by the Windows startup path in program_impl.h. It has no
+#     CUDA dependency by design, precisely so this one piece of that path can be regression-tested
+#     without the sm_86 device the rest of the suite needs.
 name: Host checks
 
 on:
@@ -37,6 +42,17 @@ jobs:
       # sandbox, which is what keeps docs/config-calculator.html a single file.
       - name: Run docs/config-calculator.test.mjs
         run: node docs/config-calculator.test.mjs
+
+  host-kv-clamp:
+    name: Host KV clamp arithmetic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run tests/host/test_host_kv_clamp.cpp
+        run: |
+          g++ -std=c++20 -Wall -Wextra -Isrc tests/host/test_host_kv_clamp.cpp \
+              -o test_host_kv_clamp
+          ./test_host_kv_clamp
 
   linux-scripts:
     name: Linux launcher and downloader guard

--- a/src/core/arena.cu
+++ b/src/core/arena.cu
@@ -406,6 +406,17 @@ PinnedHostBuffer::PinnedHostBuffer(std::size_t size_bytes) {
         throw std::runtime_error(cuda_error_message(prefix.c_str(), err));
     }
 
+    // The pending error read above is now gone for good -- `cudaGetLastError()` clears it, and
+    // nothing else has seen it since. A successful pin does not mean it never mattered: it means
+    // an earlier, unrelated CUDA call failed and nobody checked. Report it rather than let it
+    // disappear silently.
+    if (pending != cudaSuccess) {
+        std::fprintf(stderr,
+                      "ninfer: pinning %zu bytes of host memory succeeded, but cleared an "
+                      "unretrieved earlier CUDA error: %s: %s\n",
+                      size_bytes, cudaGetErrorName(pending), cudaGetErrorString(pending));
+    }
+
     data_ = ptr;
     size_ = size_bytes;
 }

--- a/src/core/host_kv_clamp.h
+++ b/src/core/host_kv_clamp.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstddef>
+
+namespace ninfer {
+
+// The pinned host KV cache competes with the model for *device* memory on Windows (WDDM maps a
+// pinned host allocation into the GPU's address space and charges it against the same budget --
+// see the measured numbers and failure mode next to this function's caller in program_impl.h).
+// Clamp the requested reservation to what is actually safe to take, rounding the result down to a
+// whole number of KV pages so the caller never has to deal with a partial-page remainder.
+//
+// Pure arithmetic, no CUDA dependency, so it can be unit-tested without a device -- see
+// tests/host/test_host_kv_clamp.cpp.
+inline std::size_t clamp_host_kv_reservation_bytes(std::size_t requested_bytes,
+                                                    std::size_t free_device_bytes,
+                                                    std::size_t minimum_stride) noexcept {
+    constexpr std::size_t kPinnedHostReserveBytes = 1ULL << 30;
+    const std::size_t budget = free_device_bytes > kPinnedHostReserveBytes
+                                    ? (free_device_bytes - kPinnedHostReserveBytes) / 2
+                                    : 0;
+    if (requested_bytes > budget) { return budget - (budget % minimum_stride); }
+    return requested_bytes;
+}
+
+} // namespace ninfer

--- a/src/serve/operational_log.cpp
+++ b/src/serve/operational_log.cpp
@@ -463,11 +463,15 @@ void OperationalLog::engine_capacity(const GenerationService& service) const {
                   product::format_pretty_bytes(memory.available_after_startup_bytes));
 
     if (cache.enabled) {
+        // Report what was actually pinned, not what was requested: on Windows the host KV cache
+        // is clamped against free VRAM at startup (program_impl.h), and can land at zero while
+        // `cache.host_kv_capacity_bytes` still holds the pre-clamp --host-kv-mib target. The
+        // memory summary is captured after that clamp runs, so it carries the true figure.
         logger_->info(
             "context cache | {} active + {} cached device states | host {} states, {} KV | "
             "private {} | shared {} | anchors {}",
             engine.max_concurrency, *cache.device_state_slots, cache.host_state_slots,
-            product::format_pretty_bytes(cache.host_kv_capacity_bytes),
+            product::format_pretty_bytes(memory.host_kv_capacity_bytes),
             *cache.max_private_continuations, *cache.max_shared_prefixes,
             *cache.max_long_anchors_per_continuation);
     } else {

--- a/src/targets/qwen3_6/impl/runtime/program_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/program_impl.h
@@ -2,6 +2,7 @@
 #include "targets/qwen3_6/impl/runtime/program.h"
 #include "targets/qwen3_6/impl/runtime/rebuild_work.h"
 
+#include "core/host_kv_clamp.h"
 #include "core/nvtx.h"
 #include "core/startup.h"
 #include "targets/qwen3_6/impl/runtime/schedule.h"
@@ -1016,24 +1017,20 @@ ProgramImplCore::ProgramImplCore(const LoadedModelData& model_in, const Sequence
         // device pages alone rather than the server failing to start.
         std::size_t reserved_bytes = plan.context_cache.host_kv_capacity_bytes;
 #if defined(_WIN32)
+        // Two terms, both learned the hard way. The 1 GiB floor (inside
+        // clamp_host_kv_reservation_bytes) is memory the run still needs after this point and
+        // that no plan accounts for: module loads, graph instantiation and the local-memory
+        // backing a launch requires. Clamping only to "free minus a few hundred MiB" got startup
+        // past the pin and then failed at the first kernel launch with
+        // `cudaErrorMemoryAllocation` from `cudaGetLastError`, which is a far worse failure than
+        // not starting.
+        //
+        // Halving what remains is the conservative split when the requirement on the other side
+        // is not known precisely: the cache never takes more headroom than it leaves.
         std::size_t free_device = 0, total_device = 0;
         if (cudaMemGetInfo(&free_device, &total_device) == cudaSuccess) {
-            // Two terms, both learned the hard way. The 1 GiB floor is memory the run still needs
-            // after this point and that no plan accounts for: module loads, graph instantiation
-            // and the local-memory backing a launch requires. Clamping only to "free minus a few
-            // hundred MiB" got startup past the pin and then failed at the first kernel launch
-            // with `cudaErrorMemoryAllocation` from `cudaGetLastError`, which is a far worse
-            // failure than not starting.
-            //
-            // Halving what remains is the conservative split when the requirement on the other
-            // side is not known precisely: the cache never takes more headroom than it leaves.
-            constexpr std::size_t kPinnedHostReserveBytes = 1ULL << 30;
-            const std::size_t budget =
-                free_device > kPinnedHostReserveBytes ? (free_device - kPinnedHostReserveBytes) / 2
-                                                      : 0;
-            if (reserved_bytes > budget) {
-                reserved_bytes = budget - (budget % minimum_stride);
-            }
+            reserved_bytes =
+                clamp_host_kv_reservation_bytes(reserved_bytes, free_device, minimum_stride);
         }
 #endif
 

--- a/tests/host/test_host_kv_clamp.cpp
+++ b/tests/host/test_host_kv_clamp.cpp
@@ -1,0 +1,57 @@
+// Pins the pinned-host-KV-cache clamp formula (src/core/host_kv_clamp.h) against known inputs.
+// Deliberately dependency-free -- no CUDA, no project headers beyond the one under test -- so it
+// can build and run on a GitHub-hosted runner. See .github/workflows/host-checks.yml.
+
+#include "core/host_kv_clamp.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+int failures = 0;
+
+void expect_eq(std::size_t actual, std::size_t expected, const char* label) {
+    if (actual != expected) {
+        std::fprintf(stderr, "%s: expected %zu, got %zu\n", label, expected, actual);
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main() {
+    using ninfer::clamp_host_kv_reservation_bytes;
+
+    // Plenty of free VRAM: the request fits under the budget untouched.
+    expect_eq(clamp_host_kv_reservation_bytes(1ULL << 30, 20ULL << 30, 1ULL << 20), 1ULL << 30,
+              "ample headroom leaves the request untouched");
+
+    // free_device just over the 1 GiB reserve: budget is (free - 1GiB) / 2, rounded to stride.
+    // free_device = 3 GiB -> budget = 1 GiB exactly; request of 2 GiB must clamp down to it.
+    expect_eq(clamp_host_kv_reservation_bytes(2ULL << 30, 3ULL << 30, 1ULL << 20), 1ULL << 30,
+              "clamps to half of what remains past the 1 GiB floor");
+
+    // free_device at or below the 1 GiB floor: budget is zero, clamping to zero is supported.
+    expect_eq(clamp_host_kv_reservation_bytes(1ULL << 30, 1ULL << 30, 1ULL << 20), 0,
+              "free VRAM at the floor clamps the reservation to zero");
+    expect_eq(clamp_host_kv_reservation_bytes(1ULL << 30, 512ULL << 20, 1ULL << 20), 0,
+              "free VRAM under the floor clamps the reservation to zero");
+
+    // Budget not an exact multiple of the page stride: rounds down, never up. free_device is
+    // 1 GiB + 10 MiB past the floor, so the budget is 5 MiB; a 3 MiB stride does not divide that
+    // evenly, which is the case that exercises the remainder subtraction.
+    const std::size_t free_device  = (1ULL << 30) + (10ULL << 20); // 1 GiB + 10 MiB
+    const std::size_t stride       = 3ULL << 20;                   // 3 MiB pages
+    const std::size_t budget       = (free_device - (1ULL << 30)) / 2; // 5 MiB
+    const std::size_t expected     = budget - (budget % stride);       // rounds 5 MiB down to 3 MiB
+    expect_eq(clamp_host_kv_reservation_bytes(1ULL << 30, free_device, stride), expected,
+              "clamp result is rounded down to a whole number of pages");
+
+    // Request already smaller than the budget: no clamp applied, even with a tight budget.
+    expect_eq(clamp_host_kv_reservation_bytes(1ULL << 20, 3ULL << 30, 1ULL << 20), 1ULL << 20,
+              "a request under budget is returned unchanged");
+
+    if (failures == 0) { std::printf("OK host_kv_clamp: all checks passed\n"); }
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Follow-up to #39 / #45 ("size the pinned host KV cache against free VRAM, not host RAM"), which merged with CodePulse review comments unaddressed. Verified all three against current master; all were still present.

## What was still wrong

- **`src/core/arena.cu:375`** — `PinnedHostBuffer` reads `cudaGetLastError()` to disambiguate a failing pin's error message from an unrelated earlier failure, then discards it either way. When the pin *succeeded* despite a real pending error from an earlier call, that error was silently cleared and gone for good. Now reported to stderr on the success path too.

- **`src/targets/qwen3_6/impl/runtime/program_impl.h:1064`** (via `src/serve/operational_log.cpp`) — the startup "context cache" log line printed the *requested* `--host-kv-mib` target, not what was actually pinned. When the Windows VRAM clamp lands on zero, the log still claimed the full request succeeded. It now reads the post-clamp figure from the engine's own memory summary (`ProgramImplCore::memory_summary()`), captured after the clamp runs.

- **`program_impl.h:1034`** ("the Windows sizing branch lacks targeted regression coverage") — pulled the clamp arithmetic into `src/core/host_kv_clamp.h`, a pure function with no CUDA dependency, and added `tests/host/test_host_kv_clamp.cpp` against it. This actually runs in CI (new `Host KV clamp arithmetic` job), unlike the rest of the suite — `host-checks.yml` already documents that CI has no sm_86 device to build or run the CUDA test suite on.

## Testing

- `tests/host/test_host_kv_clamp.cpp` compiled and run locally (MSVC, no CUDA): all 6 cases pass.
- Did not rebuild the full CUDA project (unrelated to this change; the touched CUDA-adjacent files are `arena.cu`'s host-only constructor and a call-site swap in `program_impl.h` behind `#if defined(_WIN32)`, both mechanical).