### PR TITLE
fix(sweeps): union kernel intervals for busy time, and stop trusting stale CSVs

### DIFF
--- a/scripts/sweeps/README.md
+++ b/scripts/sweeps/README.md
@@ -30,12 +30,17 @@ about three hours for twelve model/format combinations.
 | `dflash-residency-and-auto-capacity.ps1` | Does carrying DFlash cost VRAM when unused? | 15 min |
 | `speculation-matrix.ps1` | What does each speculative backend cost and buy? | 1 h |
 | `decode-roofline.ps1` | What fraction of the card's 936.2 GB/s does decode reach? | instant |
+| `decode-step-profile.ps1` | Where does a decode step's time go -- occupancy, launch gaps, or bandwidth? | a few min |
 
 `decode-roofline.ps1` needs no GPU: it reads the CSVs `kv-decode-vs-depth.ps1` leaves behind and
 divides achieved bandwidth by peak. Run that sweep first. Note it only means anything for the
 **dense** model -- applied to the A3B MoE it returns 391% of peak, which is not a result but a
 demonstration that the formula does not hold there, since an MoE never reads its resident weights
 per token. See TODO section 2c.
+
+`decode-step-profile.ps1` needs `nsys` (Nsight Systems) rather than a plain GPU run: it captures one
+measured decode repetition per configuration and reports GPU-busy vs. idle time from the trace, plus
+the top kernels by total time. Set `NINFER_NSYS` if it is not at the default install path.
 
 ## Things these got wrong, so you do not repeat them
 

--- a/scripts/sweeps/decode-step-profile.ps1
+++ b/scripts/sweeps/decode-step-profile.ps1
@@ -51,7 +51,12 @@ $configs = @(
 foreach ($c in $configs) {
   if (-not (Test-Path $c.path)) { "$($c.key): MISSING $($c.path)"; continue }
   $stem = "$out\prof_$($c.key)"
-  Remove-Item "$stem.nsys-rep","$stem.sqlite" -ErrorAction SilentlyContinue
+  # Everything nsys can write for this stem, not just the two inputs to the next `nsys profile`
+  # call. Without clearing the exported CSVs too, a later `nsys stats` failure (nonzero exit, no
+  # new CSV written) leaves the previous run's files in place, `Test-Path $trace` finds them, and
+  # this iteration reports someone else's numbers as its own.
+  Remove-Item "$stem.nsys-rep","$stem.sqlite",`
+      "$stem`_cuda_gpu_trace.csv","$stem`_cuda_gpu_kern_sum.csv" -ErrorAction SilentlyContinue
 
   & $nsys profile --force-overwrite true --output $stem `
       --trace cuda --cuda-graph-trace node --capture-range cudaProfilerApi --capture-range-end stop `
@@ -67,6 +72,11 @@ foreach ($c in $configs) {
 
   & $nsys stats --report cuda_gpu_kern_sum,cuda_gpu_trace --format csv `
       --output "$stem" "$stem.nsys-rep" > "$stem.stats.log" 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    "$($c.key): nsys stats FAILED (exit $LASTEXITCODE)"
+    Get-Content "$stem.stats.log" -Tail 5 | ForEach-Object { "    $_" }
+    continue
+  }
 
   $trace = "$stem`_cuda_gpu_trace.csv"
   $kern  = "$stem`_cuda_gpu_kern_sum.csv"
@@ -79,8 +89,32 @@ foreach ($c in $configs) {
   if (-not $rows) { "$($c.key): trace CSV had no kernel rows"; continue }
   $starts = $rows | ForEach-Object { [double]$_.'Start (ns)' }
   $ends   = $rows | ForEach-Object { [double]$_.'Start (ns)' + [double]$_.'Duration (ns)' }
-  $busy   = ($rows | Measure-Object -Property 'Duration (ns)' -Sum).Sum
   $wall   = ($ends | Measure-Object -Maximum).Maximum - ($starts | Measure-Object -Minimum).Minimum
+
+  # Union of kernel intervals, not a sum of durations: decode launches on multiple streams, and
+  # concurrent kernels overlap in time. Summing durations double-counts that overlap, which
+  # understates idle time (or drives it negative) exactly when concurrency is doing its job.
+  # Merge-sweep instead: sort by start, extend the current run while the next interval overlaps
+  # or touches it, and bank the run's width once a gap opens.
+  $intervals = for ($i = 0; $i -lt $rows.Count; $i++) {
+    [pscustomobject]@{ Start = $starts[$i]; End = $ends[$i] }
+  }
+  $busy = 0.0
+  $runStart = $null
+  $runEnd   = $null
+  foreach ($iv in ($intervals | Sort-Object Start)) {
+    if ($null -eq $runStart) {
+      $runStart = $iv.Start
+      $runEnd   = $iv.End
+    } elseif ($iv.Start -le $runEnd) {
+      if ($iv.End -gt $runEnd) { $runEnd = $iv.End }
+    } else {
+      $busy    += $runEnd - $runStart
+      $runStart = $iv.Start
+      $runEnd   = $iv.End
+    }
+  }
+  if ($null -ne $runStart) { $busy += $runEnd - $runStart }
 
   ""
   "== $($c.key), int8, one measured repetition =="


### PR DESCRIPTION
Follow-up to #51 ("make the roofline use the read set it now has, and add the decode-step profile"), which merged with all 3 CodePulse review comments unaddressed. Verified against current master; all 3 still present.

## What was still wrong

**`scripts/sweeps/decode-step-profile.ps1`**

1. **Busy time was summed, not unioned.** `($rows | Measure-Object -Property 'Duration (ns)' -Sum).Sum` adds up every kernel's duration. Decode launches overlap across CUDA streams, so overlapping time gets counted twice, understating (or driving negative) the reported idle-between-kernels figure — precisely when the GPU is doing what it's supposed to. Replaced with a merge-sweep: sort intervals by start, extend a running interval while the next one overlaps or touches it, bank the width on a gap.

2. **Stale CSVs could be reported as a fresh profile.** Only `.nsys-rep`/`.sqlite` were cleared before each run; the CSVs `nsys stats` exports were not, and that command's exit code was never checked. A silent `nsys stats` failure left the previous run's CSVs in place, `Test-Path $trace` found them, and the iteration reported someone else's numbers. Now clears both exported CSVs upfront and fails the iteration (with the tail of `$stem.stats.log`) on a nonzero `nsys stats` exit.

3. **README gap.** `scripts/sweeps/README.md`'s script table didn't list `decode-step-profile.ps1` at all. Added a row plus a short note on its `nsys` dependency.

## Testing

- PowerShell's own parser (`[System.Management.Automation.Language.Parser]::ParseFile`) accepts the edited script with no errors.
- Checked the interval-union logic in isolation against synthetic overlapping intervals (`[0,10] [5,8] [20,25] [22,23]` → union 15, naive sum would be 16): got 15.
- Did not run the script end-to-end — it needs `nsys` and a live decode workload, out of scope for validating this diff.