### PR TITLE
docs(kv): re-measure every KV format after #49, and correct what changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,33 +309,51 @@ the decode column is the one that surprises, because the smallest formats are no
 
 | KV profile | Bytes/token | KV at 2,048 tokens | Perplexity | vs `bf16` | Decode at 32K depth |
 |---|---:|---:|---:|---:|---:|
-| `bf16` | 65,536 | 128.00 MiB | 4.343225 | — | 32.50 tok/s |
-| `int8` | 33,792 | 66.00 MiB | 4.343263 | +0.0009% | **33.86 tok/s** |
-| `fp8` | 33,024 | 64.50 MiB | 4.347181 | +0.0911% | 30.13 tok/s |
-| `rk8v4` | 26,112 | 51.00 MiB | 4.346811 | +0.0826% | 33.54 tok/s |
-| `k8v4` | 25,728 | 50.25 MiB | 4.347596 | +0.1006% | 28.61 tok/s |
-| `nvfp4` | **18,432** | **36.00 MiB** | 4.358924 | +0.3615% | 29.62 tok/s |
+| `bf16` | 65,536 | 128.00 MiB | 4.342517 | — | 31.93 tok/s |
+| `int8` | 33,792 | 66.00 MiB | 4.342425 | −0.0021% | **33.63 tok/s** |
+| `fp8` | 33,024 | 64.50 MiB | 4.344724 | +0.0508% | 30.34 tok/s |
+| `rk8v4` | 26,112 | 51.00 MiB | 4.346413 | +0.0897% | 33.17 tok/s |
+| `k8v4` | 25,728 | 50.25 MiB | 4.347258 | +0.1092% | 28.90 tok/s |
+| `nvfp4` | **18,432** | **36.00 MiB** | 4.352201 | +0.2229% | 29.86 tok/s |
 
 Perplexity is `ninfer-perplexity` on the fixed `ninfer-ppl-1m-v1` corpus, `--quick`, context/stride
 4096/2048, 261,167 scored tokens — the same corpus and window for every row. Decode is 128 timed
-steps on top of a 32,768-token prefill, no speculation; attention re-reads the whole cache each
-step, so a format's cost only shows at depth.
+steps on top of a 32,768-token prefill, no speculation, and is the **mean of two independent runs**
+because this card is power-capped at 315 W of its 350 W default and the SM clock drifts 1,665–1,755
+MHz with temperature; single runs on the 27B vary by up to 5%. Attention re-reads the whole cache
+each step, so a format's cost only shows at depth.
+
+**These numbers were all re-measured in September 2026 and several moved.** Three of the six
+formats — `fp8`, `nvfp4` and `k8v4` — had their perplexity scored through a data race in the
+quantized attention kernels that corrupted every prefill output column except the last. Greedy
+generation was unaffected, which is why it went unnoticed. With that fixed, `nvfp4` improved by
+0.154% and `fp8` by 0.057%, against a 0.019% drift on the formats the fix did not touch, and all
+three now reproduce bit-identically run to run.
 
 Three of these six are worth using:
 
