### PR TITLE
Route q4 SwiGLU {513,640} to c128, and surface the spread that blocked the decision

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -819,6 +819,28 @@ ceiling, and neither has had any optimisation attempted.
 
 ## 3. Measurement debt
 
+- [ ] **Every route boundary in the repository was decided on cold-flush margins, which overstate
+      the win.** `bench/ops/schedule_sweep.cuh` and its siblings call `measure_cold_launch`, which
+      flushes 256 MiB through L2 before every repetition. That is the right default — these
+      projections stream tens of MB against 6 MB of L2 and production is usually cold — but it is
+      not the same as in situ, and the gap is not small. Measured on the q4 SwiGLU `{513,640}`
+      decision (§5): the bench put c128 7.5% ahead of Materialized at T=576, while an nsys profile
+      of the same schedules inside a real 600-token chunk put it 2.4% ahead, with **both** schedules
+      slower per call in situ than in the bench (c128 4193 vs 3625 µs, Materialized 4295 vs 3927).
+      The flush penalises Materialized's second weight pass more than a real prefill does.
+
+      The sign was right in that case, and no boundary is known to be wrong. But every route
+      comment in `src/ops/*/`*`_plan.cpp` quotes cold-flush microseconds, several of them at
+      margins under 5%, and those margins are not speedups. Worth doing: take the boundaries whose
+      measured margin is under ~5% — the `{2,10}`/`{11,16}` q5 crossover at T=10 (93.2 vs 101.4,
+      8%) and the q4 SwiGLU `{2,24}`/`{25,40}` crossover at T=25 (464.9 vs 436.2, 6%) are the
+      obvious two — and check each in situ with a profile rather than the bench. The method is in
+      §5's entry; it is one nsys run per boundary.
+
+      Do not "fix" the flush. Cold is the honest default for a first pass and warm numbers pick
+      different winners, which is documented at the top of `schedule_sweep.cuh`. The point is that
+      a narrow cold-flush margin is a reason to profile, not a decision.
+
 - [ ] **The 315 W power cap has never been measured, and it bounds every number in this file.**
       `nvidia-smi` reports the limit at 315 W against a 350 W default (400 W maximum) and throttle
       reason `SwPowerCap` continuously through every sweep; the SM clock swings 1,665-1,755 MHz
@@ -887,12 +909,46 @@ ceiling, and neither has had any optimisation attempted.
       columns in one pass where plain decode evaluates one, so reductions run in a different order
       and a near-tie argmax flips. MTP reproduces it exactly, so it predates the merge — but nobody
       has decided whether that is acceptable or worth pinning down.
