### PR TITLE
Fix the Windows benchmark shutdown, and root-cause the 8-lane scaling loss it unblocked

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -497,18 +497,39 @@ roofline finally acquired a denominator; read them before the rest.
       (`decode-step-profile.ps1` and the `scripts/sweeps/*.ps1` sweeps are all decode-only). Do not
       guess a replacement constant without that measurement.
 
-- [ ] **Eight lanes buy 3.2x, not 8x, and the reason is unestablished.** README's own cohort table
-      has C1 decode at 78.71 tok/s against C8 at 250.26. Batched decode amortises the weight read
-      across the whole cohort — the same bytes serve every lane in a round — so a weight-bound
-      decode should scale much closer to linearly until compute takes over. Somewhere between one
-      lane and eight, something other than weight bandwidth becomes the limit, and no document says
-      what. Worth knowing: C8 is the profile the 27B release recommends for multi-user serving.
+- [ ] **Eight lanes buy 3.6x, not 8x, and the cost is 4.7 ms per added row.** Measured 2026-09-09
+      on the 27B, int8 KV, no speculation, `--decode-tokens 512 --max-context 8192`, via
+      `tools/bench/run_serve_concurrency.py --suite decode-saturation`:
 
-      Careful with those particular numbers, though: they are end-to-end with MTP3 enabled, so
-      tokens per round is roughly `1 + 3 x acceptance` rather than 1, and dividing them into a
-      bandwidth figure gives nonsense (144% of peak at C1, doing it naively). The comparison needs
-      re-measuring without speculation before it can be reasoned about — `ninfer_bench` can do that
-      directly and the cohort table cannot.
+      | C | tok/s | vs C1 | batch | ms/round |
+      |---|---|---|---|---|
+      | 1 | 36.8 | 1.00x | 1.00 | 27.20 |
+      | 2 | 61.1 | 1.66x | 2.00 | 32.73 |
+      | 4 | 101.0 | 2.75x | 4.00 | 39.61 |
+      | 8 | 132.9 | 3.62x | 8.00 | 60.18 |
+
+      Batching itself is working: `batch` is exactly C at every point and `row_rounds = C x rounds`,
+      so one round serves the whole cohort and the 15.9 GiB weight read is amortised across it
+      exactly as intended. The scaling loss is entirely in what a round costs. Against the 20.0 ms
+      weight-bandwidth floor (15.9 GiB at the measured 854.2 GB/s), a C1 round spends 7.2 ms on
+      everything that is not the weight read — and **each additional row adds 4.7 ms, which is 65%
+      of that entire non-weight budget.** Per-row work is barely being amortised at all. If it were
+      free the round would stay at 27.20 ms and C8 would reach 294 tok/s; it reaches 45% of that.
+
+      So the open question is much narrower than "why isn't it linear": what costs 4.7 ms per row
+      in a round that reads its weights once? The cohort is shallow here (~850 tokens, int8 KV), so
+      KV traffic is far too small to explain it, and host time stayed at 0.3-0.5%. Candidates in
+      order of suspicion: the int8 decode GEMMs going from M=1 to M=8 against a tiling chosen for
+      GEMV, and per-row attention work outside the amortised path. Both are answerable with
+      `NINFER_OP_REPORT_STATS=1` at C1 and C8 and a subtraction, which is the next step.
+
+      The numbers this entry used to quote (C1 78.71 vs C8 250.26 tok/s) came from README's cohort
+      table, which is end-to-end **with MTP3 enabled** — tokens per round is roughly
+      `1 + 3 x acceptance` rather than 1, so dividing them into a bandwidth figure gives nonsense
+      (144% of peak at C1, done naively). It also claimed `ninfer_bench` could re-measure this
+      directly. It cannot: `ninfer_bench` has no concurrency option at all. The serving harness
+      above is the only path, and reaching it needed the Windows shutdown fix in #70 — the campaign
+      aborted on a throughput/`request_done` reconciliation that was correct and unmeetable.
 
 - [x] **Prefill has no roofline either.** It has one now (2026-09-09), and the naive version of it
       is a trap worth documenting.
