### PR TITLE
fix(calculator): model speculative memory per mode, and cross-check it against the engine

### DIFF
--- a/.github/workflows/host-checks.yml
+++ b/.github/workflows/host-checks.yml
@@ -37,6 +37,9 @@ jobs:
       # sandbox, which is what keeps docs/config-calculator.html a single file.
       - name: Run docs/config-calculator.test.mjs
         run: node docs/config-calculator.test.mjs
+      # The arithmetic tests never call render(), which is where most of the page's code is.
+      - name: Run docs/config-calculator.render.test.mjs
+        run: node docs/config-calculator.render.test.mjs
 
   linux-scripts:
     name: Linux launcher and downloader guard

--- a/TODO.md
+++ b/TODO.md
@@ -230,23 +230,22 @@ parents). The next merge from `neroued/master` will touch the same subsystem.
       *base* engine now fits without closing anything, so the remaining question — whether the
       base config should also honour the env var — is moot: it starts. Left as it is.
 
-### 1.3 `docs/config-calculator.html` undercounts startup memory for speculative configurations
+### 1.3 `docs/config-calculator.html` undercounts startup memory for speculative configurations — closed
 
-- [ ] Its "Startup memory" total only adds the extra resident weights measured for each
-      speculation option; it reuses the no-speculation CUDA graph allowance
-      (`DATA.graphBytes`, 12 MiB) for every mode and adds no extra KV pages for either backend.
-      The real engine (`src/targets/qwen3_6/impl/runtime/layouts_impl.h`) sizes the graph
-      allowance per speculative backend and draft window — up to ~86 MiB/lane for MTP, ~96
-      MiB/lane for DFlash under `NINFER_SM8X_COMPAT`, against the calculator's flat 12 MiB — and
-      `persistent_layout`'s `mtp_extra_pages` reserves additional paged-KV pages for MTP's
-      buffered draft tokens that the calculator never adds either. Closing this properly needs
-      either a full port of `mtp_graph_profiles`/`dflash_graph_profiles`/
-      `graph_topology_allowance` into the page's JS (nontrivial, capacity- and
-      draft-window-dependent piecewise logic) or fresh `ninfer_bench` measurements of the actual
-      per-mode graph allowance and extra KV pages — both out of scope for a docs PR. Descoped with
-      a prominent in-page caveat (the "What this does not model" section and the speculation
-      hint) rather than patched inline; the no-speculation case is unaffected and is the one this
-      page's own engine cross-check validates.
+- [x] Closed 2026-09-09 by the same work as §2b's first entry, which has the measured terms, the
+      engine cross-checks and the scale of what was missing. The short version: the page reused the
+      12 MiB no-speculation CUDA graph allowance for every mode and added no extra cache for any of
+      them, and the entry's own guess at the fix — "a full port of `mtp_graph_profiles` /
+      `dflash_graph_profiles` / `graph_topology_allowance` into the page's JS, nontrivial and
+      piecewise" — turned out not to be needed. Measuring the engine's reported terms at three
+      contexts per mode gave five constants per mode, one of which is a two-step function of
+      context, and those reproduce the engine to 0.044% on MTP3 and exactly on DFlash-3.
+
+      Worth keeping: the entry descoped this as "out of scope for a docs PR" and was right that
+      porting the layout logic would have been. It was wrong that the alternative needed "fresh
+      `ninfer_bench` measurements of the actual per-mode graph allowance" as though that were the
+      expensive path — the whole matrix is ten minutes of load-and-report, because the engine
+      already prints every term.
 
 ---
 
@@ -303,35 +302,43 @@ shallowest measurement rather than claimed as interpolated), and per-row weight-
 The doc contradictions were fixed separately in #33. The evidence for each is kept below so nobody
 has to re-derive it.
 
-- [ ] **Speculative modes undercount memory by roughly 170 MiB, plus a per-token term.** The page
-      models speculation as a weights delta only. Measured on the 27B at `--max-ctx 40960`, INT8,
-      `none` against `mtp3 + --lm-head-draft`:
+- [x] **Speculative modes undercount memory by roughly 170 MiB, plus a per-token term.** Closed
+      2026-09-09. Every term is now measured per mode by
+      `scripts/sweeps/speculative-memory-terms.ps1`, and the undercount was far larger than 170 MiB
+      at anything but the mildest mode and depth.
 
-      | component | none | mtp3+head | delta | modelled? |
-      |---|---:|---:|---:|---|
-      | weights | 17,093,490,688 | 17,901,798,400 | +771 MiB | yes |
-      | sequence | 1,550,561,536 | 1,646,461,184 | +91.5 MiB | **no** |
-      | CUDA graph allowance | 12,582,912 | 90,177,536 | +74 MiB | **no** |
-      | workspace | 159,981,568 | 159,981,568 | 0 | n/a |
+      | model | spec | graph | seq fixed | seq/token | kv ratio | kv extra/token |
+      |---|---|---:|---:|---:|---:|---:|
+      | 27B | none | 12 MiB | 158.7 MiB | 1/16 | 1 | 0 |
+      | 27B | mtp3 (+head) | 86 MiB | 167.6 MiB | 1/8 | 1.06299 | 0 |
+      | 27B | dflash2-7 (+head) | **288/384 MiB** | 266.2 MiB | 1/16 | 1 | 0 |
+      | 35B | none | 12 MiB | 67.3 MiB | 1/16 | 1 | 0 |
+      | 35B | mtp3 (+head) | 86 MiB | 72.6 MiB | 1/8 | 1.10078 | 0 |
+      | 35B | dflash-3 (+head) | 160 MiB | 184.2 MiB | 1/8 | 1 | **4,096 B** |
 
-      `graphBytes` is hardcoded at 12,582,912, which is only right with speculation off.
+      **The "one constant multiplier" in the old entry only ever fitted MTP.** MTP buffers extra
+      draft tokens *in the KV format*, so its cost is multiplicative and identical across formats
+      — +6.2988% per token on the 27B, +10.078% on the 35B, both confirmed against nvfp4 to within
+      page rounding. DFlash v1 instead reserves a fixed scratch region per token, measured at
+      **exactly 4,096 bytes** and format-independent: 32 MiB at 8,192 tokens, 64 MiB at 16,384,
+      128 MiB at 32,768. Read as a ratio that is +38.8% on `int8` and +71.1% on `nvfp4`, which is
+      what made it look format-dependent. DFlash2 costs nothing per token and pays entirely in a
+      graph allowance that is itself a step in context: 288 MiB to 8,192 tokens, 384 MiB beyond.
 
-      **The speculative KV term is per-token, and it is one constant.** Measured across all six
-      formats on the 27B, MTP3 + draft head raises KV bytes/token by the same **6.26%** every time:
+      **Cross-checked against the engine's own refusal arithmetic, which the old entry noted had
+      only ever been done for `--spec` unset:**
 
