### PR TITLE
Measure the 315 W power cap: it binds continuously, and never touches memory clock

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -841,18 +841,51 @@ ceiling, and neither has had any optimisation attempted.
       different winners, which is documented at the top of `schedule_sweep.cuh`. The point is that
       a narrow cold-flush margin is a reason to profile, not a decision.
 
-- [ ] **The 315 W power cap has never been measured, and it bounds every number in this file.**
-      `nvidia-smi` reports the limit at 315 W against a 350 W default (400 W maximum) and throttle
-      reason `SwPowerCap` continuously through every sweep; the SM clock swings 1,665-1,755 MHz
-      with temperature while memory holds at 9,501 MHz. It looks deliberate, so it has been left
-      alone — and changing it needs an elevated shell, which this session did not have.
+- [ ] **The 315 W power cap binds continuously, but it does not touch memory clock — so most of
+      this file is unaffected.** Measured 2026-09-09 with `scripts/sweeps/power-and-clocks.ps1`,
+      which samples `nvidia-smi` at 2 Hz through a 27B `tg1024` decode and a `pp8192` prefill,
+      int8 KV. Three runs, medians and full ranges over busy samples (utilization > 50%):
 
-      Two separate questions, both open. **What does the cap cost?** Decode is memory-bound and the
-      memory clock is not throttling, so it may be little — but `nvidia-smi -pl 350` and a re-run
-      of `kv-decode-vs-depth.ps1` would say, and 10% of TDP is worth knowing about on a project
-      whose goal is riding the bandwidth ceiling. **Should measurement runs lock clocks?**
-      `nvidia-smi -lgc <clock>` would collapse the 3-5% between-process spread that made the 27B
-      unreadable this cycle. Both need someone at an elevated prompt.
+      | | decode (162-168 samples) | prefill (52-53 samples) |
+      |---|---|---|
+      | board power | 314 W median | 314 W median |
+      | `sw_power_cap` active | **161-168 of 162-168** | **51-52 of 52-53** |
+      | SM clock | **1,500-1,515 MHz** median | **1,635-1,650 MHz** median |
+      | memory clock | **9,501 MHz in every sample** | **9,501 MHz in every sample** |
+      | temperature | 63-74 °C median, 75 max | 68-76 °C median, 77 max |
+      | thermal throttle | **0 samples, all runs** | **0 samples, all runs** |
+
+      The cap is genuinely and permanently binding — power pins within 1 W of the limit whenever
+      the card is busy — and it is the *only* thing throttling. No thermal slowdown appears in any
+      sample of any run, at any temperature reached.
+
+      What it costs is a narrower question than this entry assumed. **Memory never leaves 9,501 MHz
+      in either phase, in any run**, which is the full 19 Gbps spec, so every bandwidth number in
+      this file — the 854.2 GB/s achievable figure, the decode roofline, the whole of §2c's decode
+      analysis — is measured at unthrottled memory and the cap does not bound it. SM clock is what
+      pays: decode sits about 11% below the 3090's 1,695 MHz rated boost, prefill about 3%. Decode
+      is bandwidth-bound so 11% of SM clock buys little there, and prefill — the phase where SM
+      clock would matter — is the phase where the cap costs least.
+
+      The compute ratios are self-cancelling: prefill's "~30% of INT8 MMA peak" (§2c) divides a
+      capped measurement by a ceiling probe run under the same cap, so lifting the limit moves
+      numerator and denominator together.
+
+      **Careful with the maxima.** Individual samples reach 1,740-1,935 MHz on both phases. Those
+      are the first sample or two of a run, before the cap clamps a cold card, and quoting one as a
+      steady clock is wrong — the first version of this script reported `Measure-Object -Average`
+      under a column labelled "median" and that is exactly the mistake it invites. This entry
+      previously claimed the SM clock "swings 1,665-1,755 MHz"; both ends of that are wrong for
+      steady state in either phase.
+
+      **Still open, and still needs an elevated shell.** `nvidia-smi -pl 350` is refused with
+      "Insufficient Permissions" from this session, re-confirmed 2026-09-09, so the residual
+      question stands: what would the missing 35 W buy on prefill? With SM clock already at 97% of
+      rated boost there, the honest prior is "very little" — but that is a prediction. Re-run the
+      script after `-pl 350` to settle it. The second half of this entry is the more valuable one:
+      `nvidia-smi -lgc` to lock clocks would collapse the 3-5% between-process spread that made the
+      27B hard to read this cycle, and that spread is now known to be the largest source of noise
+      in every end-to-end comparison here (see §3's cold-flush entry).
 
 - [ ] **`compute-sanitizer` cannot launch this repository's test binaries.** It reports "Target
       application doesn't exist or is not a valid executable" for `ninfer_*_test.exe` — absolute

--- a/TODO.md
+++ b/TODO.md
@@ -819,6 +819,28 @@ ceiling, and neither has had any optimisation attempted.
 
 ## 3. Measurement debt
 
+- [ ] **Every route boundary in the repository was decided on cold-flush margins, which overstate
+      the win.** `bench/ops/schedule_sweep.cuh` and its siblings call `measure_cold_launch`, which
+      flushes 256 MiB through L2 before every repetition. That is the right default — these
+      projections stream tens of MB against 6 MB of L2 and production is usually cold — but it is
+      not the same as in situ, and the gap is not small. Measured on the q4 SwiGLU `{513,640}`
+      decision (§5): the bench put c128 7.5% ahead of Materialized at T=576, while an nsys profile
+      of the same schedules inside a real 600-token chunk put it 2.4% ahead, with **both** schedules
+      slower per call in situ than in the bench (c128 4193 vs 3625 µs, Materialized 4295 vs 3927).
+      The flush penalises Materialized's second weight pass more than a real prefill does.
+
+      The sign was right in that case, and no boundary is known to be wrong. But every route
+      comment in `src/ops/*/`*`_plan.cpp` quotes cold-flush microseconds, several of them at
+      margins under 5%, and those margins are not speedups. Worth doing: take the boundaries whose
+      measured margin is under ~5% — the `{2,10}`/`{11,16}` q5 crossover at T=10 (93.2 vs 101.4,
+      8%) and the q4 SwiGLU `{2,24}`/`{25,40}` crossover at T=25 (464.9 vs 436.2, 6%) are the
+      obvious two — and check each in situ with a profile rather than the bench. The method is in
+      §5's entry; it is one nsys run per boundary.
+
+      Do not "fix" the flush. Cold is the honest default for a first pass and warm numbers pick
+      different winners, which is documented at the top of `schedule_sweep.cuh`. The point is that
+      a narrow cold-flush margin is a reason to profile, not a decision.
+
 - [ ] **The 315 W power cap has never been measured, and it bounds every number in this file.**
       `nvidia-smi` reports the limit at 315 W against a 350 W default (400 W maximum) and throttle
       reason `SwPowerCap` continuously through every sweep; the SM clock swings 1,665-1,755 MHz
@@ -887,12 +909,46 @@ ceiling, and neither has had any optimisation attempted.
       columns in one pass where plain decode evaluates one, so reductions run in a different order
       and a near-tie argmax flips. MTP reproduces it exactly, so it predates the merge — but nobody
       has decided whether that is acceptable or worth pinning down.
-- [ ] **q4 SwiGLU `{513,640}` is still on `Materialized`, unmeasured either way.** The one band
-      where Materialized and the c128 tile could not be separated: Materialized won T=576 in three
-      of four runs, but c128 there ranged 4147–4959 µs (**19.6% spread**) and the margins outside
-      the single outlying run were ±2%. Changing it would be fitting noise. Re-measure if the noise
-      floor on this Op improves — it is markedly noisier than the other route tables, which is
-      itself worth understanding.
+- [x] **q4 SwiGLU `{513,640}` settled: it goes to c128, and the alternation is gone.** The band
+      stayed on `Materialized` because the measurement could not separate the two — over four runs
+      Materialized won T=576 three times, while c128 there ranged 4147–4959 µs (19.6% spread) and
+      the margins outside the outlying run were ±2%.
+
+      The blocker was the instrument, not the card. `ColdTiming` had carried `min_us` and `p95_us`
+      all along and the sweep harness threw both away, printing only the median, so the spread that
+      made the decision impossible was never visible in the table. Added `--spread` to
+      `bench/ops/schedule_sweep.cuh` and to the q4 SwiGLU bench (which has its own arg loop), then
+      re-measured at 31–51 repetitions on an idle card. c128 wins all three widths in four
+      independent runs — 1.3–2.5% at 513, 1.2–7.5% at 576, 7.3–11.2% at 640 — and its *fastest*
+      sample beats Materialized's fastest everywhere, by 7–9% at 640 with no overlap at all. Sign
+      consistent 12 times out of 12. `{49,512}`, `{513,640}` and `{641,∞}` collapse into one
+      `{49,∞}` c128 route and the table drops from seven entries to five.
+
+      **Two things worth more than the route change itself.**
+
+      *The bench overstates margins.* Confirmed in situ with nsys on a single 600-token chunk:
+      Materialized costs 269.73 ms in `q4_rowsplit_gemm_mma` plus 5.16 ms in
+      `silu_and_mul_dim0_split` across 64 layers = 274.89 ms, against 268.32 ms for the c128 pair
+      kernel. c128 still wins, but by **2.4%, not 7.5%** — and both are slower per call in situ
+      than in the bench (4193 vs 3625 µs for c128; 4295 vs 3927 for Materialized). The bench
+      flushes L2 before every repetition and a real prefill does not arrive with a cold cache, so
+      the flush penalises Materialized's second pass more than production does. **This applies to
+      every band in every one of these route tables**, all of which were decided on cold-flush
+      numbers alone. Nothing is known to be mis-routed because of it — the sign was right here —
+      but no margin in those comments should be quoted as a speedup.
+
+      *End-to-end it is invisible, and that is expected.* `pp600` measured 886.0–888.8 tok/s with
+      c128 against 888.5–892.1 on Materialized: inside the run-to-run spread, because 6.6 ms of a
+      ~660 ms prefill sits under the ±3% that unrelated kernels move between runs.
+
+      One trap on the way: `--prefill-chunk 640` looks like the obvious way to exercise this band
+      and does not touch it. `q4a8_swiglu` claims any width with `tokens >= 128 && tokens % 128 ==
+      0`, and `--prefill-chunk` is required to be a multiple of 128, so **every full prefill chunk
+      goes to the integer-activation kernel and never reaches this table at all.** The `{49,∞}`
+      route is reached only by decode widths and by a prompt's ragged tail chunk. That is why
+      `{513,640}` was simultaneously close and inconsequential for so long. The first end-to-end
+      comparison here was run at chunk 640 and measured nothing, twice, before the profile showed
+      `q4a8_swiglu_kernel` where `q4_linear_swiglu` was assumed to be.
 
 ---
 

--- a/bench/ops/q4_linear_swiglu_schedule_bench.cu
+++ b/bench/ops/q4_linear_swiglu_schedule_bench.cu
@@ -67,8 +67,12 @@ constexpr std::size_t kFlushBytes  = 256ULL << 20;
 
 int main(int argc, char** argv) {
     std::vector<std::int32_t> tokens;
-    int repeat = 9;
-    int warmup = 3;
+    int repeat  = 9;
+    int warmup  = 3;
+    // A route boundary is only decidable if the margin between two schedules clears their own
+    // spread. This Op is the noisiest of the route tables and the {513,640} band went unresolved
+    // because of it, so print min..p95 beside the median when asked.
+    bool spread = false;
     for (int i = 1; i < argc; ++i) {
         const std::string_view arg(argv[i]);
         if (arg == "--tokens" && i + 1 < argc) {
@@ -85,8 +89,10 @@ int main(int argc, char** argv) {
             repeat = std::atoi(argv[++i]);
         } else if (arg == "--warmup" && i + 1 < argc) {
             warmup = std::atoi(argv[++i]);
+        } else if (arg == "--spread") {
+            spread = true;
         } else {
-            std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N]\n", argv[0]);
+            std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n", argv[0]);
             return 2;
         }
     }
@@ -111,12 +117,14 @@ int main(int argc, char** argv) {
                                                                            max_tokens);
     ninfer::WorkspaceArena workspace(std::max<std::size_t>(workspace_bytes, 1));
 
+    const int width = spread ? 30 : 22;
     cudaDeviceProp properties{};
     cudaGetDeviceProperties(&properties, 0);
-    std::printf("# gpu=%s sm=%d%d  q4 swiglu schedules, cold, median of %d\n", properties.name,
-                properties.major, properties.minor, repeat);
+    std::printf("# gpu=%s sm=%d%d  q4 swiglu schedules, cold, %s of %d\n", properties.name,
+                properties.major, properties.minor, spread ? "median min..p95" : "median",
+                repeat);
     std::printf("%6s", "T");
-    for (const Schedule& schedule : kSchedules) { std::printf(" %22s", schedule.name); }
+    for (const Schedule& schedule : kSchedules) { std::printf(" %*s", width, schedule.name); }
     std::printf("   %-22s\n", "winner");
 
     for (const std::int32_t token_count : tokens) {
@@ -128,23 +136,30 @@ int main(int argc, char** argv) {
         for (int s = 0; s < kScheduleCount; ++s) {
             const Schedule& schedule = kSchedules[s];
             if (schedule.max_cols != 0 && token_count > schedule.max_cols) {
-                std::printf(" %22s", "out-of-domain");
+                std::printf(" %*s", width, "out-of-domain");
                 continue;
             }
             const auto invoke = [&](cudaStream_t launch_stream) {
                 ninfer::ops::detail::q4_linear_swiglu_execute_schedule(
                     schedule.id, x, packed.weight, out, workspace, launch_stream);
             };
-            double us = 0.0;
+            ninfer::bench::ColdTiming timing{};
             try {
-                us = ninfer::bench::measure_cold_launch(invoke, flush, stream, warmup, repeat)
-                         .median_us;
+                timing = ninfer::bench::measure_cold_launch(invoke, flush, stream, warmup, repeat);
             } catch (const std::exception&) {
                 cudaGetLastError();
-                std::printf(" %22s", "n/a");
+                std::printf(" %*s", width, "n/a");
                 continue;
             }
-            std::printf(" %22.3f", us);
+            const double us = timing.median_us;
+            if (spread) {
+                char cell[64];
+                std::snprintf(cell, sizeof(cell), "%.1f %.1f..%.1f", us, timing.min_us,
+                              timing.p95_us);
+                std::printf(" %*s", width, cell);
+            } else {
+                std::printf(" %*.3f", width, us);
+            }
             if (best_us == 0.0 || us < best_us) {
                 best_us   = us;
                 best_name = schedule.name;

--- a/bench/ops/q4_q5_attn_input_schedule_bench.cu
+++ b/bench/ops/q4_q5_attn_input_schedule_bench.cu
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
         } else if (arg == "--warmup" && i + 1 < argc) {
             warmup = std::atoi(argv[++i]);
         } else {
-            std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N]\n", argv[0]);
+            std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n", argv[0]);
             return 2;
         }
     }

--- a/bench/ops/q5_linear_add_schedule_bench.cu
+++ b/bench/ops/q5_linear_add_schedule_bench.cu
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
     ninfer::bench::SweepOptions options;
     options.tokens = {1, 8, 16, 24, 32, 40, 48, 56, 64, 96, 128, 160, 176, 192, 208, 256};
     if (!ninfer::bench::parse_sweep_args(argc, argv, options)) {
-        std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N]\n", argv[0]);
+        std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n", argv[0]);
         return 2;
     }
     sweep_for_k(6144, options);

--- a/bench/ops/schedule_sweep.cuh
+++ b/bench/ops/schedule_sweep.cuh
@@ -58,14 +58,19 @@ struct SweepOptions {
     int warmup                = 3;
     std::size_t flush_bytes   = 256ULL << 20;
     const char* title         = "schedules";
+    // Print "median min..p95" per cell instead of the median alone. A route decision is only
+    // meaningful if the margin between two schedules clears their own spread, and the median by
+    // itself cannot tell you that -- TODO section 5 has a band that stayed unresolved for exactly
+    // this reason, where the losing schedule's own samples ranged 19.6%.
+    bool spread               = false;
     // Optional: what the Op's own resolver picks at this width, and the public Op itself. Supply
     // both or neither.
     std::function<const char*(std::int32_t)> routed_name;
     std::function<void(std::int32_t, cudaStream_t)> public_op;
 };
 
-// Parses "--tokens A,B,C", "--repeat N", "--warmup N". Returns false on an unrecognised argument
-// so the caller can print its own usage.
+// Parses "--tokens A,B,C", "--repeat N", "--warmup N", "--spread". Returns false on an
+// unrecognised argument so the caller can print its own usage.
 inline bool parse_sweep_args(int argc, char** argv, SweepOptions& options) {
     for (int i = 1; i < argc; ++i) {
         const std::string_view arg(argv[i]);
@@ -84,6 +89,8 @@ inline bool parse_sweep_args(int argc, char** argv, SweepOptions& options) {
             options.repeat = std::atoi(argv[++i]);
         } else if (arg == "--warmup" && i + 1 < argc) {
             options.warmup = std::atoi(argv[++i]);
+        } else if (arg == "--spread") {
+            options.spread = true;
         } else {
             return false;
         }
@@ -95,12 +102,14 @@ inline void run_sweep(const SweepOptions& options, const std::vector<SweepEntry>
     DeviceBuffer flush(options.flush_bytes);
     cudaStream_t stream = nullptr;
 
+    const int width = options.spread ? 30 : 22;
     cudaDeviceProp properties{};
     cudaGetDeviceProperties(&properties, 0);
-    std::printf("# gpu=%s sm=%d%d  %s, cold, median of %d\n", properties.name, properties.major,
-                properties.minor, options.title, options.repeat);
+    std::printf("# gpu=%s sm=%d%d  %s, cold, %s of %d\n", properties.name, properties.major,
+                properties.minor, options.title,
+                options.spread ? "median min..p95" : "median", options.repeat);
     std::printf("%6s", "T");
-    for (const SweepEntry& entry : schedules) { std::printf(" %22s", entry.name); }
+    for (const SweepEntry& entry : schedules) { std::printf(" %*s", width, entry.name); }
     if (options.public_op) { std::printf(" %12s %-34s", "public_op", "routed_to"); }
     std::printf("   %-22s\n", "winner");
 
@@ -110,22 +119,30 @@ inline void run_sweep(const SweepOptions& options, const std::vector<SweepEntry>
         std::printf("%6d", tokens);
         for (const SweepEntry& entry : schedules) {
             if (entry.max_cols != 0 && tokens > entry.max_cols) {
-                std::printf(" %22s", "out-of-domain");
+                std::printf(" %*s", width, "out-of-domain");
                 continue;
             }
             const auto launch = [&](cudaStream_t launch_stream) {
                 entry.invoke(tokens, launch_stream);
             };
-            double us = 0.0;
+            ColdTiming timing{};
             try {
-                us = measure_cold_launch(launch, flush, stream, options.warmup, options.repeat)
-                         .median_us;
+                timing = measure_cold_launch(launch, flush, stream, options.warmup,
+                                             options.repeat);
             } catch (const std::exception&) {
                 cudaGetLastError();
-                std::printf(" %22s", "n/a");
+                std::printf(" %*s", width, "n/a");
                 continue;
             }
-            std::printf(" %22.3f", us);
+            const double us = timing.median_us;
+            if (options.spread) {
+                char cell[64];
+                std::snprintf(cell, sizeof(cell), "%.1f %.1f..%.1f", us, timing.min_us,
+                              timing.p95_us);
+                std::printf(" %*s", width, cell);
+            } else {
+                std::printf(" %*.3f", width, us);
+            }
             if (best_us == 0.0 || us < best_us) {
                 best_us   = us;
                 best_name = entry.name;

--- a/bench/ops/w8_dflash2_schedule_bench.cu
+++ b/bench/ops/w8_dflash2_schedule_bench.cu
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
     ninfer::bench::SweepOptions options;
     options.tokens = {1, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 96, 112, 128, 160, 192, 256, 384};
     if (!ninfer::bench::parse_sweep_args(argc, argv, options)) {
-        std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N]\n", argv[0]);
+        std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n", argv[0]);
         return 2;
     }
     sweep_attn_input(options);

--- a/bench/ops/w8_pair_schedule_bench.cu
+++ b/bench/ops/w8_pair_schedule_bench.cu
@@ -202,7 +202,7 @@ int main(int argc, char** argv) {
                                           86, 96,  112, 128, 160, 192, 256, 384, 512, 768, 960, 961,
                                           1024};
     if (!ninfer::bench::parse_sweep_args(argc, argv, options)) {
-        std::fprintf(stderr, "usage: %s [--k2048] [--tokens T,...] [--repeat N] [--warmup N]\n",
+        std::fprintf(stderr, "usage: %s [--k2048] [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n",
                      argv[0]);
         return 2;
     }

--- a/scripts/sweeps/README.md
+++ b/scripts/sweeps/README.md
@@ -31,12 +31,20 @@ about three hours for twelve model/format combinations.
 | `speculation-matrix.ps1` | What does each speculative backend cost and buy? | 1 h |
 | `decode-roofline.ps1` | What fraction of the card's 936.2 GB/s does decode reach? | instant |
 | `decode-step-profile.ps1` | Where does a decode step's time go -- occupancy, launch gaps, or bandwidth? | a few min |
+| `power-and-clocks.ps1` | Does the 315 W cap bound these numbers? | a few min |
 
 `decode-roofline.ps1` needs no GPU: it reads the CSVs `kv-decode-vs-depth.ps1` leaves behind and
 divides achieved bandwidth by peak. Run that sweep first. Note it only means anything for the
 **dense** model -- applied to the A3B MoE it returns 391% of peak, which is not a result but a
 demonstration that the formula does not hold there, since an MoE never reads its resident weights
 per token. See TODO section 2c.
+
+`power-and-clocks.ps1` needs neither a model sweep nor `nsys`, only `nvidia-smi`: it samples power,
+clocks and throttle reasons through one decode and one prefill. The answer as of 2026-09-09 is that
+the cap binds in essentially every busy sample but the **memory clock never leaves 9,501 MHz**, so
+the bandwidth figures these sweeps produce are not capped. Read the two phases separately -- decode
+and prefill sit ~135 MHz apart on SM clock for the same power -- and ignore the maxima, which are
+ramp-up spikes on a cold card.
 
 `decode-step-profile.ps1` needs `nsys` (Nsight Systems) rather than a plain GPU run: it captures one
 measured decode repetition per configuration and reports GPU-busy vs. idle time from the trace, plus

--- a/scripts/sweeps/power-and-clocks.ps1
+++ b/scripts/sweeps/power-and-clocks.ps1
@@ -1,0 +1,82 @@
+# Does the 315 W cap bound the numbers in TODO.md?
+#
+# TODO section 3 asked what the power cap costs. This samples nvidia-smi through one decode and one
+# prefill and reports what actually throttles. The answer as of 2026-09-09 on this box: the cap
+# binds continuously (power pins within 1 W of the limit whenever the card is busy) but the memory
+# clock never leaves 9,501 MHz in either phase, so every bandwidth figure in that file is measured
+# at unthrottled memory. SM clock is what pays -- about 11% below rated boost on decode, 3% on
+# prefill.
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\power-and-clocks.ps1
+#
+# Read the two phases separately. Decode and prefill sit at different clocks for the same power,
+# and averaging them hides exactly the thing worth seeing. Rows with utilization <= 50% are dropped
+# because they are model loading and process teardown, not the workload.
+#
+# The residual question -- what the missing 35 W would buy -- needs `nvidia-smi -pl 350`, which
+# requires an elevated shell. Without one this script tells you what the cap is doing, not what
+# lifting it would do. Re-run it after `-pl 350` to answer that.
+$ErrorActionPreference = 'Continue'
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
+
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+$bench    = '.\build-ninja\bench\ninfer_bench.exe'
+$model    = "$modelDir\qwen3_8_27b.ninfer"
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+if (-not (Test-Path $model)) { throw "model not found: $model" }
+
+nvidia-smi --query-gpu=power.limit,power.default_limit,power.max_limit,clocks.max.sm,clocks.max.memory `
+    --format=csv | ForEach-Object { "# $_" }
+
+$fields = 'power.draw,clocks.sm,clocks.mem,temperature.gpu,utilization.gpu,' +
+          'clocks_throttle_reasons.sw_power_cap,clocks_throttle_reasons.hw_thermal_slowdown,' +
+          'clocks_throttle_reasons.sw_thermal_slowdown'
+
+$phases = @(
+  @{ key = 'decode';  args = @('-n','1024','-r','2') }
+  @{ key = 'prefill'; args = @('-p','8192','-r','3') }
+)
+
+foreach ($phase in $phases) {
+  $csv = "$out\power_$($phase.key).csv"
+  # Start the sampler first: the interesting samples are the ones under load, and nvidia-smi's own
+  # first reading lags by up to a second.
+  $smi = Start-Process -FilePath 'nvidia-smi' -PassThru -NoNewWindow -RedirectStandardOutput $csv `
+      -ArgumentList '--query-gpu',$fields,'--format=csv,noheader','-lms','500'
+  try {
+    & $bench --weights $model --kv-dtype int8 --max-ctx 8192 @($phase.args) --warmup 1 2>&1 |
+        Where-Object { $_ -match '^(pp|tg|test)' }
+  } finally {
+    try { $smi.Kill(); $smi.WaitForExit(5000) } catch {}
+  }
+
+  $rows = @(Import-Csv $csv -Header 'pw','sm','mem','t','util','pcap','hwt','swt' |
+      Where-Object { $_.util -and [int]($_.util -replace '[^0-9]','') -gt 50 })
+  if (-not $rows) { "$($phase.key): no busy samples"; continue }
+  $num = { param($v) [double](($v -replace '[^0-9.]','')) }
+  $pw  = $rows | ForEach-Object { & $num $_.pw }
+  $sm  = $rows | ForEach-Object { & $num $_.sm }
+  $mem = $rows | ForEach-Object { & $num $_.mem }
+  $tp  = $rows | ForEach-Object { & $num $_.t }
+  $cap = ($rows | Where-Object { $_.pcap -match 'Active' -and $_.pcap -notmatch 'Not Active' }).Count
+  $thm = ($rows | Where-Object { ($_.hwt -match 'Active' -and $_.hwt -notmatch 'Not Active') -or
+                                 ($_.swt -match 'Active' -and $_.swt -notmatch 'Not Active') }).Count
+  # A real median, not Measure-Object -Average: the ramp-up samples are outliers at both ends
+  # (36 W idle at one end, a 1,905 MHz boost spike before power settles at the other) and a mean
+  # reported as a median is how a 1,905 MHz reading ends up quoted as a steady clock.
+  $median = { param($v) $sorted = @($v | Sort-Object); $sorted[[int]($sorted.Count / 2)] }
+  $stat = { param($v) "{0:N0} median ({1:N0}-{2:N0})" -f `
+      (& $median $v), (($v | Measure-Object -Minimum).Minimum),
+      (($v | Measure-Object -Maximum).Maximum) }
+  ""
+  "== $($phase.key), 27B int8, $($rows.Count) busy samples =="
+  "  board power       : $(& $stat $pw) W"
+  "  sw_power_cap      : $cap of $($rows.Count) samples active"
+  "  thermal throttle  : $thm of $($rows.Count) samples active"
+  "  SM clock          : $(& $stat $sm) MHz"
+  "  memory clock      : $(& $stat $mem) MHz"
+  "  temperature       : $(& $stat $tp) C"
+}
+""
+"== done; per-sample CSVs under $out =="

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
@@ -31,7 +31,7 @@ struct RouteSpec {
 
 constexpr Q4LinearSwiGluProblem kShape{34816, 17408, 5120, 5120, 1};
 
-constexpr std::array<RouteSpec, 7> kRoutes{{
+constexpr std::array<RouteSpec, 5> kRoutes{{
     {{1, 1}, Q4LinearSwiGluScheduleId::GemvPair},
     // Measured on sm_86 with bench/ops/q4_linear_swiglu_schedule_bench.cu (cold, median of 11):
     // SmallTTiled and the 40-wide pair tile cross between 24 and 25, us --
@@ -58,17 +58,47 @@ constexpr std::array<RouteSpec, 7> kRoutes{{
     //   mat       856    855    890    864   3004   2724   2398
     //   c128 by  5.1%   3.9%   4.7%   6.4%  23.1%  15.2%   8.7%
     //
-    // So {49,128} and {257,384} join the c128 bands on either side, and 49..512 becomes one route
-    // instead of four.
+    // So {49,128} and {257,384} join the c128 bands on either side.
     //
-    // {513,640} is deliberately left on Materialized. It is the one band where the two are close,
-    // and the measurement cannot separate them: over four runs Materialized won 576 three times,
-    // but c128 at that width ranged 4147-4959 us (19.6% spread) and the margins outside the single
-    // outlying run were +-2%. Changing it would be fitting noise. Re-measure it if the noise floor
-    // on this Op ever improves.
-    {{49, 512}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
-    {{513, 640}, Q4LinearSwiGluScheduleId::Materialized},
-    {{641, kAnyCols}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
+    // {513,640} used to stay on Materialized because the measurement could not separate them:
+    // over four runs Materialized won 576 three times, but c128 there ranged 4147-4959 us (19.6%
+    // spread) and the margins outside the single outlying run were +-2%. Re-measured 2026-09-09
+    // with --spread (which did not exist then, so the spread that blocked the decision was never
+    // visible) at 31-51 repetitions per point on an idle card. c128 won all three widths in four
+    // independent runs; us, range of the per-run medians:
+    //
+    //   T            513          576          640
+    //   c128     3788-3906    3876-3933    3611-3641
+    //   mat      3863-3956    3950-4216    3895-4077
+    //   c128 by  1.3-2.5%     1.2-7.5%     7.3-11.2%
+    //
+    // The min settles it: c128's fastest sample beats Materialized's fastest at every width in
+    // every run, by 7-9% at 640 with no overlap (3524-3581 against 3862-3867). Sign is consistent
+    // 12 times out of 12.
+    //
+    // **This bench overstates the margin, so do not quote it as a speedup.** Confirmed in situ by
+    // profiling a single 600-token chunk (nsys, node-level graph trace, 64 layers): Materialized
+    // costs 269.73 ms in q4_rowsplit_gemm_mma plus 5.16 ms in silu_and_mul_dim0_split = 274.89 ms,
+    // against 268.32 ms for the c128 pair kernel. c128 still wins, but by 2.4%, not 7.5% -- and
+    // both are slower per call in situ than in the bench (4193 vs 3625 us for c128, 4295 vs 3927
+    // for Materialized). The bench flushes L2 before every repetition; a real prefill does not
+    // arrive with a cold cache, and the flush penalises Materialized's second pass more than
+    // production does. The same caveat applies to every band in this table.
+    //
+    // End-to-end the win is invisible: pp600 measured 886.0-888.8 tok/s with c128 against
+    // 888.5-892.1 on Materialized, i.e. inside the run-to-run spread, because 6.6 ms of a ~660 ms
+    // prefill is under the +-3% that unrelated kernels move between runs. Keep the change for
+    // consistency and because it is right, not for a number.
+    //
+    // Reachability, so nobody over-values this band: q4a8_swiglu takes any width with
+    // `tokens >= 128 && tokens % 128 == 0`, and --prefill-chunk must be a multiple of 128, so
+    // every full prefill chunk goes to the integer-activation kernel and never reaches this table.
+    // The 49..end route is reached only by decode widths and by a prompt's ragged tail chunk. That
+    // is why {513,640} was both close and inconsequential for so long.
+    //
+    // With this the alternation is gone completely and 49..end is one route. That was the
+    // suspicious thing about upstream's table to begin with.
+    {{49, kAnyCols}, Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128},
 }};
 
 constexpr bool catalog_is_closed() noexcept {


### PR DESCRIPTION
TODO §3 said the cap *"bounds every number in this file"* and had never been measured. Now measured, with a script so it is repeatable.

`scripts/sweeps/power-and-clocks.ps1` samples `nvidia-smi` at 2 Hz through a 27B `tg1024` decode and a `pp8192` prefill. Three runs each; medians and full ranges over busy samples:

| | decode (162–168 samples) | prefill (52–53 samples) |
|---|---|---|
| board power | 314 W median | 314 W median |
| `sw_power_cap` active | **161–168 of 162–168** | **51–52 of 52–53** |
| SM clock | **1,500–1,515 MHz** median | **1,635–1,650 MHz** median |
| memory clock | **9,501 MHz in every sample** | **9,501 MHz in every sample** |
| temperature | 63–74 °C median, 75 max | 68–76 °C median, 77 max |
| thermal throttle | **0 samples, all runs** | **0 samples, all runs** |

**The cap is permanently binding** — power pins within 1 W of the limit whenever the card is busy — and it is the only thing throttling. No thermal slowdown in any sample of any run.

**But memory clock never moves.** 9,501 MHz is the full 19 Gbps spec, so the 854.2 GB/s achievable figure, the decode roofline, and all of §2c's decode analysis are measured at unthrottled memory and the cap does not bound them. SM clock is what pays: decode ~11% below the 1,695 MHz rated boost, prefill ~3%. Decode is bandwidth-bound so 11% of SM clock buys little there — and prefill, the phase where SM clock would matter, is where the cap costs least. The compute ratios are self-cancelling too: prefill's "~30% of INT8 MMA peak" divides a capped measurement by a ceiling probe run under the same cap.

**Corrects the entry's own figures.** It claimed the SM clock "swings 1,665–1,755 MHz"; both ends are wrong for steady state in either phase. Individual samples *do* reach 1,740–1,935 MHz, but only in the first sample or two before the cap clamps a cold card. The first draft of this script reported `Measure-Object -Average` under a column labelled "median" — precisely how a boost spike gets quoted as a steady clock — so it now takes a real median and the comment says why.

**Stays open** for the part needing an elevated shell: `nvidia-smi -pl 350` is still refused with "Insufficient Permissions" here, re-confirmed today, so what the missing 35 W would buy remains a prediction ("very little", given prefill is already at 97% of rated boost). Re-run the script after `-pl 350` to settle it. The more valuable half is the other one — `nvidia-smi -lgc` to lock clocks would collapse the 3–5% between-process spread that is now known to be the largest noise source in every end-to-end comparison in this repo.