@@ -714,17 +735,36 @@ ceiling, and neither has had any optimisation attempted.
       Closing even half the gap between the expert kernels and the contiguous ones is worth
       roughly 15-20% on the recommended model. Nothing here has been tried.
 
-- [ ] **Prefill's MLP GEMMs run at ~30% of the card's INT8 tensor-core rate.** Measured (#53 plus
-      `tools/tensor_core_rate_probe.cu`): `q4a8_swiglu` reaches 97.4 T/s and `q5a8_add` 89.4 T/s
-      against a measured 314.8 TOPS INT8 ceiling, while the BF16 GDN projections reach 51-54% of
-      the measured 67.6 TFLOPS BF16 ceiling. A well-tuned large GEMM on Ampere usually reaches
-      60-80% of a pure-MMA microbenchmark.
+- [ ] **Prefill's MLP GEMMs run at ~30% of the card's INT8 tensor-core rate**, and the obvious
+      excuse for that has been measured and ruled out.
 
-      One caveat before anyone chases it: these are 1,024-token prefill chunks against GEMM
-      dimensions of 34,816 x 5,120, which is skinny. **Sweep `--prefill-chunk` against this ceiling
-      first** — the percentage may be mostly a tile-shape artifact, and that is a cheap thing to
-      find out before touching a kernel. The MLP GEMMs are 68% of prefill FLOPs, so if the gap is
-      real it is worth more than anything in decode.
+      Measured (#53 plus `tools/tensor_core_rate_probe.cu`): `q4a8_swiglu` reaches 97.4 T/s and
+      `q5a8_add` 89.4 T/s against a measured **314.8 TOPS** INT8 ceiling, while the BF16 GDN
+      projections reach 51-54% of the measured **67.6 TFLOPS** BF16 ceiling. A well-tuned large
+      GEMM on Ampere usually reaches 60-80% of a pure-MMA microbenchmark.
+
+      **It is not a skinny-tile artifact.** The worry was that 1,024-token chunks against GEMM
+      dimensions of 34,816 x 5,120 are too narrow to fill the MMA pipeline, so the percentage would
+      improve with a bigger chunk. Swept on the 27B, int8 KV, an 8,192-token prompt, three
+      repetitions each:
+
+      | `--prefill-chunk` | prefill tok/s | vs 1,024 |
+      |---:|---:|---:|
+      | 256 | 1,139.7 | −6.9% |
+      | 512 | 1,192.1 | −2.7% |
+      | 1,024 (default) | 1,224.5 | — |
+      | 2,048 | 1,234.9 | +0.8% |
+      | 4,096 | 1,237.0 | +1.0% |
+
+      Throughput **plateaus by 2,048**, and quadrupling the chunk from the default buys 1.0%.
+      Nothing there closes a gap from 30% to 60-80%, so the shortfall is in the kernels and they
+      are the target. The MLP pair is 68% of prefill FLOPs, which makes this the largest
+      compute-side opportunity in the file.
+
+      Two small things fall out. The default chunk of 1,024 is 1.0% off the plateau, so 2,048 is
+      free throughput *if* the extra workspace is affordable — worth checking against the memory
+      model in `docs/config-calculator.html` before changing a default. And 256 costs 6.9%, which
+      is worth knowing for anyone tempted to shrink the chunk to save memory.
 
 - [ ] **DFlash2 has a cliff between five and six draft tokens**, 57.2 to 48.4 tok/s (#65), a 15%
       drop where acceptance is still rising. Seven through twelve continue to degrade. It looks

--- a/TODO.md
+++ b/TODO.md
@@ -497,9 +497,9 @@ roofline finally acquired a denominator; read them before the rest.
       (`decode-step-profile.ps1` and the `scripts/sweeps/*.ps1` sweeps are all decode-only). Do not
       guess a replacement constant without that measurement.
 
-- [ ] **Eight lanes buy 3.6x, not 8x, and the cost is 4.7 ms per added row.** Measured 2026-09-09
-      on the 27B, int8 KV, no speculation, `--decode-tokens 512 --max-context 8192`, via
-      `tools/bench/run_serve_concurrency.py --suite decode-saturation`:
+- [ ] **Eight lanes buy 3.6x, not 8x, because no kernel amortises a weight read across 2-10 rows.**
+      Measured 2026-09-09 on the 27B, int8 KV, no speculation, `--decode-tokens 512
+      --max-context 8192`, via `tools/bench/run_serve_concurrency.py --suite decode-saturation`:
 
       | C | tok/s | vs C1 | batch | ms/round |
       |---|---|---|---|---|
@@ -508,28 +508,64 @@ roofline finally acquired a denominator; read them before the rest.
       | 4 | 101.0 | 2.75x | 4.00 | 39.61 |
       | 8 | 132.9 | 3.62x | 8.00 | 60.18 |
 
-      Batching itself is working: `batch` is exactly C at every point and `row_rounds = C x rounds`,
-      so one round serves the whole cohort and the 15.9 GiB weight read is amortised across it
-      exactly as intended. The scaling loss is entirely in what a round costs. Against the 20.0 ms
-      weight-bandwidth floor (15.9 GiB at the measured 854.2 GB/s), a C1 round spends 7.2 ms on
-      everything that is not the weight read — and **each additional row adds 4.7 ms, which is 65%
-      of that entire non-weight budget.** Per-row work is barely being amortised at all. If it were
-      free the round would stay at 27.20 ms and C8 would reach 294 tok/s; it reaches 45% of that.
+      Batching itself works: `batch` is exactly C at every point and `row_rounds = C x rounds`, so
+      one round serves the whole cohort and the 15.9 GiB weight read is amortised across it as
+      intended. The loss is entirely in what a round costs. Against the 20.0 ms weight-bandwidth
+      floor (15.9 GiB at the measured 854.2 GB/s), a C1 round spends 7.2 ms on everything that is
+      not the weight read, and each added row costs 4.7 ms — 65% of that whole budget.
 
-      So the open question is much narrower than "why isn't it linear": what costs 4.7 ms per row
-      in a round that reads its weights once? The cohort is shallow here (~850 tokens, int8 KV), so
-      KV traffic is far too small to explain it, and host time stayed at 0.3-0.5%. Candidates in
-      order of suspicion: the int8 decode GEMMs going from M=1 to M=8 against a tiling chosen for
-      GEMV, and per-row attention work outside the amortised path. Both are answerable with
-      `NINFER_OP_REPORT_STATS=1` at C1 and C8 and a subtraction, which is the next step.
+      **What it is not.** nsys at node-level graph tracing over a clean 150-round steady window
+      (`profiles/conc-prof`, overhead negligible: 27.45 ms/round against 27.20 unprofiled) puts the
+      GPU 95.2% busy at C1 and 97.6% busy at C8, so launch gaps explain none of it. The cohort is
+      ~850 tokens deep on int8 KV, far too little traffic to matter, and host time stayed at
+      0.3-0.5%.
 
-      The numbers this entry used to quote (C1 78.71 vs C8 250.26 tok/s) came from README's cohort
-      table, which is end-to-end **with MTP3 enabled** — tokens per round is roughly
-      `1 + 3 x acceptance` rather than 1, so dividing them into a bandwidth figure gives nonsense
-      (144% of peak at C1, done naively). It also claimed `ninfer_bench` could re-measure this
-      directly. It cannot: `ninfer_bench` has no concurrency option at all. The serving harness
-      above is the only path, and reaching it needed the Windows shutdown fix in #70 — the campaign
-      aborted on a throughput/`request_done` reconciliation that was correct and unmeetable.
+      **What it is.** C1 and C8 run almost disjoint kernel sets. At C1, 89% of the round is GEMV
+      specialisations (`q5_rowsplit_gemv`, `q4_linear_swiglu_gemv_pair`). At C8 those drop to zero
+      instances and the round redistributes:
+
+      | kernel | C1 ms/round | C8 ms/round |
+      |---|---|---|
+      | `q4_small_t_mma` | 0.00 | 15.45 |
+      | `rowsplit_grouped_mma` | 0.00 | 13.78 |
+      | `q5_rowsplit_gemm_simt_split2` (2 variants) | 0.00 | 17.10 |
+      | `q5_rowsplit_gemv` (4 variants) | 13.61 | 0.09 |
+      | `q4_linear_swiglu_gemv_pair` | 7.59 | 0.05 |
+      | **all kernels** | **26.18** | **56.29** |
+
+      36% of the C8 round runs in SIMT kernels that use no tensor cores and had zero instances at
+      C1. That looks like a routing bug and **it is not one** — checked, so nobody re-checks it.
+      Every dominant family was swept against its own schedule bench at T=1..16 and in each case
+      the routed schedule is the fastest kernel that exists at T=8: `q5_linear_add` picks
+      `split2_exact` (74.8 us at k=6144) over `mma_r64_c16` (101.4); `q4_q5_attn_input` picks
+      `parent_split_fixed` (169.0) over `grouped_r32_c32_s4` (202.8); `q4_swiglu` picks
+      `small_t_tiled`. The `{{2, 10}, Split2ExactResidual}` band in
+      `src/ops/linear_add/q5/q5_linear_add_plan.cpp` carries no measured comment while
+      every band from 11 upward does, but it turns out to be right anyway.
+
+      The gap is kernel coverage, not dispatch. In the T=2..10 band the choice is between two bad
+      shapes, and the crossover at 11 is simply where they cross:
+
+      - `split2_exact` **grows with T** — 41.0 / 56.3 / 74.8 / 93.2 us at T=4/6/8/10 (k=6144),
+        about +8.7 us per row. It barely amortises the weight read at all.
+      - `mma_r64_c16` is **flat** — 101.4 us from T=4 all the way to T=16 — but flat at 4x the
+        25.3 us that weight (21.6 MB at 854.2 GB/s) should cost to stream once. The T=1 GEMV
+        reaches 41.0 us, or 62% of that floor.
+
+      So the prize is a narrow-extent MMA kernel that keeps `mma_r64_c16`'s flatness at the GEMV's
+      fraction of bandwidth. Perfect amortisation would hold the C8 round at C1's 26.18 ms and give
+      305 tok/s instead of 132.9; the realistic share of that is whatever closes the 4x. Worth it:
+      C8 is the profile the 27B release recommends for multi-user serving, and all three dominant
+      families sit at 1.9-2.5x their T=1 cost for 8x the rows.
+
+      Two notes on how this entry used to read. The numbers it quoted (C1 78.71 vs C8 250.26 tok/s)
+      came from README's cohort table, which is end-to-end **with MTP3 enabled** — tokens per round
+      is roughly `1 + 3 x acceptance` rather than 1, so dividing them into a bandwidth figure gives
+      nonsense (144% of peak at C1, done naively). And it named two tools that cannot do this:
+      `ninfer_bench` has no concurrency option at all, and `NINFER_OP_REPORT_STATS` is the Op-test
+      *accuracy* reporter, not a timing one. The serving harness plus nsys is the path, and reaching
+      it needed the Windows shutdown fix in #70 — the campaign aborted on a throughput/`request_done`
+      reconciliation that was correct and unmeetable.
 
 - [x] **Prefill has no roofline either.** It has one now (2026-09-09), and the naive version of it
       is a trap worth documenting.

--- a/apps/serve/main.cpp
+++ b/apps/serve/main.cpp
@@ -87,6 +87,13 @@ int main(int argc, char** argv) {
         g_server.store(&server);
         std::signal(SIGINT, handle_signal);
         std::signal(SIGTERM, handle_signal);
+#ifdef SIGBREAK
+        // Windows has no way to deliver SIGTERM to another process: TerminateProcess kills it
+        // outright and the shutdown path -- which flushes the final partial throughput interval --
+        // never runs. GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT) is the one graceful stop a parent
+        // can request, and the CRT raises it as SIGBREAK.
+        std::signal(SIGBREAK, handle_signal);
+#endif
 
         serving = true;
         operational_log.server_ready(options.host, options.port, server.public_model_id(),

--- a/src/ops/linear_add/q5/q5_linear_add_plan.cpp
+++ b/src/ops/linear_add/q5/q5_linear_add_plan.cpp
@@ -36,6 +36,20 @@ constexpr std::array<SupportSpec, 2> kSupports{{
     {5120, 17408, 17408},
 }};
 
+// The 2..10 band is measured too (2026-09-09, same bench, --tokens 1,2,4,6,8,10,12,16, medians of
+// 15): SIMT split2 wins it outright, and the boundary at 10/11 is where the two curves actually
+// cross. k=6144, T=8: split2 74.8 vs c16 101.4. T=10: 93.2 vs 101.4, still split2 but only just,
+// and split2's +8.7 us per row puts T=11 at ~102 -- level with c16, which is flat. Same story at
+// k=17408 (T=8: 200.7 vs 282.6). split2 is registered only to 10, so 11 upward is not a measured
+// flip; it is the domain edge landing exactly where the extrapolation says it should.
+//
+// Be clear about what that does and does not say, because a serving cohort of 8 lands here. It is
+// the right choice between the kernels that exist, not a good one. split2 grows ~8.7 us per row
+// (k=6144: 41.0/56.3/74.8/93.2 at T=4/6/8/10) so it barely amortises the weight read, while c16 is
+// flat from T=4 to T=16 but flat at 4x the 25.3 us this weight costs to stream once at 854 GB/s.
+// The T=1 GEMV reaches 41.0 us, 62% of that floor. A narrow-extent kernel with c16's flatness at
+// the GEMV's efficiency is worth most of the C1-to-C8 scaling loss; see TODO section 2c.
+//
 // A tile narrower than the live extent repeats the whole weight pass per column slice, so
 // above 16 columns the 32-wide tile covers a decode round in one pass instead of two.
 // Measured on sm_86 with bench/ops/q5_linear_add_schedule_bench.cu, cold, medians of 9-15.

--- a/tools/bench/run_serve_corpus.py
+++ b/tools/bench/run_serve_corpus.py
@@ -10,6 +10,7 @@ import http.client
 import json
 import math
 import os
+import signal
 import statistics
 import subprocess
 import sys
@@ -201,7 +202,13 @@ class RunningServer:
 
     def __enter__(self) -> "RunningServer":
         initial_offset = self.log_path.stat().st_size if self.log_path.exists() else 0
-        self.process = subprocess.Popen(self.command, cwd=REPO_ROOT)
+        # A new process group on Windows is what makes GenerateConsoleCtrlEvent addressable, so
+        # stop() can ask for a graceful shutdown instead of killing the server. It also detaches
+        # the child from our own Ctrl+C, which is why stop() must always be reached.
+        creation_flags = (
+            subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0
+        )
+        self.process = subprocess.Popen(self.command, cwd=REPO_ROOT, creationflags=creation_flags)
         self.tail = ServerLogTail(self.log_path, self.process, initial_offset)
         return self
 
@@ -211,7 +218,17 @@ class RunningServer:
     def stop(self) -> None:
         if self.process is None or self.process.poll() is not None:
             return
-        self.process.terminate()
+        # The server flushes its final partial throughput interval only on the signal path, and the
+        # campaign reconciles those intervals against request_done. Popen.terminate() is SIGTERM on
+        # POSIX but TerminateProcess on Windows, which delivers nothing -- so ask for CTRL_BREAK
+        # there and fall back to the kill only if the server ignores it.
+        if sys.platform == "win32":
+            try:
+                self.process.send_signal(signal.CTRL_BREAK_EVENT)
+            except (OSError, ValueError):
+                self.process.terminate()
+        else:
+            self.process.terminate()
         try:
             self.process.wait(timeout=15.0)
         except subprocess.TimeoutExpired:


### PR DESCRIPTION
Three commits: a harness fix, the measurement it made possible, and the root cause that measurement led to.

## The fix

The concurrency and corpus campaigns reconcile the server's periodic throughput intervals against `request_done`, and the last interval always ends mid-request — the 27B C=1 point emitted 6 of its 512 tokens in the 128 ms after the final sample. The server already handles that: `run_stats_reporter` flushes the exact partial interval to the request log on its shutdown path.

That path is only reachable by signal. `Popen.terminate()` is `SIGTERM` on POSIX but `TerminateProcess` on Windows, which delivers nothing, so the reporter thread is never joined and the tail record is never written. Every campaign on this box died on `throughput and request_done decode token totals differ` before recording a point — a check that was correct and unmeetable.

This asks for `CTRL_BREAK_EVENT` instead (the one graceful stop a Windows parent can address to a specific child, which needs `CREATE_NEW_PROCESS_GROUP` at spawn) and handles the `SIGBREAK` the CRT raises from it. The kill remains as the 15-second fallback. Verified: the run now logs `server stopped` and reconciles to the token — 15 intervals summing to 511, against 512 output tokens less the one prefill produces. Before: 14 intervals, 506.

## What it measured

27B, int8 KV, **no speculation**, 512 decode tokens, 8K context:

| C | tok/s | vs C1 | batch | ms/round |
|---|---|---|---|---|
| 1 | 36.8 | 1.00x | 1.00 | 27.20 |
| 2 | 61.1 | 1.66x | 2.00 | 32.73 |
| 4 | 101.0 | 2.75x | 4.00 | 39.61 |
| 8 | 132.9 | 3.62x | 8.00 | 60.18 |

Batching works — `batch` is exactly C and `row_rounds = C × rounds`, so the 15.9 GiB weight read really is amortised across the cohort. The loss is all in round cost: against the 20.0 ms weight-bandwidth floor, a C1 round has 7.2 ms of non-weight work and **each added row costs 4.7 ms**, 65% of that budget.

## Why

**Not launch gaps.** nsys with node-level graph tracing over a clean 150-round steady window puts the GPU 95.2% busy at C1 and 97.6% at C8, at negligible overhead (27.45 ms/round vs 27.20 unprofiled). Not KV depth (~850 tokens, int8), not the host (0.3–0.5%).

**C1 and C8 run almost disjoint kernel sets.** 89% of a C1 round is GEMV specialisations; at C8 those fall to zero instances and 36% of the round lands in SIMT kernels that use no tensor cores.

| kernel | C1 ms/round | C8 ms/round |
|---|---|---|
| `q4_small_t_mma` | 0.00 | 15.45 |
| `rowsplit_grouped_mma` | 0.00 | 13.78 |
| `q5_rowsplit_gemm_simt_split2` | 0.00 | 17.10 |
| `q5_rowsplit_gemv` | 13.61 | 0.09 |
| `q4_linear_swiglu_gemv_pair` | 7.59 | 0.05 |
| **all** | **26.18** | **56.29** |

That reads as a mis-tuned route table. **It isn't** — swept all three dominant families against their own schedule benches at T=1..16, and in every case the routed schedule is the fastest kernel that exists at T=8 (`q5_linear_add` picks `split2_exact` at 74.8 µs over `mma_r64_c16` at 101.4; `attn_input` picks `parent_split_fixed` at 169.0 over `grouped_r32_c32_s4` at 202.8). Recorded as a negative result so nobody re-checks it.

What remains is **kernel coverage in the T=2..10 band**, where both available shapes are bad: `split2` grows ~8.7 µs per row and barely amortises the weight read, while `c16` is flat from T=4 to T=16 but flat at 4× the 25.3 µs that weight costs to stream once. The T=1 GEMV reaches 62% of that floor. A narrow-extent kernel with `c16`'s flatness at the GEMV's efficiency is the prize, and C8 is the profile the 27B release recommends for multi-user serving.

The `{{2, 10}}` route band also gets the measured comment it never had — every band from 11 upward carried one — including why the 10/11 boundary is where the curves genuinely cross rather than just where `split2`'s domain ends.

Fixes two tools the entry named that cannot do this: `ninfer_bench` has no concurrency option, and `NINFER_OP_REPORT_STATS` is the Op-test *accuracy* reporter, not a timing one.

Also records the prefill-chunk sweep on the MLP GEMM entry: 256 → 4,096 moves prefill only 1,139.7 → 1,237.0 tok/s, so the ~30% of INT8 peak is **not** the tile-shape artifact that entry warned it might be.