### PR TITLE
docs(todo): fix a fail/skip conflation, and record an unvalidated upstream MoE constant

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,10 +57,14 @@ NINFER_REAL_TEST_MAX_CONTEXT=8192      # only needed for the 35B
 `NINFER_QWEN3_6_27B_NVFP4_WEIGHTS` was missing from this block for a cycle, and it is the only
 thing that was keeping `27b_load_plan` skipping — the artifact has been on the disk all along.
 
-**Free VRAM used to decide whether these pass or skip.** It no longer does: the reason was the
-pinned host-KV allocation being charged against the card (§6, #45), and with that clamped the six
-real-model tests pass on an idle box and under `ctest -j2`. Still worth closing GPU clients before
-a *measurement* run, where free VRAM changes the automatic sizing.
+**Free VRAM used to make these fail outright, not skip.** Skip (exit 77) here is reserved for a
+missing artifact env var; a VRAM shortfall instead threw during `Engine` construction and failed
+the test. The specific cause was the pinned host-KV allocation being charged against the card (§6,
+#45), and with that clamped the six real-model tests pass on an idle box and under `ctest -j2`.
+That closes the one source of VRAM-caused failure this fix addresses -- it does not mean free VRAM
+no longer affects these tests at all: the model-weights allocation itself can still fail under real
+memory pressure from another process. Still worth closing GPU clients before a *measurement* run,
+where free VRAM also changes the automatic sizing.
 
 ### Recently landed, and what is still owed on it
 
@@ -458,6 +462,22 @@ roofline finally acquired a denominator; read them before the rest.
       **99.3% GPU idle** from 807 launches over 128 steps of a 64-layer model, about six kernels
       per step, because nsys records a CUDA graph replay as one opaque entity unless given
       `--cuda-graph-trace=node`. Both reasons are written into the script.
+
+- [ ] **The routed prefill gate/up pipeline-depth threshold is upstream's RTX 5090 number,
+      unmeasured on this card.** `src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu:314-315`
+      (`kGateUpDeepJobsNum`/`Den`, currently 7/4) picks between a 2-stage ("Spread") and a 6-stage
+      ("Packed") pipeline for the narrow routed gate/up kernel based on jobs-per-expert crossing
+      this ratio. The comment above it is explicit that the crossing point was measured on
+      upstream's server, with a fixture that walks the ratio continuously and disagrees with the
+      operator microbenchmark by about 6x depending on L2 warmth. That crossing depends on L2 size,
+      and an RTX 5090 has 16x the L2 of this box's RTX 3090 (96 MB vs. 6 MB) — there is no reason to
+      expect 7/4 is where *this* card's Spread/Packed tradeoff actually flips. Wrong constant,
+      wrong pipeline depth selected, not wrong output: `kExpertStages`/`kGateUpNarrowStages` still
+      produce correct results either way, so this is a performance risk, not a correctness one.
+      Re-measuring needs the same round-robin fixture the comment describes, built and run on this
+      RTX 3090; no sweep script here currently drives sparse MoE prefill directly
+      (`decode-step-profile.ps1` and the `scripts/sweeps/*.ps1` sweeps are all decode-only). Do not
+      guess a replacement constant without that measurement.
 
 - [ ] **Eight lanes buy 3.2x, not 8x, and the reason is unestablished.** README's own cohort table
       has C1 decode at 78.71 tok/s against C8 at 250.26. Batched decode amortises the weight read


### PR DESCRIPTION
Follow-up to #54 and #55, both merged with CodePulse review comments unaddressed. Verified against current master; both still valid.

## #54 — TODO.md ~line 60 overclaimed what the VRAM fix does

Said free VRAM "no longer" decides whether the real-model tests "pass or skip." That conflates two different things: skip (exit 77) in this codebase is reserved for a missing artifact env var — none of the real-model test files check free VRAM at all. A VRAM shortfall instead threw during `Engine` construction and failed the test outright, which is not the same failure mode. The #39/#45 host-KV clamp closes the one source of that failure it was measured against; it doesn't mean free VRAM stopped mattering to these tests in general (the weights allocation itself can still fail under real memory pressure from another process). Reworded to say what actually happens.

## #55 — an upstream tuning constant carried forward with no tracking

`src/ops/sparse_moe/prefill/sparse_moe_prefill_kernels.cu:314-315` (`kGateUpDeepJobsNum`/`Den`, currently 7/4) picks the routed gate/up prefill pipeline depth off a jobs-per-expert threshold. Its own comment says the crossing point was measured on upstream's server — an RTX 5090 with 16x this box's L2 (96 MB vs. 6 MB), and this is specifically an L2-crossing threshold. Nothing in TODO.md tracked that this hasn't been revalidated on the RTX 3090 this fork targets. Added an entry under §2c documenting the gap, what a re-measurement would need (the same round-robin fixture the code comment describes, run on this card), and explicitly not guessing a replacement number.

## Testing

Documentation-only change; no code or build affected.