### PR TITLE
fix(downloaders): check that the final move actually landed the artifact

### DIFF
--- a/scripts/download-qwen36-27b.bat
+++ b/scripts/download-qwen36-27b.bat
@@ -46,6 +46,10 @@ if not "!VERIFY_OK!"=="1" (
 )
 
 move /y "%PART%" "%MODEL%" >nul
+if errorlevel 1 (
+  echo Failed to move "%PART%" to "%MODEL%". Delete "%PART%" and run this file again.
+  exit /b 1
+)
 echo Model ready: %MODEL%
 echo Point the tests at it with:  set NINFER_QWEN3_6_27B_WEIGHTS=%MODEL%
 exit /b 0

--- a/scripts/download-qwen36-35b-a3b.bat
+++ b/scripts/download-qwen36-35b-a3b.bat
@@ -49,6 +49,10 @@ if not "!VERIFY_OK!"=="1" (
 )
 
 move /y "%PART%" "%MODEL%" >nul
+if errorlevel 1 (
+  echo Failed to move "%PART%" to "%MODEL%". Delete "%PART%" and run this file again.
+  exit /b 1
+)
 echo Model ready: %MODEL%
 exit /b 0
 

--- a/scripts/download-qwen38-27b.bat
+++ b/scripts/download-qwen38-27b.bat
@@ -48,6 +48,10 @@ if not "!VERIFY_OK!"=="1" (
 )
 
 move /y "%PART%" "%MODEL%" >nul
+if errorlevel 1 (
+  echo Failed to move "%PART%" to "%MODEL%". Delete "%PART%" and run this file again.
+  exit /b 1
+)
 echo Model ready: %MODEL%
 echo Point the tests at it with:  set NINFER_QWEN3_8_27B_WEIGHTS=%MODEL%
 exit /b 0


### PR DESCRIPTION
Follow-up to #48 ("pin and verify the Qwen3.8-27B fetch, and state the one that cannot be"), which merged with a CodePulse review comment unaddressed. Verified against current master; still present, and present identically in the two sibling downloaders (they're deliberately kept in lockstep, per the comment in each file).

## What was still wrong

`scripts/download-qwen38-27b.bat:50` moves the checksum-verified `.part` file onto the final artifact path with no errorlevel check:

```bat
move /y "%PART%" "%MODEL%" >nul
echo Model ready: %MODEL%
```

Every other fallible step in the same script (`curl.exe`, the verify subroutine) checks `errorlevel` and bails with a clear message. A failed move — disk full, file in use, permissions — instead falls straight through to "Model ready" and `exit /b 0`, so the caller believes a verified artifact is at the final path when it isn't.

Fixed the same way in all three `.bat` downloaders that share this structure (`download-qwen38-27b.bat`, `download-qwen36-27b.bat`, `download-qwen36-35b-a3b.bat`) rather than only the one PR#48 touched, since the comment in each explicitly says they're kept identical on purpose:

```bat
move /y "%PART%" "%MODEL%" >nul
if errorlevel 1 (
  echo Failed to move "%PART%" to "%MODEL%". Delete "%PART%" and run this file again.
  exit /b 1
)
echo Model ready: %MODEL%
```

## What I didn't do

The other PR#48 finding — `scripts/check-linux-scripts.sh:139`'s positive-path fixture sets `NINFER_SKIP_SHA256=1` and so never exercises real SHA-256 rejection — is a separate concern (a Linux-only test-fixture gap, not a Windows-script bug) and is being addressed in its own follow-up.

## Testing

Not run end-to-end (would require an actual download or a synthetic failure of `move` against a real artifact). The added block is a direct copy of the `errorlevel`-check pattern already used and exercised by the same script's `curl.exe` step two lines above it.