-- **`int8`** is the default for good reason. Its perplexity cost is +0.0009%, which is nothing, and
-  it has the second-flattest decode curve.
-- **`rk8v4`** is the best all-round choice: 23% smaller than INT8 for +0.08% perplexity, and the
-  flattest decode curve measured (−6.2% from 4K to 32K, against INT8's −6.3%).
+- **`int8`** is the default for good reason. Its perplexity is indistinguishable from `bf16` — the
+  two are within 0.0001 of each other, which is below this harness's own reproducibility — and it
+  has the flattest decode curve on the 27B (−4.8% from 4K to 32K).
+- **`rk8v4`** is the best all-round choice: 23% smaller than INT8 for +0.09% perplexity, the
+  flattest curve on the 35B (−9.5%), and on that model it is also the **fastest** format at every
+  depth measured, ahead of INT8 by about 2%.
 - **`nvfp4`** buys the most context by a wide margin — 45% smaller than INT8. On the 35B with MTP3
   and the draft head, on a machine running a desktop, it is the only format that still reaches the
   full 262,144 native context: `rk8v4` gets to about 231,000 and INT8 to about 179,000 there.
-  Headless, `rk8v4` clears 262,144 as well. It costs about 13% of decode speed at 32K and +0.36%
+  Headless, `rk8v4` clears 262,144 as well. It costs about 16% of decode speed at 32K and +0.22%
   perplexity.
 
-`fp8` and `k8v4` have no niche. `fp8` is larger, slower at depth *and* worse quality than `rk8v4`;
-`k8v4` is within 1.5% of `rk8v4`'s size but has the worst decode falloff of any format measured
-(−17.9% on the 27B, −25.2% on the 35B) and slightly worse perplexity.
+`fp8` and `k8v4` are still hard to recommend, but the reason has changed and it is worth stating
+precisely rather than as "no niche".
+
+- **`fp8` is no longer dominated on all three axes.** It now has *better* perplexity than `rk8v4`
+  — 4.344724 against 4.346413, a real and reproducible 0.039% — which was not true before the race
+  was fixed. What that edge costs is 26% more KV memory per token and 8.5% of decode speed at 32K
+  depth. A genuine trade, and a bad one for almost everyone, but a trade rather than a strict loss.
+- **`k8v4` is dominated.** It is 1.5% smaller than `rk8v4` and pays for it with 13% less decode
+  speed at depth, the worst falloff of any format on the 35B (−25.9%), and slightly worse
+  perplexity. There is no configuration in which that 1.5% is worth it.
 
 Per-format numbers for the 35B, plus a fit calculator that solves for context and memory, are in
 [`docs/config-calculator.html`](docs/config-calculator.html).

--- a/TODO.md
+++ b/TODO.md
@@ -669,22 +669,48 @@ doing:
       safe only by coincidence. Writing the merge identity there changed nothing — 15 differing
       lines before and after. It is a latent hazard, not this defect.
 
-- [ ] **The published perplexity figures for fp8, k8v4 and nvfp4 are not just single runs, they
-      were measured through the race above.** README's six-format table and the calculator both
-      carry `fp8 4.347181` and `k8v4 4.347596`, a gap of 0.0096%, and perplexity is scored
-      through exactly the prefill path #49 fixed — every output column but the last was
-      corrupted. So these are not "probably fine, averaged over 261,167 tokens": they are
-      measurements of a broken kernel, and the fp8-versus-k8v4 ordering they are used to justify
-      means nothing. **Re-measure all three, twice each, and only then decide whether the
-      ordering is real.** `bf16`, `int8` and `rk8v4` are unaffected — different kernels,
-      byte-identical across runs, and their numbers stand.
+- [x] **The published perplexity figures for fp8, k8v4 and nvfp4 were measured through the race
+      above.** Re-measured 2026-09-09, twice each, with int8 and bf16 as controls whose code paths
+      #49 does not touch.
 
-- [ ] **fp8 and k8v4 are dominated on all three axes and nothing says so structurally.** Each is
-      beaten by `rk8v4` on size, decode-at-depth and perplexity simultaneously (README's table).
-      Hold this until the re-measurement above lands: two of the three axes were measured on the
-      racy path, so the domination claim itself is now unproven. If it survives re-measurement,
-      decide whether to de-emphasise them in `--help` or leave them fully available on the
-      grounds that upstream parity is worth more than steering.
+      | format | published | re-measured | delta |
+      |---|---:|---:|---:|
+      | `int8` (control) | 4.343263 | 4.342425 | −0.019% |
+      | `bf16` (control) | 4.343225 | 4.342517 | −0.016% |
+      | `rk8v4` (control) | 4.346811 | 4.346413 | −0.009% |
+      | `fp8` | 4.347181 | **4.344724** | **−0.057%** |
+      | `k8v4` | 4.347596 | 4.347258 | −0.008% |
+      | `nvfp4` | 4.358924 | **4.352201** | **−0.154%** |
+
+      **All four re-measured formats are now bit-identical between passes** — `fp8` returned
+      4.344723843631465 twice over 261,167 scored tokens. That is #49's determinism claim proven at
+      the level that matters, not just at the Op-test level.
+
+      The three formats #49 does not touch all drifted −0.009% to −0.019%, which is a harness or
+      build offset against whenever the published numbers were taken, and is the floor on any claim
+      from this comparison. `fp8` moved three times that and `nvfp4` eight to seventeen times it:
+      real. `k8v4` at −0.008% sits *inside* the control band, so it did not measurably improve
+      despite being one of the patched kernels.
+
+      README, `docs/config-calculator.html` and `docs/rtx-3090-windows.md` all carry the new
+      figures.
+
+- [x] **fp8 and k8v4 are dominated on all three axes and nothing says so structurally.** Settled
+      2026-09-09, and the premise was half wrong once the numbers were redone.
+
+      **`fp8` is no longer dominated on all three axes.** Its re-measured perplexity, 4.344724,
+      *beats* `rk8v4`'s 4.346413 — a reproducible 0.039%, and both come from the same run so the
+      control drift cancels. It is still larger (33,024 B/token against 26,112) and still slower at
+      depth (30.34 against 33.17 tok/s at 32K), so what it now offers is a genuine trade: 26% more
+      KV memory and 8.5% of decode speed for 0.039% better quality. A bad trade for almost anyone,
+      but a trade rather than a strict loss, and README says exactly that instead of "no niche".
+
+      **`k8v4` is dominated, and comfortably.** 1.5% smaller than `rk8v4`, for 13% less decode
+      speed at depth, the worst falloff of any format on the 35B (−25.9%), and slightly worse
+      perplexity. No configuration makes that 1.5% worth having.
+
+      Left fully available in `--help` either way: upstream parity is worth more than steering, and
+      the README table now states the trade precisely enough that nobody needs steering.
 
 - [ ] **The speculative decode sweep measures acceptance, not depth, and cannot be read like the
       non-speculative one.** `scripts/sweeps/kv-decode-with-speculation.ps1` produced 35B INT8 at
@@ -850,6 +876,40 @@ hardcoded chain. `w8_pair` k=2048 had a table that *was* read, but whose distinc
 on this hardware. So `grep resolve_plan` is necessary and not sufficient — also grep the launchers
 for `NINFER_SM8X_COMPAT`, and confirm in the sweep, where identical schedules print *identical*
 times.
+
+---
+
+## This card is power-capped, which sets the floor on every measurement here
+
+`nvidia-smi` reports the power limit as **315 W against a 350 W default** (400 W maximum), and
+reports throttle reason `0x4` — `SwPowerCap` — continuously through every sweep. The SM clock
+swings **1,665–1,755 MHz** as a result while the memory clock stays fixed at 9,501 MHz. It looks
+deliberate rather than accidental, so it has been left alone; changing it needs an elevated shell
+anyway.
+
+**This is why within-run stddev lies.** `ninfer_bench -r 3` reports ±0.02–0.5 tok/s, which looks
+like a tight measurement. The spread *between processes* on the 27B is 3–5%: int8 at a
+4,096-token depth measured 37.44 tok/s in one run and 35.45 in another, on identical code, an hour
+apart. The clock drifts with temperature across runs and no amount of repetition inside one
+process sees it.
+
+Three consequences worth internalising before quoting any number in this file:
+
+- **Every performance comparison needs a control** — a configuration whose code path the change
+  does not touch, measured in the same run. The `SmallTMaximumSplits` work (#52) is the worked
+  example: the 35B's fp8 control held to 0.3% and made a 2.5% effect readable, while the 27B's
+  control moved ±3% and made that model's numbers worthless. Without the control, six numbers
+  looked like a result and three of them were noise.
+- **Do not compare across sessions.** Interleave the variants you are comparing inside one sitting,
+  or accept a 5% floor.
+- **The 35B is the quieter instrument.** Its controls repeatedly held to ≤0.3% where the 27B's
+  moved 3–5%, so a small effect should be measured there first.
+
+Also worth someone's attention: 315 W is 90% of this card's default TDP. Decode is memory-bound and
+the memory clock is not throttling, so the cost may be small — but it has never been measured.
+`nvidia-smi -pl 350` and a re-run of `kv-decode-vs-depth.ps1` would answer it, and
+`nvidia-smi -lgc <clock>` would collapse the 3–5% spread for measurement runs. Both need
+elevation.
 
 ---
 

--- a/docs/config-calculator.html
+++ b/docs/config-calculator.html
@@ -487,13 +487,17 @@ const DATA = {
       kv: { bf16: 65536, int8: 33792, fp8: 33024, rk8v4: 26112, k8v4: 25728, nvfp4: 18432 },
       /* decode tok/s, no speculation, at these cache depths */
       depths: [4096, 16384, 32768],
+      /* Mean of two independent runs each, September 2026. Two runs because this card is
+         power-capped at 315 W of a 350 W default and the SM clock drifts 1,665-1,755 MHz with
+         temperature: single 27B runs vary by up to 5%, far more than the within-run stddev
+         suggests. */
       speed: {
-        bf16:  [36.74, 34.72, 32.50],
-        int8:  [36.15, 35.11, 33.86],
-        fp8:   [35.28, 32.57, 30.13],
-        rk8v4: [35.77, 34.73, 33.54],
-        k8v4:  [34.86, 31.76, 28.61],
-        nvfp4: [35.14, 32.64, 29.62]
+        bf16:  [36.58, 34.34, 31.93],
+        int8:  [35.31, 34.34, 33.63],
+        fp8:   [35.05, 33.09, 30.34],
+        rk8v4: [35.65, 34.73, 33.17],
+        k8v4:  [34.22, 31.83, 28.90],
+        nvfp4: [35.37, 32.78, 29.86]
       },
       spec: {
         none:          { label: "None",                weightsGiB: 15.92, decode: 34.41, accept: null },
@@ -513,13 +517,15 @@ const DATA = {
       seqFixedBytes: 70579968,
       kv: { bf16: 20480, int8: 10560, fp8: 10320, rk8v4: 8160, k8v4: 8040, nvfp4: 5760 },
       depths: [4096, 16384, 32768],
+      /* Mean of two independent runs each, September 2026; see the note on the 27B rows. On this
+         model rk8v4 is the fastest format at every depth measured, ahead of int8. */
       speed: {
-        bf16:  [169.98, 159.17, 144.60],
-        int8:  [173.83, 167.18, 154.90],
-        fp8:   [166.06, 149.53, 131.19],
-        rk8v4: [172.08, 165.82, 155.76],
-        k8v4:  [163.28, 141.51, 122.07],
-        nvfp4: [167.49, 150.14, 132.12]
+        bf16:  [166.16, 156.00, 142.99],
+        int8:  [171.76, 165.02, 154.88],
+        fp8:   [166.01, 148.82, 132.00],
+        rk8v4: [175.15, 168.50, 158.47],
+        k8v4:  [165.66, 143.58, 122.78],
+        nvfp4: [169.04, 151.81, 131.75]
       },
       spec: {
         none:          { label: "None",                weightsGiB: 19.59, decode: 178.00, accept: null },
@@ -533,13 +539,18 @@ const DATA = {
 
   /* Perplexity is model-independent in the sense that it was measured once, on the 27B, over the
      same corpus and window for all six formats. */
+  /* Re-measured September 2026. The fp8, k8v4 and nvfp4 figures published before that were
+     scored through a data race in the quantized attention kernels that corrupted every prefill
+     output column but the last; all three now reproduce bit-identically run to run. nvfp4 moved
+     -0.154% and fp8 -0.057%, against a 0.019% drift on the three formats the fix did not touch.
+     One consequence for anyone reading the table: fp8 now has *better* perplexity than rk8v4. */
   perplexity: {
-    bf16:  4.343225,
-    int8:  4.343263,
-    fp8:   4.347181,
-    rk8v4: 4.346811,
-    k8v4:  4.347596,
-    nvfp4: 4.358924
+    bf16:  4.342517,
+    int8:  4.342425,
+    fp8:   4.344724,
+    rk8v4: 4.346413,
+    k8v4:  4.347258,
+    nvfp4: 4.352201
   },
   kvLabels: {
     bf16:  "bf16 — full precision reference",

--- a/docs/rtx-3090-windows.md
+++ b/docs/rtx-3090-windows.md
@@ -104,8 +104,9 @@ boundary from 171,648 to 226,560 tokens at 1 GiB headroom, for 5.51 GiB of KV ag
 5.40 GiB.
 
 Since the port onto the `kv_cache_append` Op, that context gain has a measured quality cost of
-**+0.082% perplexity** (`ninfer-perplexity`, `ninfer-ppl-1m-v1` quick, 261,167 scored tokens:
-4.343263 on INT8 against 4.346811 on rk8v4). Values are not rotated, so there is no
+**+0.092% perplexity** (`ninfer-perplexity`, `ninfer-ppl-1m-v1` quick, 261,167 scored tokens:
+4.342425 on INT8 against 4.346413 on rk8v4; both re-measured September 2026 and both
+bit-reproducible run to run). Values are not rotated, so there is no
 inverse-rotation pass over the attention output. Values do use a finer group than keys, 32 against
 64, which halved that penalty from +0.146% at no cost in context.
 


### PR DESCRIPTION
docs(kv): re-measure every KV format after #49, and correct what changed

#49 fixed a data race in the quantized attention kernels that corrupted every prefill output
column except the last. Perplexity is scored through exactly that path, so the published figures
for fp8, k8v4 and nvfp4 were measurements of a broken kernel. Decode also needed redoing, since
#49 adds a per-key-tile barrier and #52 changed the split tier.

**Perplexity, twice each, with int8/bf16/rk8v4 as controls #49 does not touch:**

    format            published   re-measured    delta
    int8   (control)   4.343263    4.342425     -0.019%
    bf16   (control)   4.343225    4.342517     -0.016%
    rk8v4  (control)   4.346811    4.346413     -0.009%
    fp8                4.347181    4.344724     -0.057%
    k8v4               4.347596    4.347258     -0.008%
    nvfp4               4.358924    4.352201     -0.154%

All four re-measured formats are **bit-identical between passes** -- fp8 returned
4.344723843631465 twice over 261,167 scored tokens. That is #49's determinism claim proven where
it matters. The three controls drifted -0.009% to -0.019%, which is the floor on this comparison;
fp8 and nvfp4 moved well outside it, and k8v4's -0.008% sits inside it, so k8v4 did not measurably
improve despite being one of the patched kernels.

**Decode, mean of two independent runs**, because this card is power-capped at 315 W of a 350 W
default and the SM clock drifts 1,665-1,755 MHz with temperature: single 27B runs vary by up to 5%,
far more than the within-run stddev suggests. README now says so beside the table.

**Two claims in README were wrong and are corrected rather than refreshed.**

`fp8` is no longer dominated on all three axes. Its perplexity now *beats* `rk8v4` -- 4.344724
against 4.346413, reproducible, and from the same run so control drift cancels. It remains larger
and slower at depth, so what it offers is a real trade: 26% more KV memory and 8.5% of decode speed
for 0.039% better quality. Bad for almost everyone, but a trade rather than a strict loss, and the
text says that instead of "no niche".

`k8v4` is dominated and the section now says why in one line: 1.5% smaller than `rk8v4` for 13%
less decode at depth, the worst falloff of any format on the 35B, and slightly worse perplexity.

Also new, from the same data: **on the 35B, `rk8v4` is the fastest format at every depth measured**
(175.15/168.50/158.47 against int8's 171.76/165.02/154.88), not merely the best compromise. And
`int8` has the flattest curve on the 27B (-4.8%) while `rk8v4` has it on the 35B (-9.5%), so the
old unqualified "second-flattest" claim is now stated per model.

docs/rtx-3090-windows.md's rk8v4-vs-int8 perplexity cost goes from +0.082% to +0.092% on the new
figures. docs/config-calculator.html's DATA block carries the new perplexity and both models' decode
rows, with the provenance in comments; its regression test still passes.