-      | format | none | mtp3+head | ratio |
+      | configuration | engine | page | error |
       |---|---:|---:|---:|
-      | `bf16` | 65,536 | 69,638.4 | 1.0626 |
-      | `int8` | 33,792 | 35,907.3 | 1.0626 |
-      | `fp8` | 33,024 | 35,091.2 | 1.0626 |
-      | `rk8v4` | 26,112 | 27,746.6 | 1.0626 |
-      | `k8v4` | 25,728 | 27,338.5 | 1.0626 |
-      | `nvfp4` | 18,432 | 19,585.8 | 1.0626 |
+      | 27B int8 262,144, mtp3+head | 9,838,038,272 | 9,842,380,571 | +0.044% |
+      | 35B int8 262,144, dflash-3 | 4,312,377,600 | 4,312,377,600 | **exact** |
 
-      So the fix is a per-token multiplier on the cache plus a per-mode constant for the graph
-      allowance and sequence delta, not a flat offset. Only MTP3 + draft head was swept; DFlash and
-      DFlash2 need the same treatment before their rows can be trusted. Raw CSVs come from
-      `scripts/sweeps/kv-decode-with-speculation.ps1`.
+      For scale, the model the page used before this: 611 MiB short on the first, and **1,289 MiB
+      short (−31%)** on the second. "Roughly 170 MiB" was measured on MTP3 at a 40,960 context —
+      the mildest combination of mode and depth in the matrix.
+
+      User-visible effect: the page reported 262,144 tokens as the largest fitting context for
+      *every* speculation mode on the 35B. DFlash-3 actually tops out at 240,192.
 
 - [x] **KV is allocated in 64-token pages; the page charges exact tokens.** Fixed on #32. `KV page groups
       4096 / 4096` at a 262,144 context is 64 tokens per group. A context just past a page boundary
@@ -349,18 +356,20 @@ has to re-derive it.
       per weight profile, so `weightsBytes` is not transferable to, say, the NVFP4-weight variant.
       Either add the weight-profile dimension or label each row with its artifact.
 
-- [ ] **The regression tests exist but nothing runs them.** #32 landed
-      `docs/config-calculator.test.mjs`, and it is good: it extracts the page's `<script>` into a
-      `vm` sandbox against a DOM stub — keeping the one-file, no-build property rather than
-      restructuring the page into modules — and pins page rounding, the `decodeAtDepth` boundaries,
-      and a golden case asserting the 262,144-token INT8 figure still equals the engine's own
-      9,197,389,568-byte refusal. It passes (`node docs/config-calculator.test.mjs`).
+- [x] **The regression tests exist but nothing runs them.** Closed. #47 put
+      `docs/config-calculator.test.mjs` in a GitHub workflow — it needs `node`, which no other test
+      here does, so CTest was the wrong home for it. It now also covers the speculative path, which
+      the old entry correctly said it did not: three golden cases against the engine's own refusal
+      figures (no speculation, MTP3+head, DFlash-3), a check that DFlash's extra KV is a fixed
+      4,096 bytes per token rather than a ratio, a check that DFlash2's graph allowance steps with
+      context, and an invariant that no speculative mode may cost less than no speculation in
+      either fixed or per-token memory — which is precisely the failure the old model had.
 
-      What is missing is a runner. Nothing in CI, CTest or `scripts/` invokes it, so it will catch
-      a regression only if someone remembers to run it by hand. Wire it in. It needs `node`, which
-      no other test here does, so it probably belongs in the GitHub workflow rather than CTest.
-      It also does not cover the speculative path — which is the half still known to be wrong — so
-      extend it alongside that fix rather than after.
+      `docs/config-calculator.render.test.mjs` is new and covers what none of that did: `render()`
+      itself, over all 360 model x speculation x KV x context combinations, plus an assertion that
+      the reported largest-fitting context actually responds to the speculation mode. Most of the
+      page's code lives in `render()`, and a wrong property name there shows up only as a blank
+      page in a browser.
 
 - [x] **Active docs still contradict the six-format claim.** Fixed in #33, across four places. #32 fixed README's `Current limits`
       and `docs/perplexity.md`, but README's *opening* summary still says the FP8 E4M3 KV profile
@@ -472,12 +481,49 @@ roofline finally acquired a denominator; read them before the rest.
       re-measuring without speculation before it can be reasoned about — `ninfer_bench` can do that
       directly and the cohort table cannot.
 
-- [ ] **Prefill has no roofline either.** Measured this cycle at 1,254 tok/s on the 27B and 5,715
-      on the 35B at a 4,096-token prompt, falling to 1,087 and 4,302 by 32,768 — a 13% and 25%
-      decay that nothing explains or has looked at. Prefill is compute-bound rather than
-      bandwidth-bound, so the denominator is FLOPs and the accounting differs from decode; it has
-      not been done. Note the route tables *are* all measured (that work is finished), but measured
-      against each other, not against the hardware's ceiling.
+- [x] **Prefill has no roofline either.** It has one now (2026-09-09), and the naive version of it
+      is a trap worth documenting.
+
+      Prefill is compute-bound: a 1,024-token chunk does 2 x 25.02e9 x 1024 = 51.2 TFLOP of GEMM
+      against 15.74 GB of weight reads, an arithmetic intensity above 3,000 FLOP/byte. So the
+      denominator is MMA throughput, and `tools/tensor_core_rate_probe.cu` — already in the tree,
+      never pointed at this card — measures what it actually is:
+
+      | MMA shape | measured |
+      |---|---:|
+      | BF16 m16n8k16, f32 accumulate | **67.6 TFLOPS** |
+      | FP16 m16n8k16, f16 accumulate | 148.6 TFLOPS |
+      | INT8 m16n8k32 | **314.8 TOPS** |
+      | INT8 m16n8k16 | 302.4 TOPS |
+      | INT4 m16n8k64 | 601.3 TOPS |
+
+      **There is no single denominator, and using one gives whatever answer you want.** The 27B's
+      prefill mixes paths: the MLP GEMMs quantize activations to INT8 (`q4a8_swiglu_kernel`,
+      `q5a8_add_kernel`, fed by `quantize_activations`) while the GDN projections stay BF16
+      (`rowsplit_grouped_mma_kernel`, `q5_rowsplit_gemm_mma_kernel`). Time splits 54/46 between
+      them. Taking `2 x params` over the whole model and dividing by one ceiling gives **96.0% of
+      peak if you assume BF16** and **20.6% if you assume INT8** — for the same measurement. The
+      first number is very nearly what this entry was going to claim.
+
+      Per kernel, against the ceiling each one actually uses (from #53's capture, 4,096-token
+      prefill, parameter counts from the artifact):
+
+      | kernel | GFLOP/token | path | achieved | % of that ceiling |
+      |---|---:|---|---:|---:|
+      | `q4a8_swiglu` (mlp gate_up) | 22.82 | int8 | 97.4 T/s | **30.9%** |
+      | `q5a8_add` (mlp down) | 11.41 | int8 | 89.4 T/s | **28.4%** |
+      | `rowsplit_grouped_mma` (gdn value_z, query_key) | 8.05 | bf16 | 34.7 T/s | 51.4% |
+      | `q5_rowsplit_gemm_mma` (gdn output) | 3.02 | bf16 | 36.8 T/s | 54.4% |
+
+      So prefill is *not* near its ceiling. The MLP GEMMs, which are 68% of the FLOPs, run at
+      about **30% of the card's INT8 tensor-core rate**, and the BF16 projections at about 52% of
+      the BF16 rate. A well-tuned large GEMM on Ampere usually reaches 60-80% of a pure-MMA
+      microbenchmark, so there is real room here — plausibly more than in decode.
+
+      One caveat kept deliberately: these chunks are 1,024 tokens, which is skinny for a GEMM whose
+      other dimensions are 34,816 x 5,120, and the percentage would look different at a larger
+      prefill chunk. Sweeping `--prefill-chunk` against this ceiling is the obvious next step and
+      has not been done.
 
 - [ ] **Vision has essentially one performance number in the entire repository.** One acceptance
       figure for DFlash2 on the committed image fixture, and nothing about encode throughput,

--- a/docs/config-calculator.html
+++ b/docs/config-calculator.html
@@ -426,15 +426,23 @@
     expert offload are all out of scope here &mdash; see <code>docs/performance.md</code>.
   </p>
   <p>
-    <strong>Speculative-mode startup memory is an undercount, not just an approximation</strong>
-    (tracked in <code>TODO.md</code>). The "Startup memory" total above only adds the extra
-    resident weights measured for each speculation option; it reuses the no-speculation CUDA graph
-    allowance and adds no extra KV pages for either backend. The real engine sizes the graph
-    allowance per backend and draft window and can need tens of MiB more per lane for MTP or
-    DFlash than the flat figure used here, and MTP separately reserves extra paged-KV pages for
-    buffered draft tokens. The engine-cross-check above is for <code>--spec</code> unset; it does
-    not validate a speculative configuration. Leave headroom, or verify empirically, before relying
-    on a speculative "Fits" verdict close to the edge.
+    <strong>Speculative modes are now modelled per mode, and cross-checked against the engine.</strong>
+    Every term — resident weights, CUDA graph allowance, the fixed and per-token parts of the
+    non-KV sequence block, and the extra cache each backend reserves — is measured separately for
+    each speculation option by <code>scripts/sweeps/speculative-memory-terms.ps1</code>. Two
+    configurations are pinned against the engine's own refusal arithmetic: MTP3 with the draft head
+    on the 27B at a 262,144-token context agrees to 0.044%, and DFlash-3 on the 35B agrees
+    <em>exactly</em>. Before this, the page reused the 12 MiB no-speculation graph allowance and
+    added no extra cache for any mode, which understated that DFlash-3 case by 1,289 MiB.
+  </p>
+  <p>
+    The two backends behave differently and the page reflects that. MTP buffers extra draft tokens
+    in the KV format, so its cost is a multiplier — +6.30% per token on the 27B, +10.08% on the
+    35B — identical across storage formats. DFlash v1 instead reserves a fixed 4,096 bytes per
+    token regardless of format, which as a ratio would read as +38.8% on <code>int8</code> and
+    +71.1% on <code>nvfp4</code>. DFlash2 costs nothing per token and pays entirely in a graph
+    allowance that is itself context-dependent: 288 MiB up to 8,192 tokens and 384 MiB beyond,
+    against 12 MiB with speculation off.
   </p>
   <p>
     <strong>Weight profile.</strong> Every model here is measured against the one
@@ -464,10 +472,6 @@
 /* Every number below is measured; see the method notes in the page body. Bytes are bytes. */
 const DATA = {
   cardMiB: 24576,
-  graphBytes: 12582912,
-  /* Measured: the non-KV sequence block also carries 1/16 byte per token on both models. Tiny,
-     but it is what makes the fixed constants above reproduce every measurement exactly. */
-  seqPerToken: 0.0625,
 
   models: {
     "27b": {
@@ -482,7 +486,6 @@ const DATA = {
       /* Non-KV sequence state, = sequence capacity - KV payload. Measured at four context lengths:
          it is a fixed block plus 1/16 byte per token, not a per-token cost. Solved exactly from
          8k/16k/32k/64k, which reproduce all four measurements to the byte. */
-      seqFixedBytes: 166438656,
       /* KV payload bytes per token, = kv_payload_bytes / max_context. */
       kv: { bf16: 65536, int8: 33792, fp8: 33024, rk8v4: 26112, k8v4: 25728, nvfp4: 18432 },
       /* decode tok/s, no speculation, at these cache depths */
@@ -500,11 +503,11 @@ const DATA = {
         nvfp4: [35.37, 32.78, 29.86]
       },
       spec: {
-        none:          { label: "None",                weightsGiB: 15.92, decode: 34.41, accept: null },
-        mtp3:          { label: "MTP, 3 draft tokens", weightsGiB: 16.34, decode: 39.90, accept: null },
-        "mtp3+head":   { label: "MTP3 + draft head",   weightsGiB: 16.67, decode: 42.33, accept: 0.302 },
-        "dflash2-7":   { label: "DFlash2, 7 tokens",   weightsGiB: 17.99, decode: 27.57, accept: 0.108 },
-        "dflash2-7+head": { label: "DFlash2-7 + draft head", weightsGiB: 18.33, decode: 28.33, accept: null }
+        none:          { label: "None",                weightsGiB: 15.92, decode: 34.41, accept: null, graphBytes: 12582912, seqFixedBytes: 166438656, seqPerToken: 0.0625, kvRatio: 1, kvExtraPerToken: 0 },
+        mtp3:          { label: "MTP, 3 draft tokens", weightsGiB: 16.34, decode: 39.90, accept: null, graphBytes: 90177536, seqFixedBytes: 175693056, seqPerToken: 0.125, kvRatio: 1.062988281, kvExtraPerToken: 0 },
+        "mtp3+head":   { label: "MTP3 + draft head",   weightsGiB: 16.67, decode: 42.33, accept: 0.302, graphBytes: 90177536, seqFixedBytes: 175693056, seqPerToken: 0.125, kvRatio: 1.062988281, kvExtraPerToken: 0 },
+        "dflash2-7":   { label: "DFlash2, 7 tokens",   weightsGiB: 17.99, decode: 27.57, accept: 0.108, graphBytes: [[8192, 301989888], [Infinity, 402653184]], seqFixedBytes: 279090432, seqPerToken: 0.0625, kvRatio: 1, kvExtraPerToken: 0 },
+        "dflash2-7+head": { label: "DFlash2-7 + draft head", weightsGiB: 18.33, decode: 28.33, accept: null, graphBytes: [[8192, 301989888], [Infinity, 402653184]], seqFixedBytes: 279090432, seqPerToken: 0.0625, kvRatio: 1, kvExtraPerToken: 0 }
       }
     },
     "35b": {
@@ -514,7 +517,6 @@ const DATA = {
       weightsBytes: 21038469632,
       workspaceBytes: 109453312,
       nativeMaxContext: 262144,
-      seqFixedBytes: 70579968,
       kv: { bf16: 20480, int8: 10560, fp8: 10320, rk8v4: 8160, k8v4: 8040, nvfp4: 5760 },
       depths: [4096, 16384, 32768],
       /* Mean of two independent runs each, September 2026; see the note on the 27B rows. On this
@@ -528,11 +530,11 @@ const DATA = {
         nvfp4: [169.04, 151.81, 131.75]
       },
       spec: {
-        none:          { label: "None",                weightsGiB: 19.59, decode: 178.00, accept: null },
-        mtp3:          { label: "MTP, 3 draft tokens", weightsGiB: 20.43, decode: 214.37, accept: null },
-        "mtp3+head":   { label: "MTP3 + draft head",   weightsGiB: 20.56, decode: 256.03, accept: 0.594 },
-        "dflash-3":    { label: "DFlash, 3 tokens",    weightsGiB: 19.98, decode: 173.73, accept: null },
-        "dflash-3+head": { label: "DFlash-3 + draft head", weightsGiB: 20.11, decode: 196.65, accept: 0.379 }
+        none:          { label: "None",                weightsGiB: 19.59, decode: 178.00, accept: null, graphBytes: 12582912, seqFixedBytes: 70579968, seqPerToken: 0.0625, kvRatio: 1, kvExtraPerToken: 0 },
+        mtp3:          { label: "MTP, 3 draft tokens", weightsGiB: 20.43, decode: 214.37, accept: null, graphBytes: 90177536, seqFixedBytes: 76086528, seqPerToken: 0.125, kvRatio: 1.10078125, kvExtraPerToken: 0 },
+        "mtp3+head":   { label: "MTP3 + draft head",   weightsGiB: 20.56, decode: 256.03, accept: 0.594, graphBytes: 90177536, seqFixedBytes: 76086528, seqPerToken: 0.125, kvRatio: 1.10078125, kvExtraPerToken: 0 },
+        "dflash-3":    { label: "DFlash, 3 tokens",    weightsGiB: 19.98, decode: 173.73, accept: null, graphBytes: 167772160, seqFixedBytes: 193136896, seqPerToken: 0.125, kvRatio: 1, kvExtraPerToken: 4096 },
+        "dflash-3+head": { label: "DFlash-3 + draft head", weightsGiB: 20.11, decode: 196.65, accept: 0.379, graphBytes: 167772160, seqFixedBytes: 193136896, seqPerToken: 0.125, kvRatio: 1, kvExtraPerToken: 4096 }
       }
     }
   },
@@ -593,26 +595,48 @@ const fmtInt = (n) => Math.round(n).toLocaleString("en-US");
 function modelOf() { return DATA.models[$("model").value]; }
 
 /* Per-token resident cost: the cache itself plus the non-KV sequence state that scales with it. */
-function perToken(model, kv) {
+/* Per-token resident cost: the cache itself plus the non-KV sequence state that scales with it.
+   Both move with the speculation mode, and the two speculative backends move them differently --
+   which is why TODO.md section 2b's "one constant multiplier" only ever fit MTP.
+     MTP buffers extra draft tokens *in the KV format*, so its cost is multiplicative and identical
+   across formats: +6.2988% per token on the 27B, +10.078% on the 35B (both confirmed against a
+   second format, nvfp4, to within page rounding).
+     DFlash v1 instead reserves a fixed scratch region per token, measured at exactly 4,096 bytes
+   and independent of the format. Modelling that as a ratio is what made it look format-dependent:
+   4,096 bytes is +38.8% on int8's 10,560 but +71.1% on nvfp4's 5,760.
+     DFlash2 on the 27B costs nothing per token at all and pays entirely in its graph allowance. */
+function perToken(model, kv, specKey) {
   const k = model.kv[kv];
-  return k === null ? null : k + DATA.seqPerToken;
+  if (k === null) return null;
+  const spec = model.spec[specKey === undefined ? "none" : specKey];
+  return k * spec.kvRatio + spec.kvExtraPerToken + spec.seqPerToken;
 }
 
-function fixedBytes(model, specKey) {
-  const spec = model.spec[specKey];
-  const base = model.spec.none.weightsGiB;
-  /* Speculation heads are extra resident weights; the measured deltas are in GiB.
-     KNOWN GAP (see TODO.md): DATA.graphBytes is the no-speculation CUDA graph allowance for
-     every spec mode. The real engine sizes it per speculative backend and draft window
-     (layouts_impl.h: 12 MiB flat for None, up to ~86 MiB/lane for MTP, up to ~96 MiB/lane for
-     DFlash), and MTP also reserves extra paged-KV pages for buffered draft tokens
-     (persistent_layout's mtp_extra_pages) that this function does not add either. Both are
-     undercounts specific to specKey != "none"; the no-speculation case is unaffected and is the
-     one figure this page's engine cross-check (see the method notes) actually validates. */
-  const specExtra = (spec.weightsGiB - base) * GIB;
-  return model.weightsBytes + specExtra + model.workspaceBytes + DATA.graphBytes +
-         model.seqFixedBytes;
+
+/* The CUDA graph allowance is per speculative backend, and for DFlash2 it is per context as well.
+   Measured with scripts/sweeps/speculative-memory-terms.ps1 at 8,192/16,384/32,768: DFlash2 asks
+   288 MiB at 8,192 and 384 MiB at both deeper points, so it is modelled as a step. Only three
+   contexts were measured, so treat a value between them as the higher of the two. */
+function graphBytes(spec, ctx) {
+  const g = spec.graphBytes;
+  if (typeof g === "number") return g;
+  for (const [limit, bytes] of g) if (ctx <= limit) return bytes;
+  return g[g.length - 1][1];
 }
+
+/* Everything resident that does not scale with context, for one speculation mode.
+   Every term here is measured per mode rather than borrowed from the no-speculation case, which
+   is what this page got wrong until 2026-09-09: it reused the 12 MiB graph allowance for all of
+   them and added no extra KV, understating MTP3 on the 27B by 149 MiB and the DFlash2 graph
+   allowance alone by 372 MiB. */
+function fixedBytes(model, specKey, ctx) {
+  const spec = model.spec[specKey];
+  const specExtra = (spec.weightsGiB - model.spec.none.weightsGiB) * GIB;
+  return model.weightsBytes + specExtra + model.workspaceBytes +
+         graphBytes(spec, ctx === undefined ? model.nativeMaxContext : ctx) +
+         spec.seqFixedBytes;
+}
+
 
 function usableBytes() {
   return (DATA.cardMiB - Number($("reserve").value)) * MIB;
@@ -654,18 +678,20 @@ function render() {
   const specKey = $("spec").value;
   const ctx = Math.max(256, Number($("ctx").value) || 0);
 
-  const pt = perToken(model, kv);
-  const fixed = fixedBytes(model, specKey);
+  const pt = perToken(model, kv, specKey);
+  const fixed = fixedBytes(model, specKey, ctx);
   const usable = usableBytes();
 
   const haveKv = pt !== null;
   /* KV is reserved by the physical page the requested context rounds up to, not by the exact
      token count -- see the PAGE_TOKENS note above. */
-  const kvBytes = haveKv ? model.kv[kv] * pageRoundUp(ctx) : 0;
-  const ovhBytes = haveKv ? model.seqFixedBytes + DATA.seqPerToken * ctx : 0;
-  const specExtra = (model.spec[specKey].weightsGiB - model.spec.none.weightsGiB) * GIB;
+  const specMode = model.spec[specKey];
+  const kvBytes = haveKv
+    ? (model.kv[kv] * specMode.kvRatio + specMode.kvExtraPerToken) * pageRoundUp(ctx) : 0;
+  const ovhBytes = haveKv ? specMode.seqFixedBytes + specMode.seqPerToken * ctx : 0;
+  const specExtra = (specMode.weightsGiB - model.spec.none.weightsGiB) * GIB;
   const weightsBytes = model.weightsBytes + specExtra;
-  const wsBytes = model.workspaceBytes + DATA.graphBytes;
+  const wsBytes = model.workspaceBytes + graphBytes(specMode, ctx);
   const total = weightsBytes + kvBytes + ovhBytes + wsBytes;
 
   /* Bar is drawn against the full card so the OS reserve is visible as unclaimed space. */
@@ -773,8 +799,11 @@ function render() {
   $("out-ppl-sub").textContent = ppl.toFixed(6) + " vs bf16 " + base.toFixed(6) +
     ($("model").value === "27b" ? "" : " · measured on the 27B");
 
+  /* Per mode: MTP and DFlash both raise the fixed block and double the per-token term, so
+     showing the no-speculation numbers here would contradict the memory bar above. */
   $("overhead-note").textContent =
-    (model.seqFixedBytes / MIB).toFixed(1) + " MiB fixed + 1/16 B per token";
+    (specMode.seqFixedBytes / MIB).toFixed(1) + " MiB fixed + " +
+    (specMode.seqPerToken === 0.0625 ? "1/16" : "1/8") + " B per token";
   $("kv-hint").textContent = DATA.kvNotes[kv];
   $("spec-hint").textContent = (spec.accept !== null
     ? "Measured draft acceptance " + (spec.accept * 100).toFixed(1) + "% on this model. "
@@ -800,7 +829,8 @@ function buildKvTable() {
   /* Against the real card and the chosen OS reserve rather than an arbitrary fixed budget: on the
      35B a 6 GiB budget put every format at the 262,144 cap, so the column distinguished nothing.
      fixedBytes already accounts for the fixed sequence block, so what is left is the cache. */
-  const budget = usableBytes() - fixedBytes(model, $("spec").value);
+  const specKeyForTable = $("spec").value;
+  const budget = usableBytes() - fixedBytes(model, specKeyForTable, model.nativeMaxContext);
 
   const deepest = model.depths[model.depths.length - 1];
   const rows = KV_ORDER.map((kv) => {
@@ -811,7 +841,8 @@ function buildKvTable() {
     if (b === null) return { kv, b, ppl, deep, ctx: null, capped: false };
     // Page-aligned, same reasoning as render()'s "Largest context that fits": see the PAGE_TOKENS
     // note near the top of this script.
-    const raw = PAGE_TOKENS * Math.floor(budget / (PAGE_TOKENS * (b + DATA.seqPerToken)));
+    const ptTable = perToken(model, kv, specKeyForTable);
+    const raw = PAGE_TOKENS * Math.floor(budget / (PAGE_TOKENS * ptTable));
     /* Report what is actually reachable: past the model's own context limit the extra budget
        buys nothing, and showing the uncapped figure would promise context that cannot be had. */
     return { kv, b, ppl, deep, ctx: Math.min(raw, model.nativeMaxContext),
@@ -837,7 +868,7 @@ function buildKvTable() {
   $("kv-caption").textContent =
     "Largest context is what fits on the " + model.label +
     " at the currently selected OS reserve and speculation mode, after the fixed " +
-    (model.seqFixedBytes / MIB).toFixed(1) +
+    (model.spec[specKeyForTable].seqFixedBytes / MIB).toFixed(1) +
     " MiB of non-KV sequence state. Decode is at a " + fmtInt(deepest) +
     "-token cache depth, no speculation. Perplexity was measured on the Qwen3.8-27B.";
 }

--- a/docs/config-calculator.render.test.mjs
+++ b/docs/config-calculator.render.test.mjs
@@ -1,0 +1,95 @@
+// Drive render() and buildKvTable() through the page's own script with a DOM stub, over every
+// model x speculation x KV x context combination.
+//
+// config-calculator.test.mjs exercises the arithmetic helpers -- pageRoundUp, perToken,
+// fixedBytes, graphBytes, decodeAtDepth, buildKvTable -- but never render(), which is where most
+// of the page's own code lives and where a wrong property name or an out-of-scope variable would
+// only show up as a blank page in a browser. Adding per-mode speculative memory touched render()
+// in four places, so this exists to catch that class of mistake without a browser.
+//
+// It asserts two things: that nothing throws across all 360 combinations, and that the reported
+// largest-fitting context actually responds to the speculation mode. The second one matters --
+// before per-mode terms the page reported 262,144 tokens for every mode on the 35B, including
+// DFlash-3, which really tops out at 240,192.
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+const html = readFileSync("docs/config-calculator.html", "utf8");
+const m = html.match(/<script>\n([\s\S]*?)<\/script>/);
+const source = m[1];
+
+const els = new Map();
+function el(id) {
+  if (!els.has(id)) {
+    els.set(id, { id, value: "", textContent: "", innerHTML: "", className: "", style: {},
+                  firstChild: { nodeValue: "" }, lastChild: { nodeValue: "" },
+                  dataset: {}, hidden: false, children: [],
+                  addEventListener() {}, appendChild(c) { this.children.push(c); },
+                  querySelector() { return el(id + "-q"); },
+                  querySelectorAll() { return []; },
+                  setAttribute() {}, getAttribute() { return null; },
+                  classList: { add() {}, remove() {}, toggle() {}, contains: () => false } });
+  }
+  return els.get(id);
+}
+const document = {
+  getElementById: el,
+  querySelector: (s) => el("sel:" + s),
+  querySelectorAll: () => [],
+  createElement: (t) => el("new:" + t + ":" + Math.random()),
+  addEventListener() {},
+};
+const context = { document, window: { addEventListener() {}, matchMedia: () => ({ matches: false, addEventListener() {} }) },
+                  console, Math, Number, String, Object, Array, JSON, isNaN, parseFloat, parseInt,
+                  Infinity, NaN, location: { hash: "" }, history: { replaceState() {} } };
+context.globalThis = context;
+// The page runs buildControls() at load, which reads these, so seed them first.
+el("model").value = "27b";
+el("spec").value = "none";
+el("kv").value = "int8";
+el("ctx").value = "8192";
+el("reserve").value = "307";
+vm.createContext(context);
+vm.runInContext(source, context, { filename: "config-calculator inline script" });
+
+const { DATA, render, buildKvTable } = vm.runInContext("({DATA, render, buildKvTable})", context);
+let runs = 0, failures = 0;
+for (const modelKey of Object.keys(DATA.models)) {
+  const model = DATA.models[modelKey];
+  for (const specKey of Object.keys(model.spec)) {
+    for (const kv of Object.keys(model.kv)) {
+      for (const ctx of [256, 4096, 8192, 8193, 40960, 262144]) {
+        el("model").value = modelKey;
+        el("spec").value = specKey;
+        el("kv").value = kv;
+        el("ctx").value = String(ctx);
+        el("reserve").value = "307";
+        try { render(); buildKvTable(); runs++; }
+        catch (e) {
+          failures++;
+          if (failures <= 3) console.log(`FAIL ${modelKey}/${specKey}/${kv}/${ctx}: ${e.message}`);
+        }
+      }
+    }
+  }
+}
+console.log(`render()+buildKvTable() over ${runs + failures} combinations: ${failures} threw`);
+
+// The largest-fitting context must respond to the speculation mode, or the page is silently
+// promising context a speculative configuration cannot deliver.
+el("model").value = "35b"; el("kv").value = "int8"; el("ctx").value = "32768"; el("reserve").value = "307";
+for (const specKey of ["none", "mtp3+head", "dflash-3"]) {
+  el("spec").value = specKey; render();
+  const mx = el("out-maxctx").firstChild.nodeValue;
+  console.log(`  35b/${specKey.padEnd(10)} largest ctx=${mx}  |  ${el("out-maxctx-sub").textContent}`);
+}
+el("spec").value = "none"; render();
+const noneCtx = el("out-maxctx").firstChild.nodeValue;
+el("spec").value = "dflash-3"; render();
+const dflashCtx = el("out-maxctx").firstChild.nodeValue;
+if (noneCtx === dflashCtx) {
+  console.log(`FAIL largest context did not move with the speculation mode (${noneCtx} both ways)`);
+  failures++;
+}
+console.log(failures ? `FAIL (${failures})` : "PASS");
+process.exit(failures ? 1 : 0);

--- a/docs/config-calculator.test.mjs
+++ b/docs/config-calculator.test.mjs
@@ -61,9 +61,10 @@ vm.runInContext(source, context, { filename: "config-calculator.html inline scri
 // Top-level `const`/`let` bindings in a vm context live in that context's script-level lexical
 // environment, not as properties of the context object itself -- pull the ones under test out
 // with a second expression evaluated in the same context, where they are still in scope.
-const { DATA, PAGE_TOKENS, pageRoundUp, perToken, fixedBytes, decodeAtDepth, buildKvTable } =
+const { DATA, PAGE_TOKENS, MIB, pageRoundUp, perToken, fixedBytes, graphBytes, decodeAtDepth,
+        buildKvTable } =
   vm.runInContext(
-    "({DATA, PAGE_TOKENS, pageRoundUp, perToken, fixedBytes, decodeAtDepth, buildKvTable})",
+    "({DATA, PAGE_TOKENS, MIB, pageRoundUp, perToken, fixedBytes, graphBytes, decodeAtDepth, buildKvTable})",
     context);
 
 let failures = 0;
@@ -136,17 +137,117 @@ check("decodeAtDepth: past the deepest measured point extrapolates", () => {
 check("golden: 262144-token int8, no speculation, 27B matches the engine's own refusal figure", () => {
   const model = model27b;
   const ctx = 262144;
-  const kvBytes = model.kv.int8 * pageRoundUp(ctx);
-  const ovhBytes = model.seqFixedBytes + DATA.seqPerToken * ctx;
-  const reservation = kvBytes + ovhBytes + model.workspaceBytes + DATA.graphBytes;
+  const none = model.spec.none;
+  const kvBytes = (model.kv.int8 * none.kvRatio + none.kvExtraPerToken) * pageRoundUp(ctx);
+  const ovhBytes = none.seqFixedBytes + none.seqPerToken * ctx;
+  const reservation = kvBytes + ovhBytes + model.workspaceBytes + graphBytes(none, ctx);
   assert.equal(reservation, 9197389568);
+});
+
+// --- and the same cross-check for a *speculative* configuration ---------------------------------
+// This is the half TODO.md section 2b flagged as untested, and it was untested because the page's
+// speculative model was known to be wrong. With per-mode terms measured by
+// scripts/sweeps/speculative-memory-terms.ps1, the engine can be asked the same question:
+//
+//   ninfer qwen3_8_27b.ninfer --max-context 262144 --kv-dtype int8 --spec mtp --draft-tokens 3 //       --lm-head-draft
+//   error: requested Engine runtime reservation requires 9838038272 bytes
+//
+// The page's terms reproduce that to 0.044%. The remaining 4.3 MB on 9.84 GB is page-rounding in
+// the engine's own allocator, which this page models at KV-page granularity only.
+//
+// For scale, the model this page used before carrying per-mode terms came out 611 MiB *short* of
+// the same figure -- section 2b's "roughly 170 MiB optimistic" was itself measured at a 40,960
+// context, where the per-token terms contribute far less than they do here.
+check("golden: 262144-token int8 with MTP3 + draft head is within 0.1% of the engine", () => {
+  const model = model27b;
+  const ctx = 262144;
+  const spec = model.spec["mtp3+head"];
+  const kvBytes = (model.kv.int8 * spec.kvRatio + spec.kvExtraPerToken) * pageRoundUp(ctx);
+  const ovhBytes = spec.seqFixedBytes + spec.seqPerToken * ctx;
+  const reservation = kvBytes + ovhBytes + model.workspaceBytes + graphBytes(spec, ctx);
+  const engine = 9838038272;
+  const error = Math.abs(reservation - engine) / engine;
+  assert.ok(error < 0.001, `reservation ${reservation} vs engine ${engine} (${(error * 100).toFixed(3)}%)`);
+});
+
+// --- DFlash v1 on the 35B, which the model reproduces exactly ----------------------------------
+// The strongest cross-check available, and the one that settles how DFlash should be modelled:
+//
+//   ninfer qwen3_6_35b_a3b.ninfer --max-context 262144 --kv-dtype int8 --spec dflash --draft-tokens 3
+//   error: requested Engine runtime reservation requires 4312377600 bytes
+//
+// The page's terms reproduce that figure *to the byte*. They only do so because DFlash's extra KV
+// is modelled as a fixed 4,096 bytes per token rather than as a multiplier: measured, the extra is
+// 32 MiB at 8,192 tokens, 64 MiB at 16,384 and 128 MiB at 32,768, exactly linear in context and
+// identical for int8 and nvfp4. As a ratio it would have to be 1.388 for int8 and 1.711 for nvfp4,
+// which is the same quantity wearing the wrong shape.
+//
+// For scale: the model this page used before per-mode terms came out 1,289 MiB short here, a 31%
+// undercount. Section 2b's "roughly 170 MiB" was measured at a 40,960 context on MTP3, which is
+// the mildest combination of mode and depth.
+check("golden: 262144-token int8 with DFlash-3 on the 35B matches the engine exactly", () => {
+  const model = DATA.models["35b"];
+  const ctx = 262144;
+  const spec = model.spec["dflash-3"];
+  const kvBytes = (model.kv.int8 * spec.kvRatio + spec.kvExtraPerToken) * pageRoundUp(ctx);
+  const ovhBytes = spec.seqFixedBytes + spec.seqPerToken * ctx;
+  const reservation = kvBytes + ovhBytes + model.workspaceBytes + graphBytes(spec, ctx);
+  assert.equal(reservation, 4312377600);
+});
+
+// --- DFlash's extra KV is per token, not per format --------------------------------------------
+// If someone re-derives this as a ratio, these two assertions fail. That is the point.
+check("DFlash's extra KV is a fixed 4096 bytes per token across formats", () => {
+  const model = DATA.models["35b"];
+  const spec = model.spec["dflash-3"];
+  assert.equal(spec.kvExtraPerToken, 4096);
+  assert.equal(spec.kvRatio, 1);
+  for (const kv of ["int8", "nvfp4", "bf16"]) {
+    const delta = perToken(model, kv, "dflash-3") - perToken(model, kv, "none");
+    // 4096 of extra cache plus the doubled non-KV per-token term (0.0625 -> 0.125).
+    assert.equal(delta, 4096 + 0.0625);
+  }
+});
+
+// --- the DFlash2 graph allowance is a step in context -------------------------------------------
+// Measured 288 MiB at 8,192 and 384 MiB at 16,384 and 32,768. A flat value would understate the
+// deeper contexts by 96 MiB, and using the deeper value everywhere would overstate 8,192 by the
+// same. Pin both sides so a future edit cannot quietly flatten it.
+check("graphBytes: DFlash2's allowance steps with context, other modes are flat", () => {
+  const spec = model27b.spec["dflash2-7"];
+  assert.equal(graphBytes(spec, 8192), 288 * MIB);
+  assert.equal(graphBytes(spec, 16384), 384 * MIB);
+  assert.equal(graphBytes(spec, 262144), 384 * MIB);
+  const mtp = model27b.spec["mtp3+head"];
+  assert.equal(graphBytes(mtp, 8192), 86 * MIB);
+  assert.equal(graphBytes(mtp, 262144), 86 * MIB);
+  assert.equal(graphBytes(model27b.spec.none, 262144), 12 * MIB);
+});
+
+// --- speculation must never look cheaper than no speculation ------------------------------------
+// The failure mode the old model had: every speculative row understated memory, so the page could
+// report a speculative configuration fitting a context that the plain one did not. Assert the
+// ordering directly, for every mode on both models.
+check("every speculative mode costs at least as much as none, per token and fixed", () => {
+  for (const key of Object.keys(DATA.models)) {
+    const model = DATA.models[key];
+    const noneFixed = fixedBytes(model, "none", 262144);
+    const nonePt = perToken(model, "int8", "none");
+    for (const specKey of Object.keys(model.spec)) {
+      if (specKey === "none") continue;
+      assert.ok(fixedBytes(model, specKey, 262144) >= noneFixed,
+        `${key}/${specKey} fixed bytes below none`);
+      assert.ok(perToken(model, "int8", specKey) >= nonePt,
+        `${key}/${specKey} per-token below none`);
+    }
+  }
 });
 
 // --- max-context page alignment -----------------------------------------------------------------
 check("max-context formula (mirrored here) is always a page multiple and fits", () => {
   const model = model27b;
-  const pt = perToken(model, "int8");
-  const fixed = fixedBytes(model, "none"); // weights + workspace + graph + seqFixedBytes, once
+  const pt = perToken(model, "int8", "none");
+  const fixed = fixedBytes(model, "none", model.nativeMaxContext); // weights + workspace + graph + seqFixed, once
   for (const reserveMiB of [0, 307, 1536, 2560]) {
     const usable = (DATA.cardMiB - reserveMiB) * 1024 * 1024;
     const room = usable - fixed;
@@ -155,7 +256,7 @@ check("max-context formula (mirrored here) is always a page multiple and fits", 
     // Reconstructed the same way render()'s `total` is: seqFixedBytes counted once (inside
     // ovhBytes), not twice (fixedBytes() already carries its own copy for the room calculation).
     const kvBytes = model.kv.int8 * pageRoundUp(maxCtx);
-    const perTokenOverhead = DATA.seqPerToken * maxCtx;
+    const perTokenOverhead = model.spec.none.seqPerToken * maxCtx;
     assert.ok(fixed + kvBytes + perTokenOverhead <= usable + 1e-6,
       "reserve=" + reserveMiB + "MiB: reported max-context must not exceed usable memory");
   }

--- a/scripts/sweeps/speculative-memory-terms.ps1
+++ b/scripts/sweeps/speculative-memory-terms.ps1
@@ -1,0 +1,71 @@
+# What does each speculative backend actually cost in memory?
+#
+# docs/config-calculator.html modelled speculation as a weights delta and nothing else, which made
+# every speculative configuration it reported roughly 170 MiB optimistic (TODO section 2b). The
+# missing pieces are the CUDA graph allowance, the non-KV sequence block and the KV cache itself,
+# all three of which move when a draft window is added.
+#
+# Everything needed is reported by the engine at load, so this asks for one token and reads the
+# summary rather than measuring anything. Two contexts per configuration separate the fixed part of
+# the sequence block from its per-token part; a third is a check that the two-point solve is right.
+#
+# Roughly ten minutes for the whole matrix, dominated by artifact load time.
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\speculative-memory-terms.ps1
+$ErrorActionPreference = 'Continue'
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
+
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+
+# DFlash2 lives in its own artifact. The calculator's 27B row is measured against
+# qwen3_8_27b.ninfer, so its DFlash2 entries are a different file from its other entries -- which
+# is worth stating rather than smoothing over, and is why `artifact` is a column below.
+$dense   = "$modelDir\qwen3_8_27b.ninfer"
+$dense2  = "$modelDir\qwen3_8_27b_dflash2.ninfer"
+$moe     = "$modelDir\qwen3_6_35b_a3b.ninfer"
+
+$configs = @(
+  @{ model='27b'; key='none';            weights=$dense;  spec=@() }
+  @{ model='27b'; key='mtp3';            weights=$dense;  spec=@('--spec','mtp','--draft-tokens','3') }
+  @{ model='27b'; key='mtp3+head';       weights=$dense;  spec=@('--spec','mtp','--draft-tokens','3','--lm-head-draft') }
+  @{ model='27b'; key='dflash2-7';       weights=$dense2; spec=@('--spec','dflash2','--draft-tokens','7') }
+  @{ model='27b'; key='dflash2-7+head';  weights=$dense2; spec=@('--spec','dflash2','--draft-tokens','7','--lm-head-draft') }
+  @{ model='35b'; key='none';            weights=$moe;    spec=@() }
+  @{ model='35b'; key='mtp3';            weights=$moe;    spec=@('--spec','mtp','--draft-tokens','3') }
+  @{ model='35b'; key='mtp3+head';       weights=$moe;    spec=@('--spec','mtp','--draft-tokens','3','--lm-head-draft') }
+  @{ model='35b'; key='dflash-3';        weights=$moe;    spec=@('--spec','dflash','--draft-tokens','3') }
+  @{ model='35b'; key='dflash-3+head';   weights=$moe;    spec=@('--spec','dflash','--draft-tokens','3','--lm-head-draft') }
+)
+
+# int8 for the solve; one nvfp4 point per configuration checks that the speculative KV multiplier
+# is a property of the draft window rather than of the storage format.
+$points = @(
+  @{ kv='int8';  ctx=8192  }
+  @{ kv='int8';  ctx=16384 }
+  @{ kv='int8';  ctx=32768 }
+  @{ kv='nvfp4'; ctx=16384 }
+)
+
+"model,spec,artifact,kv,max_ctx,weights_bytes,sequence_bytes,kv_payload_bytes,workspace_bytes,graph_bytes"
+foreach ($c in $configs) {
+  if (-not (Test-Path $c.weights)) { "$($c.model),$($c.key),MISSING,,,,,,,"; continue }
+  foreach ($p in $points) {
+    $tag = "spm_$($c.model)_$($c.key -replace '\+','p')_$($p.kv)_$($p.ctx)"
+    $csv = "$out\$tag.csv"
+    $argv = @('--weights',$c.weights,'--kv-dtype',$p.kv,'--max-ctx',[string]$p.ctx,
+              '-n','1','-r','1','--warmup','0','-o','csv','--output-file',$csv) + $c.spec
+    & .\build-ninja\bench\ninfer_bench.exe @argv > "$out\$tag.log" 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $csv)) {
+      "$($c.model),$($c.key),$(Split-Path -Leaf $c.weights),$($p.kv),$($p.ctx),FAILED,,,,"
+      Get-Content "$out\$tag.log" -Tail 3 | ForEach-Object { "    $_" }
+      continue
+    }
+    $r = Import-Csv $csv | Select-Object -First 1
+    "$($c.model),$($c.key),$(Split-Path -Leaf $c.weights),$($p.kv),$($p.ctx)," +
+      "$($r.weights_capacity_bytes),$($r.sequence_capacity_bytes),$($r.kv_payload_bytes)," +
+      "$($r.workspace_capacity_bytes),$($r.cuda_graph_allowance_bytes)"
+  }
+}
+"== done =="


### PR DESCRIPTION
fix(calculator): model speculative memory per mode, and cross-check it against the engine

Closes TODO.md §1.3 and the first two entries of §2b. The page is linked from README as
authoritative and every speculative configuration it reported was optimistic; §2b put that at
"roughly 170 MiB", which turns out to be the mildest case in the matrix.

`scripts/sweeps/speculative-memory-terms.ps1` asks the engine for every term at three contexts per
mode -- ten minutes of load-and-report, no benchmarking, because the engine already prints all of
them. Solving two contexts separates the fixed and per-token parts; the third confirms the solve.

    model  spec                graph        seq fixed  seq/tok   kv ratio  kv extra/tok
    27B    none                12 MiB       158.7 MiB     1/16          1             0
    27B    mtp3 (+head)        86 MiB       167.6 MiB      1/8    1.06299             0
    27B    dflash2-7 (+head)   288/384 MiB  266.2 MiB     1/16          1             0
    35B    none                12 MiB        67.3 MiB     1/16          1             0
    35B    mtp3 (+head)        86 MiB        72.6 MiB      1/8    1.10078             0
    35B    dflash-3 (+head)    160 MiB      184.2 MiB      1/8          1       4,096 B

**§2b's "one constant multiplier" only ever fitted MTP, and finding out why fixed the model.** MTP
buffers extra draft tokens *in the KV format*, so its cost is multiplicative and identical across
formats -- +6.2988% per token on the 27B, +10.078% on the 35B, both confirmed against nvfp4 to
within page rounding. DFlash v1 reserves a fixed scratch region per token instead, measured at
**exactly 4,096 bytes** and format-independent: 32 MiB at 8,192 tokens, 64 at 16,384, 128 at
32,768. Expressed as a ratio that is 1.388 on int8 and 1.711 on nvfp4, which is the same quantity
wearing the wrong shape -- and is what would have made a ratio-based model wrong for every format
but the one it was fitted on. DFlash2 costs nothing per token and pays entirely in a graph
allowance that is itself a step in context.

**Cross-checked against the engine's own refusal arithmetic**, which §2b noted had only ever been
done with `--spec` unset:

    configuration                     engine          page          error
    27B int8 262,144 mtp3+head     9,838,038,272  9,842,380,571     +0.044%
    35B int8 262,144 dflash-3      4,312,377,600  4,312,377,600      exact

The previous model was 611 MiB short on the first and **1,289 MiB short (-31%)** on the second.

User-visible effect: the page reported 262,144 tokens as the largest fitting context for *every*
speculation mode on the 35B. DFlash-3 actually tops out at 240,192, and it now says so.

Tests. The unit suite gains the three golden cases above, an assertion that DFlash's extra KV is
4,096 bytes per token rather than a ratio, one pinning DFlash2's graph step at both sides of 8,192
tokens, and an invariant that no speculative mode may cost *less* than no speculation in either
fixed or per-token memory -- exactly the failure the old model had. The no-speculation golden case
is unchanged and still matches to the byte, which is what proves this did not disturb the one
figure the page was already right about.

`docs/config-calculator.render.test.mjs` is new, and covers what none of the above did: `render()`
itself, across all 360 model x speculation x KV x context combinations, plus an assertion that the
largest-fitting context responds to the speculation mode. Most of the page's code is in `render()`
and this change edited four places inside it; a wrong property name there surfaces only as a blank
page in a browser. Both suites run in CI.

Removed rather than left stale: `DATA.graphBytes`, `DATA.seqPerToken` and the model-level
`seqFixedBytes`, all of which are now per mode. The two body captions that quoted the
no-speculation figures now quote the selected mode's, so they cannot contradict the memory bar
above them.

