### PR TITLE
fix(dflash2): verify identical output instead of assuming it, and fix two stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,8 @@ The server supports:
 See [HTTP serving](docs/serving.md) and [CLI usage](docs/cli.md).
 
 Qwen3.8-27B artifacts carrying the DFlash2 companion weights support
-`--spec dflash2 --draft-tokens 7`, with draft counts 1..15 and either full or optimized
+`--spec dflash2 --draft-tokens 4` (see [CLI usage](docs/cli.md) for why four rather than seven),
+with draft counts 1..15 and either full or optimized
 proposal heads. **DFlash2 runs with `--vision`**, verified on a 3090 against the committed
 `image_chart` fixture: target verification carries its own continuation RoPE position, so a
 multimodal row keeps its per-sequence `rope_delta` through verification rather than being

--- a/scripts/sweeps/dflash2-draft-tokens-realtext.ps1
+++ b/scripts/sweeps/dflash2-draft-tokens-realtext.ps1
@@ -19,8 +19,12 @@
 #
 #   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\dflash2-draft-tokens-realtext.ps1
 #
-# About 25 minutes. Greedy, so each configuration generates the same text and the comparison is of
-# speed on identical output rather than of two different continuations.
+# About 25 minutes. Greedy at every configuration, which is necessary but not sufficient for the
+# comparison to be of speed on identical output: TODO.md records DFlash2 and MTP producing
+# byte-identical output *to each other*, and both diverging from the width-1 greedy path within the
+# first hundred tokens -- squarely inside this sweep's --max-new 256 window. So this does not
+# assume identical output; it hashes each run's generated text (content_sha256 below) and leaves the
+# comparison to whoever reads the CSV, rather than asserting a thing that has been measured false.
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
@@ -46,18 +50,24 @@ foreach ($n in 1,2,3,4,5,6,7,8,10,12) {
 $configs += @{ label='mtp3';      args=@('--spec','mtp','--draft-tokens','3') }
 $configs += @{ label='mtp3+head'; args=@('--spec','mtp','--draft-tokens','3','--lm-head-draft') }
 
-"config,rep,decode_tok_s,generated_tokens"
+"config,rep,decode_tok_s,generated_tokens,content_sha256"
 foreach ($c in $configs) {
   for ($rep = 1; $rep -le 3; $rep++) {
-    $log = "$out\rt_$($c.label -replace '\+','p')_$rep.log"
+    $stem = "$out\rt_$($c.label -replace '\+','p')_$rep"
+    $log  = "$stem.err.log"
+    $text = "$stem.txt"
     $argv = @($weights,'--prompt',$prompt,'--max-new','256','--max-context','8192',
               '--kv-dtype','int8','--greedy','--no-thinking') + $c.args
-    & .\build-ninja\apps\ninfer.exe @argv > $log 2>&1
-    if ($LASTEXITCODE -ne 0) { "$($c.label),$rep,FAILED,"; Get-Content $log -Tail 2 | ForEach-Object { "    $_" }; continue }
-    $txt = Get-Content $log -Raw
-    $dec = if ($txt -match 'decode speed\s+([\d.]+) tok/s') { $Matches[1] } else { '' }
-    $gen = if ($txt -match 'generated tokens\s+(\d+)')      { $Matches[1] } else { '' }
-    "$($c.label),$rep,$dec,$gen"
+    # apps/cli/main.cpp writes generated text to stdout and every stage/summary line (including
+    # decode_tok_s and generated_tokens below) to stderr -- captured separately so $text is exactly
+    # the model's output and can be hashed, rather than the merged stream this used to read.
+    & .\build-ninja\apps\ninfer.exe @argv > $text 2> $log
+    if ($LASTEXITCODE -ne 0) { "$($c.label),$rep,FAILED,,"; Get-Content $log -Tail 2 | ForEach-Object { "    $_" }; continue }
+    $txt  = Get-Content $log -Raw
+    $dec  = if ($txt -match 'decode speed\s+([\d.]+) tok/s') { $Matches[1] } else { '' }
+    $gen  = if ($txt -match 'generated tokens\s+(\d+)')      { $Matches[1] } else { '' }
+    $hash = (Get-FileHash $text -Algorithm SHA256).Hash
+    "$($c.label),$rep,$dec,$gen,$hash"
   }
 }
 "== done =="

--- a/tools/bench/make_bench_corpus.py
+++ b/tools/bench/make_bench_corpus.py
@@ -249,8 +249,13 @@ def build_manifest(
         "source": "source_text" if source_provenance else "builtin_curated_bank",
         "source_files": source_provenance,
         "note": (
-            "meaningful tokens; tiled (rotated) and truncated to exactly `tokens`. "
-            "Repetition fills length only and does not bias throughput."
+            "meaningful tokens; tiled (rotated) and truncated to exactly `tokens`. Repetition "
+            "fills length only and does not bias PREFILL OR PLAIN DECODE throughput, which are "
+            "token-count and bandwidth bound. It does NOT hold for anything that drafts: a "
+            "sufficiently repetitive corpus lets a draft head predict it near-perfectly, "
+            "inflating acceptance and decode rate with no relationship to real text. Use a "
+            "diverse --source-text for speculative measurements, or measure the serving path on "
+            "generated prose (scripts/sweeps/dflash2-draft-tokens-realtext.ps1)."
         ),
     }
 


### PR DESCRIPTION
Follow-up to #65 ("four draft tokens, not seven -- and the benchmark corpus cannot measure drafting"), which merged with all 3 CodePulse review comments unaddressed. Verified against current master; all 3 still present.

## What was still wrong

1. **`scripts/sweeps/dflash2-draft-tokens-realtext.ps1:22`** asserted every configuration "generates the same text," so its decode-speed comparison was implicitly of identical output — but never checked that. TODO.md already records DFlash2 and MTP producing byte-identical output *to each other* while both diverge from the width-1 greedy path within the first hundred tokens — squarely inside this sweep's `--max-new 256` window. Split the merged stdout/stderr capture (generated text is stdout, every stage/summary line including `decode_tok_s` is stderr — confirmed in `apps/cli/main.cpp`) and added a `content_sha256` column hashing each run's actual output, so the CSV lets a reader check identity instead of assuming it.

2. **`README.md:604`** still recommended `--spec dflash2 --draft-tokens 7`. `docs/cli.md` (already updated by #65) recommends 4 and shows the measurement for why. Fixed the README to match and cross-link to it.

3. **`tools/bench/make_bench_corpus.py`'s `build_manifest()`** still wrote the old, uncaveated `"Repetition fills length only and does not bias throughput."` note. The committed `bench/fixtures/bench_corpus.manifest.json` already carries a corrected, hand-edited note about speculative decoding (added elsewhere by #65) — but regenerating the corpus from the generator would silently revert the manifest to the stale claim. Updated the generator to write the same caveat, generalized rather than hardcoding the default corpus's specific numbers (682 ids, 98.4% bigrams), since this code path also runs for `--source-text` corpora.

## Testing

- PowerShell's parser (`[System.Management.Automation.Language.Parser]::ParseFile`) accepts the edited sweep script with no errors.
- Python `ast.parse` accepts the edited generator with no errors.
- Did **not** run the sweep itself — it needs a live GPU, the DFlash2 artifact, and ~25 minutes, and another agent is currently using the GPU on this box. Whoever picks this up with the GPU free should run it once and spot-check that `content_sha256` actually differs where TODO.md says it should (DFlash2/MTP vs. greedy) and matches where it says it shouldn't (DFlash2 vs. MTP, and repeats of the same config).