-- [ ] **q4 SwiGLU `{513,640}` is still on `Materialized`, unmeasured either way.** The one band
-      where Materialized and the c128 tile could not be separated: Materialized won T=576 in three
-      of four runs, but c128 there ranged 4147–4959 µs (**19.6% spread**) and the margins outside
-      the single outlying run were ±2%. Changing it would be fitting noise. Re-measure if the noise
-      floor on this Op improves — it is markedly noisier than the other route tables, which is
-      itself worth understanding.
+- [x] **q4 SwiGLU `{513,640}` settled: it goes to c128, and the alternation is gone.** The band
+      stayed on `Materialized` because the measurement could not separate the two — over four runs
+      Materialized won T=576 three times, while c128 there ranged 4147–4959 µs (19.6% spread) and
+      the margins outside the outlying run were ±2%.
+
+      The blocker was the instrument, not the card. `ColdTiming` had carried `min_us` and `p95_us`
+      all along and the sweep harness threw both away, printing only the median, so the spread that
+      made the decision impossible was never visible in the table. Added `--spread` to
+      `bench/ops/schedule_sweep.cuh` and to the q4 SwiGLU bench (which has its own arg loop), then
+      re-measured at 31–51 repetitions on an idle card. c128 wins all three widths in four
+      independent runs — 1.3–2.5% at 513, 1.2–7.5% at 576, 7.3–11.2% at 640 — and its *fastest*
+      sample beats Materialized's fastest everywhere, by 7–9% at 640 with no overlap at all. Sign
+      consistent 12 times out of 12. `{49,512}`, `{513,640}` and `{641,∞}` collapse into one
+      `{49,∞}` c128 route and the table drops from seven entries to five.
+
+      **Two things worth more than the route change itself.**
+
+      *The bench overstates margins.* Confirmed in situ with nsys on a single 600-token chunk:
+      Materialized costs 269.73 ms in `q4_rowsplit_gemm_mma` plus 5.16 ms in
+      `silu_and_mul_dim0_split` across 64 layers = 274.89 ms, against 268.32 ms for the c128 pair
+      kernel. c128 still wins, but by **2.4%, not 7.5%** — and both are slower per call in situ
+      than in the bench (4193 vs 3625 µs for c128; 4295 vs 3927 for Materialized). The bench
+      flushes L2 before every repetition and a real prefill does not arrive with a cold cache, so
+      the flush penalises Materialized's second pass more than production does. **This applies to
+      every band in every one of these route tables**, all of which were decided on cold-flush
+      numbers alone. Nothing is known to be mis-routed because of it — the sign was right here —
+      but no margin in those comments should be quoted as a speedup.
+
+      *End-to-end it is invisible, and that is expected.* `pp600` measured 886.0–888.8 tok/s with
+      c128 against 888.5–892.1 on Materialized: inside the run-to-run spread, because 6.6 ms of a
+      ~660 ms prefill sits under the ±3% that unrelated kernels move between runs.
+
+      One trap on the way: `--prefill-chunk 640` looks like the obvious way to exercise this band
+      and does not touch it. `q4a8_swiglu` claims any width with `tokens >= 128 && tokens % 128 ==
+      0`, and `--prefill-chunk` is required to be a multiple of 128, so **every full prefill chunk
+      goes to the integer-activation kernel and never reaches this table at all.** The `{49,∞}`
+      route is reached only by decode widths and by a prompt's ragged tail chunk. That is why
+      `{513,640}` was simultaneously close and inconsequential for so long. The first end-to-end
+      comparison here was run at chunk 640 and measured nothing, twice, before the profile showed
+      `q4a8_swiglu_kernel` where `q4_linear_swiglu` was assumed to be.
 
 ---
 

