### PR TITLE
test(real): exercise all three affected KV cache formats in the score determinism check

### DIFF
--- a/tests/targets/qwen3_6_27b/test_engine_score_real.cpp
+++ b/tests/targets/qwen3_6_27b/test_engine_score_real.cpp
@@ -2,24 +2,35 @@
 #include "ninfer/engine.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <string>
 #include <vector>
 
-int run_score_checks() {
-    const char* artifact = std::getenv("NINFER_QWEN3_6_27B_WEIGHTS");
-    if (artifact == nullptr || *artifact == '\0') {
-        std::cout << "SKIP: NINFER_QWEN3_6_27B_WEIGHTS is not set\n";
-        return 77;
+namespace {
+
+const char* kv_cache_name(ninfer::KvCacheStorage storage) {
+    switch (storage) {
+    case ninfer::KvCacheStorage::BFloat16: return "bf16";
+    case ninfer::KvCacheStorage::Int8Group64: return "int8";
+    case ninfer::KvCacheStorage::Fp8E4M3Row256: return "fp8";
+    case ninfer::KvCacheStorage::RotatedInt8KeyInt4ValueGroup64: return "rk8v4";
+    case ninfer::KvCacheStorage::Nvfp4Group16: return "nvfp4";
+    case ninfer::KvCacheStorage::Fp8KeyNvfp4Value: return "k8v4";
     }
+    return "unknown";
+}
+
+int run_score_checks_for(const char* artifact, ninfer::KvCacheStorage kv_cache) {
+    const char* name = kv_cache_name(kv_cache);
 
     ninfer::EngineOptions options;
     options.artifact_path = artifact;
     options.purpose       = ninfer::EnginePurpose::CausalScoring;
     options.max_context   = 2048;
-    options.kv_cache      = ninfer::KvCacheStorage::Fp8E4M3Row256;
+    options.kv_cache      = kv_cache;
     ninfer::Engine engine(options);
     const auto& effective = engine.options();
     if (effective.max_concurrency != 1 || effective.prefill_chunk != 1024 ||
@@ -27,8 +38,8 @@ int run_score_checks() {
         effective.kv_capacity.explicit_tokens != effective.max_context ||
         effective.context_cache.enabled ||
         effective.speculative.backend != ninfer::SpeculativeBackend::None ||
-        effective.kv_cache != ninfer::KvCacheStorage::Fp8E4M3Row256) {
-        std::cerr << "causal scoring options were not normalized correctly\n";
+        effective.kv_cache != kv_cache) {
+        std::cerr << name << ": causal scoring options were not normalized correctly\n";
         return 1;
     }
 
@@ -47,7 +58,7 @@ int run_score_checks() {
     const std::vector<float> suffix   = engine.score_tokens(tokens, 513);
     const std::vector<float> repeated = engine.score_tokens(tokens, 513);
     if (all.size() != 1536 || suffix.size() != 1024 || repeated.size() != suffix.size()) {
-        std::cerr << "causal scoring returned an invalid result shape\n";
+        std::cerr << name << ": causal scoring returned an invalid result shape\n";
         return 1;
     }
     float maximum_overlap_error = 0.0F;
@@ -56,7 +67,7 @@ int run_score_checks() {
     std::size_t first_repeat_index = suffix.size();
     for (std::size_t i = 0; i < suffix.size(); ++i) {
         if (!std::isfinite(all[i + 512]) || !std::isfinite(suffix[i])) {
-            std::cerr << "causal scoring returned a non-finite logprob\n";
+            std::cerr << name << ": causal scoring returned a non-finite logprob\n";
             return 1;
         }
         maximum_overlap_error = std::max(maximum_overlap_error, std::abs(all[i + 512] - suffix[i]));
@@ -70,21 +81,51 @@ int run_score_checks() {
     // Two windows scored identically must agree, but "disagree" has two very different causes and
     // the old message asserted the worse one without measuring. State/KV leaking between windows
     // moves logprobs by a visible amount; the reduction order varying between two runs of the same
-    // fp8 kernel moves them in the last bits. Print enough to tell them apart -- how many elements
-    // moved, by how much, and where the first one is -- instead of one sentence naming a cause.
+    // quantized kernel moves them in the last bits. Print enough to tell them apart -- how many
+    // elements moved, by how much, and where the first one is -- instead of one sentence naming a
+    // cause.
     if (repeat_differences != 0) {
-        std::cerr << "a repeated score window did not reproduce: " << repeat_differences << " of "
-                  << suffix.size() << " logprobs differ, worst |delta|=" << maximum_repeat_error
-                  << " first at index " << first_repeat_index << " (suffix="
-                  << suffix[first_repeat_index] << " repeated=" << repeated[first_repeat_index]
-                  << ")\n";
+        std::cerr << name << ": a repeated score window did not reproduce: " << repeat_differences
+                  << " of " << suffix.size() << " logprobs differ, worst |delta|="
+                  << maximum_repeat_error << " first at index " << first_repeat_index
+                  << " (suffix=" << suffix[first_repeat_index]
+                  << " repeated=" << repeated[first_repeat_index] << ")\n";
         return 1;
     }
     if (maximum_overlap_error > 0.25F) {
-        std::cerr << "overlapping target suffix changed by " << maximum_overlap_error << '\n';
+        std::cerr << name << ": overlapping target suffix changed by " << maximum_overlap_error
+                  << '\n';
         return 1;
     }
-    std::cout << "OK causal_score_real max_overlap_error=" << maximum_overlap_error << '\n';
+    std::cout << "OK causal_score_real[" << name
+              << "] max_overlap_error=" << maximum_overlap_error << '\n';
+    return 0;
+}
+
+} // namespace
+
+int run_score_checks() {
+    const char* artifact = std::getenv("NINFER_QWEN3_6_27B_WEIGHTS");
+    if (artifact == nullptr || *artifact == '\0') {
+        std::cout << "SKIP: NINFER_QWEN3_6_27B_WEIGHTS is not set\n";
+        return 77;
+    }
+
+    // The fix that made this repeat-window check meaningful (barrier between cp_wait and the
+    // shared-memory dequant in the quantized kernels) named fp8, nvfp4 and k8v4 as the three KV
+    // cache storage families that were non-deterministic before it landed -- bf16 and int8 always
+    // paired the wait and the read correctly. Exercise all three with the same artifact and
+    // options rather than only fp8, so a regression in either of the other two routes fails CI
+    // instead of waiting for someone to notice by hand.
+    constexpr std::array<ninfer::KvCacheStorage, 3> kFormats = {
+        ninfer::KvCacheStorage::Fp8E4M3Row256,
+        ninfer::KvCacheStorage::Nvfp4Group16,
+        ninfer::KvCacheStorage::Fp8KeyNvfp4Value,
+    };
+    for (ninfer::KvCacheStorage format : kFormats) {
+        const int result = run_score_checks_for(artifact, format);
+        if (result != 0) { return result; }
+    }
     return 0;
 }
 


### PR DESCRIPTION
Follow-up to #43/#49 ("barrier between cp_wait and the shared-memory dequant in the quantized kernels"), which merged with a CodePulse review comment unaddressed on #43 (identical commit was separately approved on #49). Verified against current master; still true.

## What was still missing

The fix's own commit message says fp8, nvfp4 and k8v4 were the three KV cache storage families that were non-deterministic before the barrier fix, and reports all four formats (plus int8) verified byte-identical after it. But `tests/targets/qwen3_6_27b/test_engine_score_real.cpp` only forces `KvCacheStorage::Fp8E4M3Row256` — nvfp4 and k8v4 have no committed regression coverage of the exact defect this PR fixed.

`KvCacheStorage` is an `Engine` option independent of the artifact's own weight quantization on disk, so the existing `NINFER_QWEN3_6_27B_WEIGHTS` artifact and test body cover all three formats without any new environment variable or fixture. Parametrized `run_score_checks` over `{Fp8E4M3Row256, Nvfp4Group16, Fp8KeyNvfp4Value}` instead of hardcoding fp8, printing which format failed if one does.

## Testing

- Built `ninfer_qwen3_6_27b_score_real_test` locally (MSVC + CUDA 12.8): 0 errors.
- Ran the binary with the artifact env var unset: still correctly prints `SKIP` and exits 77.
- Did **not** run it against real weights — the GPU on this box is currently occupied by another running job (`ninfer_bench.exe`) with only ~5.6 GiB free against the ~17.5 GiB artifact this test needs. Whoever picks this up with the GPU free should run it once with `NINFER_QWEN3_6_27B_WEIGHTS` set to confirm all three formats report `max_overlap_error=0`, matching the manual verification described in the original fix's commit message.