--- a/bench/ops/q4_linear_swiglu_schedule_bench.cu
+++ b/bench/ops/q4_linear_swiglu_schedule_bench.cu
@@ -67,8 +67,12 @@ constexpr std::size_t kFlushBytes  = 256ULL << 20;
 
 int main(int argc, char** argv) {
     std::vector<std::int32_t> tokens;
-    int repeat = 9;
-    int warmup = 3;
+    int repeat  = 9;
+    int warmup  = 3;
+    // A route boundary is only decidable if the margin between two schedules clears their own
+    // spread. This Op is the noisiest of the route tables and the {513,640} band went unresolved
+    // because of it, so print min..p95 beside the median when asked.
+    bool spread = false;
     for (int i = 1; i < argc; ++i) {
         const std::string_view arg(argv[i]);
         if (arg == "--tokens" && i + 1 < argc) {
@@ -85,8 +89,10 @@ int main(int argc, char** argv) {
             repeat = std::atoi(argv[++i]);
         } else if (arg == "--warmup" && i + 1 < argc) {
             warmup = std::atoi(argv[++i]);
+        } else if (arg == "--spread") {
+            spread = true;
         } else {
-            std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N]\n", argv[0]);
+            std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n", argv[0]);
             return 2;
         }
     }
@@ -111,12 +117,14 @@ int main(int argc, char** argv) {
                                                                            max_tokens);
     ninfer::WorkspaceArena workspace(std::max<std::size_t>(workspace_bytes, 1));
 
+    const int width = spread ? 30 : 22;
     cudaDeviceProp properties{};
     cudaGetDeviceProperties(&properties, 0);
-    std::printf("# gpu=%s sm=%d%d  q4 swiglu schedules, cold, median of %d\n", properties.name,
-                properties.major, properties.minor, repeat);
+    std::printf("# gpu=%s sm=%d%d  q4 swiglu schedules, cold, %s of %d\n", properties.name,
+                properties.major, properties.minor, spread ? "median min..p95" : "median",
+                repeat);
     std::printf("%6s", "T");
-    for (const Schedule& schedule : kSchedules) { std::printf(" %22s", schedule.name); }
+    for (const Schedule& schedule : kSchedules) { std::printf(" %*s", width, schedule.name); }
     std::printf("   %-22s\n", "winner");
 
     for (const std::int32_t token_count : tokens) {
@@ -128,23 +136,30 @@ int main(int argc, char** argv) {
         for (int s = 0; s < kScheduleCount; ++s) {
             const Schedule& schedule = kSchedules[s];
             if (schedule.max_cols != 0 && token_count > schedule.max_cols) {
-                std::printf(" %22s", "out-of-domain");
+                std::printf(" %*s", width, "out-of-domain");
                 continue;
             }
             const auto invoke = [&](cudaStream_t launch_stream) {
                 ninfer::ops::detail::q4_linear_swiglu_execute_schedule(
                     schedule.id, x, packed.weight, out, workspace, launch_stream);
             };
-            double us = 0.0;
+            ninfer::bench::ColdTiming timing{};
             try {
-                us = ninfer::bench::measure_cold_launch(invoke, flush, stream, warmup, repeat)
-                         .median_us;
+                timing = ninfer::bench::measure_cold_launch(invoke, flush, stream, warmup, repeat);
             } catch (const std::exception&) {
                 cudaGetLastError();
-                std::printf(" %22s", "n/a");
+                std::printf(" %*s", width, "n/a");
                 continue;
             }
-            std::printf(" %22.3f", us);
+            const double us = timing.median_us;
+            if (spread) {
+                char cell[64];
+                std::snprintf(cell, sizeof(cell), "%.1f %.1f..%.1f", us, timing.min_us,
+                              timing.p95_us);
+                std::printf(" %*s", width, cell);
+            } else {
+                std::printf(" %*.3f", width, us);
+            }
             if (best_us == 0.0 || us < best_us) {
                 best_us   = us;
                 best_name = schedule.name;

--- a/bench/ops/q4_q5_attn_input_schedule_bench.cu
+++ b/bench/ops/q4_q5_attn_input_schedule_bench.cu
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
         } else if (arg == "--warmup" && i + 1 < argc) {
             warmup = std::atoi(argv[++i]);
         } else {
-            std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N]\n", argv[0]);
+            std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n", argv[0]);
             return 2;
         }
     }

--- a/bench/ops/q5_linear_add_schedule_bench.cu
+++ b/bench/ops/q5_linear_add_schedule_bench.cu
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
     ninfer::bench::SweepOptions options;
     options.tokens = {1, 8, 16, 24, 32, 40, 48, 56, 64, 96, 128, 160, 176, 192, 208, 256};
     if (!ninfer::bench::parse_sweep_args(argc, argv, options)) {
-        std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N]\n", argv[0]);
+        std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n", argv[0]);
         return 2;
     }
     sweep_for_k(6144, options);

--- a/bench/ops/schedule_sweep.cuh
+++ b/bench/ops/schedule_sweep.cuh
@@ -58,14 +58,19 @@ struct SweepOptions {
     int warmup                = 3;
     std::size_t flush_bytes   = 256ULL << 20;
     const char* title         = "schedules";
+    // Print "median min..p95" per cell instead of the median alone. A route decision is only
+    // meaningful if the margin between two schedules clears their own spread, and the median by
+    // itself cannot tell you that -- TODO section 5 has a band that stayed unresolved for exactly
+    // this reason, where the losing schedule's own samples ranged 19.6%.
+    bool spread               = false;
     // Optional: what the Op's own resolver picks at this width, and the public Op itself. Supply
     // both or neither.
     std::function<const char*(std::int32_t)> routed_name;
     std::function<void(std::int32_t, cudaStream_t)> public_op;
 };
 
-// Parses "--tokens A,B,C", "--repeat N", "--warmup N". Returns false on an unrecognised argument
-// so the caller can print its own usage.
+// Parses "--tokens A,B,C", "--repeat N", "--warmup N", "--spread". Returns false on an
+// unrecognised argument so the caller can print its own usage.
 inline bool parse_sweep_args(int argc, char** argv, SweepOptions& options) {
     for (int i = 1; i < argc; ++i) {
         const std::string_view arg(argv[i]);
@@ -84,6 +89,8 @@ inline bool parse_sweep_args(int argc, char** argv, SweepOptions& options) {
             options.repeat = std::atoi(argv[++i]);
         } else if (arg == "--warmup" && i + 1 < argc) {
             options.warmup = std::atoi(argv[++i]);
+        } else if (arg == "--spread") {
+            options.spread = true;
         } else {
             return false;
         }
@@ -95,12 +102,14 @@ inline void run_sweep(const SweepOptions& options, const std::vector<SweepEntry>
     DeviceBuffer flush(options.flush_bytes);
     cudaStream_t stream = nullptr;
 
+    const int width = options.spread ? 30 : 22;
     cudaDeviceProp properties{};
     cudaGetDeviceProperties(&properties, 0);
-    std::printf("# gpu=%s sm=%d%d  %s, cold, median of %d\n", properties.name, properties.major,
-                properties.minor, options.title, options.repeat);
+    std::printf("# gpu=%s sm=%d%d  %s, cold, %s of %d\n", properties.name, properties.major,
+                properties.minor, options.title,
+                options.spread ? "median min..p95" : "median", options.repeat);
     std::printf("%6s", "T");
-    for (const SweepEntry& entry : schedules) { std::printf(" %22s", entry.name); }
+    for (const SweepEntry& entry : schedules) { std::printf(" %*s", width, entry.name); }
     if (options.public_op) { std::printf(" %12s %-34s", "public_op", "routed_to"); }
     std::printf("   %-22s\n", "winner");
 
@@ -110,22 +119,30 @@ inline void run_sweep(const SweepOptions& options, const std::vector<SweepEntry>
         std::printf("%6d", tokens);
         for (const SweepEntry& entry : schedules) {
             if (entry.max_cols != 0 && tokens > entry.max_cols) {
-                std::printf(" %22s", "out-of-domain");
+                std::printf(" %*s", width, "out-of-domain");
                 continue;
             }
             const auto launch = [&](cudaStream_t launch_stream) {
                 entry.invoke(tokens, launch_stream);
             };
-            double us = 0.0;
+            ColdTiming timing{};
             try {
-                us = measure_cold_launch(launch, flush, stream, options.warmup, options.repeat)
-                         .median_us;
+                timing = measure_cold_launch(launch, flush, stream, options.warmup,
+                                             options.repeat);
             } catch (const std::exception&) {
                 cudaGetLastError();
-                std::printf(" %22s", "n/a");
+                std::printf(" %*s", width, "n/a");
                 continue;
             }
-            std::printf(" %22.3f", us);
+            const double us = timing.median_us;
+            if (options.spread) {
+                char cell[64];
+                std::snprintf(cell, sizeof(cell), "%.1f %.1f..%.1f", us, timing.min_us,
+                              timing.p95_us);
+                std::printf(" %*s", width, cell);
+            } else {
+                std::printf(" %*.3f", width, us);
+            }
             if (best_us == 0.0 || us < best_us) {
                 best_us   = us;
                 best_name = entry.name;

--- a/bench/ops/w8_dflash2_schedule_bench.cu
+++ b/bench/ops/w8_dflash2_schedule_bench.cu
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
     ninfer::bench::SweepOptions options;
     options.tokens = {1, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 96, 112, 128, 160, 192, 256, 384};
     if (!ninfer::bench::parse_sweep_args(argc, argv, options)) {
-        std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N]\n", argv[0]);
+        std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n", argv[0]);
         return 2;
     }
     sweep_attn_input(options);

--- a/bench/ops/w8_pair_schedule_bench.cu
+++ b/bench/ops/w8_pair_schedule_bench.cu
@@ -202,7 +202,7 @@ int main(int argc, char** argv) {
                                           86, 96,  112, 128, 160, 192, 256, 384, 512, 768, 960, 961,
                                           1024};
     if (!ninfer::bench::parse_sweep_args(argc, argv, options)) {
-        std::fprintf(stderr, "usage: %s [--k2048] [--tokens T,...] [--repeat N] [--warmup N]\n",
+        std::fprintf(stderr, "usage: %s [--k2048] [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n",
                      argv[0]);
         return 2;
     }

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
@@ -31,7 +31,7 @@ struct RouteSpec {
 
 constexpr Q4LinearSwiGluProblem kShape{34816, 17408, 5120, 5120, 1};
 
-constexpr std::array<RouteSpec, 7> kRoutes{{
+constexpr std::array<RouteSpec, 5> kRoutes{{
     {{1, 1}, Q4LinearSwiGluScheduleId::GemvPair},
     // Measured on sm_86 with bench/ops/q4_linear_swiglu_schedule_bench.cu (cold, median of 11):
     // SmallTTiled and the 40-wide pair tile cross between 24 and 25, us --
@@ -58,17 +58,47 @@ constexpr std::array<RouteSpec, 7> kRoutes{{
     //   mat       856    855    890    864   3004   2724   2398
     //   c128 by  5.1%   3.9%   4.7%   6.4%  23.1%  15.2%   8.7%
     //
-    // So {49,128} and {257,384} join the c128 bands on either side, and 49..512 becomes one route
-    // instead of four.
+    // So {49,128} and {257,384} join the c128 bands on either side.
     //
-    // {513,640} is deliberately left on Materialized. It is the one band where the two are close,
-    // and the measurement cannot separate them: over four runs Materialized won 576 three times,
-    // but c128 at that width ranged 4147-4959 us (19.6% spread) and the margins outside the single
-    // outlying run were +-2%. Changing it would be fitting noise. Re-measure it if the noise floor
-    // on this Op ever improves.
-    {{49, 512}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
-    {{513, 640}, Q4LinearSwiGluScheduleId::Materialized},
-    {{641, kAnyCols}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
+    // {513,640} used to stay on Materialized because the measurement could not separate them:
+    // over four runs Materialized won 576 three times, but c128 there ranged 4147-4959 us (19.6%
+    // spread) and the margins outside the single outlying run were +-2%. Re-measured 2026-09-09
+    // with --spread (which did not exist then, so the spread that blocked the decision was never
+    // visible) at 31-51 repetitions per point on an idle card. c128 won all three widths in four
+    // independent runs; us, range of the per-run medians:
+    //
+    //   T            513          576          640
+    //   c128     3788-3906    3876-3933    3611-3641
+    //   mat      3863-3956    3950-4216    3895-4077
+    //   c128 by  1.3-2.5%     1.2-7.5%     7.3-11.2%
+    //
+    // The min settles it: c128's fastest sample beats Materialized's fastest at every width in
+    // every run, by 7-9% at 640 with no overlap (3524-3581 against 3862-3867). Sign is consistent
+    // 12 times out of 12.
+    //
+    // **This bench overstates the margin, so do not quote it as a speedup.** Confirmed in situ by
+    // profiling a single 600-token chunk (nsys, node-level graph trace, 64 layers): Materialized
+    // costs 269.73 ms in q4_rowsplit_gemm_mma plus 5.16 ms in silu_and_mul_dim0_split = 274.89 ms,
+    // against 268.32 ms for the c128 pair kernel. c128 still wins, but by 2.4%, not 7.5% -- and
+    // both are slower per call in situ than in the bench (4193 vs 3625 us for c128, 4295 vs 3927
+    // for Materialized). The bench flushes L2 before every repetition; a real prefill does not
+    // arrive with a cold cache, and the flush penalises Materialized's second pass more than
+    // production does. The same caveat applies to every band in this table.
+    //
+    // End-to-end the win is invisible: pp600 measured 886.0-888.8 tok/s with c128 against
+    // 888.5-892.1 on Materialized, i.e. inside the run-to-run spread, because 6.6 ms of a ~660 ms
+    // prefill is under the +-3% that unrelated kernels move between runs. Keep the change for
+    // consistency and because it is right, not for a number.
+    //
+    // Reachability, so nobody over-values this band: q4a8_swiglu takes any width with
+    // `tokens >= 128 && tokens % 128 == 0`, and --prefill-chunk must be a multiple of 128, so
+    // every full prefill chunk goes to the integer-activation kernel and never reaches this table.
+    // The 49..end route is reached only by decode widths and by a prompt's ragged tail chunk. That
+    // is why {513,640} was both close and inconsequential for so long.
+    //
+    // With this the alternation is gone completely and 49..end is one route. That was the
+    // suspicious thing about upstream's table to begin with.
+    {{49, kAnyCols}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
 }};
 
 constexpr bool catalog_is_closed() noexcept {


### PR DESCRIPTION
Closes TODO §5's last open route-table band, and adds the instrument that was missing.

## Why it was stuck

`{513,640}` sat on `Materialized` because the measurement could not separate the two: over four runs Materialized won T=576 three times, but c128 there ranged 4147–4959 µs (19.6% spread) and the margins outside the outlying run were ±2%. The comment said to re-measure if the noise floor improved.

The blocker was the instrument, not the card. `ColdTiming` has carried `min_us` and `p95_us` all along and `schedule_sweep.cuh` threw both away, printing the median alone — so the spread that made the decision impossible was never visible in the table. This adds `--spread` to the shared harness and to the q4 SwiGLU bench (which has its own arg loop), plus the five usage strings.

## The decision

31–51 repetitions per point on an idle card. c128 wins all three widths in four independent runs; µs, range of the per-run medians:

| T | 513 | 576 | 640 |
|---|---|---|---|
| c128 | 3788–3906 | 3876–3933 | 3611–3641 |
| materialized | 3863–3956 | 3950–4216 | 3895–4077 |
| c128 by | 1.3–2.5% | 1.2–7.5% | 7.3–11.2% |

The min settles it: c128's fastest sample beats Materialized's fastest at every width in every run, by 7–9% at 640 with **no overlap** (3524–3581 against 3862–3867). Sign consistent 12/12.

`{49,512}`, `{513,640}` and `{641,∞}` collapse into one `{49,∞}` route. Seven entries become five, and the alternating shape this fork already called implausible in upstream's table is gone entirely.

## Two things that matter more than the route change

**The bench overstates margins.** Profiled in situ with nsys on a single 600-token chunk (64 layers): Materialized costs 269.73 ms in `q4_rowsplit_gemm_mma` plus 5.16 ms in `silu_and_mul_dim0_split` = **274.89 ms**, against **268.32 ms** for the c128 pair kernel. c128 still wins, but by **2.4%, not 7.5%** — and both are slower per call in situ than in the bench (c128 4193 vs 3625 µs; Materialized 4295 vs 3927). The 256 MiB L2 flush penalises Materialized's second weight pass more than a real prefill does.

Every band in every one of these route tables was decided on cold-flush numbers, several at margins under 5%. The sign was right here and nothing is known to be mis-routed, but those margins are not speedups — TODO §3 gets an item to check the narrow ones in situ.

**The band is barely reachable.** `q4a8_swiglu` claims any width with `tokens >= 128 && tokens % 128 == 0`, and `--prefill-chunk` must be a multiple of 128 — so every full prefill chunk goes to the integer-activation kernel and never reaches this table. Only decode widths and a prompt's ragged tail chunk do. `--prefill-chunk 640` looks like the obvious way to exercise the band and touches none of it; that cost two null end-to-end measurements before the profile showed `q4a8_swiglu_kernel` where `q4_linear_swiglu` was assumed.

End-to-end `pp600` is 886.0–888.8 tok/s with c128 against 888.5–892.1 on Materialized — inside the run-to-run spread, because 6.6 ms of a ~660 ms prefill sits under the ±3% unrelated kernels move. Recorded as such rather than dressed up. The change is kept because it is right, not for a number.

Engine runtime reservation is unchanged at 982.1 MiB either way, and `work peak` at 152.6 MiB, so removing the only workspace-consuming route frees nothing measurable — also checked rather than assumed.

## Tests

The three q4 SwiGLU correctness suites pass, including the a16 sweep that covers 513/640/641 deliberately.