### PR TITLE
Root-cause the DFlash2 5→6 cliff: a GDN route boundary, and widening it regresses

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -558,6 +558,16 @@ roofline finally acquired a denominator; read them before the rest.
       C8 is the profile the 27B release recommends for multi-user serving, and all three dominant
       families sit at 1.9-2.5x their T=1 cost for 8x the rows.
 
+      **Part of this is now attributed.** §3's DFlash2 cliff entry chased the same kernel from the
+      other direction and landed on `rowsplit_grouped_mma_kernel`, which is 13.78 ms of the 56.29 ms
+      C8 round here. It is the GDN input projection, and at C8 it runs the `{{7, 32}}` route from
+      `src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.cpp` — a **32-wide** MMA tile whose cost is
+      set by padded width, so eight live columns pay for thirty-two. The per-instance cost confirms
+      it: 0.300 ms at width 8 against 0.311 ms at width 7, near-identical where a live-token-scaled
+      kernel would differ by an eighth. So a `GroupedMixedMmaR64C8`/`R64C16` is wanted by both
+      entries, and neither the wider direct route nor a routing change gets it — that was measured
+      and refused, see §3.
+
       Two notes on how this entry used to read. The numbers it quoted (C1 78.71 vs C8 250.26 tok/s)
       came from README's cohort table, which is end-to-end **with MTP3 enabled** — tokens per round
       is roughly `1 + 3 x acceptance` rather than 1, so dividing them into a bandwidth figure gives
@@ -802,11 +812,63 @@ ceiling, and neither has had any optimisation attempted.
       model in `docs/config-calculator.html` before changing a default. And 256 costs 6.9%, which
       is worth knowing for anyone tempted to shrink the chunk to save memory.
 
-- [ ] **DFlash2 has a cliff between five and six draft tokens**, 57.2 to 48.4 tok/s (#65), a 15%
-      drop where acceptance is still rising. Seven through twelve continue to degrade. It looks
-      like a block-geometry boundary — seven forms block length eight, per `docs/cli.md` — so five
-      may be sitting just under a tile edge that six crosses. Worth a look if the last few percent
-      matter; four is already the recommended count and is on the good side of it.
+- [ ] **DFlash2's cliff between five and six draft tokens is a GDN input-projection route
+      boundary, and the fix is a narrower MMA tile.** Found 2026-09-09. Not the block geometry this
+      entry guessed at.
+
+      The cliff reproduces exactly — 27B DFlash2 artifact, greedy, `--max-new 256` on a prose
+      prompt, four repetitions each within ±0.1 tok/s. Converting to round cost is what makes it
+      readable, since acceptance and rate move together:
+
+      | k | tok/s | tok/round | ms/round | step |
+      |---|---|---|---|---|
+      | 3 | 59.1 | 2.55 | 43.1 | — |
+      | 4 | 59.5 | 2.95 | 49.6 | +6.4 |
+      | 5 | 59.2 | 3.07 | 51.9 | +2.3 |
+      | 6 | 50.0 | 2.97 | 59.4 | **+7.5** |
+      | 7 | 48.2 | 2.93 | 60.8 | +1.4 |
+      | 8 | 47.1 | 3.45 | 73.2 | +12.5 |
+
+      **Accepted tokens per round is flat at ~3.0 from k=4 onward** (2.95, 3.07, 2.97, 2.93, 3.45),
+      so nothing past four draft tokens pays for itself — every column beyond it is cost. That is
+      the real justification for the recommendation of four, which `docs/cli.md` already gives.
+
+      The 5→6 step itself is a schedule switch, confirmed by nsys per-round diff (83 rounds at k=5,
+      86 at k=6, both deterministic): kernel time per round goes 58.22 → 66.21 ms, +7.99, matching
+      the +7.5 from the throughput arithmetic. `q4_rowsplit_gemm_simt` (5.17 ms) and
+      `q5_rowsplit_gemm_simt_split4` (6.43) vanish and `rowsplit_grouped_mma_kernel` (15.82)
+      appears, on ~51 instances per round — the 27B's GDN layer count, not its 17 attention layers.
+      That is `src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.cpp`:
+
+      ```
+      {{1, 6},  IndependentDirectFixed},
+      {{7, 32}, GroupedMixedMmaR64C32},
+      ```
+
+      Verification width is k+1, so k=5 is the last count inside the direct route and k=6 is the
+      first to cross into a **32-wide** MMA tile whose cost, as that file's own comment says, is set
+      by padded width rather than live tokens. Width 7 pays for 32 columns.
+
+      **The obvious fix does not work, and that is the useful part.** Both `launch_q4` and
+      `launch_q5` accept T up to 15 with a dedicated R8C8 route for 5..15, so extending the direct
+      band looks free. Measured `{{1, 15}}` / `{{16, 32}}` end to end and normalised against k=4/5
+      (unchanged in both tables, and they calibrate a ~3% between-process drift): **−3.6% at width
+      7, +1.3% at width 8, −23.8% at width 9, −13.2% at width 11.** The `{1,6}` boundary is right.
+      Width 8 is the one place the direct path is competitive, which is the R8C8 tile fitting
+      exactly; 9 needs two passes and collapses. Recorded in that file so it is not retried.
+
+      **What to build instead: a `GroupedMixedMmaR64C8` or `R64C16`.** The grouped tile wins at
+      width 7 *despite* padding 7 columns into 32 — so the MMA path beats the SIMT direct path by
+      more than 4.6x of wasted width, and the prize is keeping that efficiency without the dead
+      columns. Two independent measurements want the same kernel: this cliff, and §2c's 8-lane
+      entry, where a C8 decode cohort spends **13.8 ms of a 56.3 ms round in this exact kernel at
+      width 8** (0.300 ms per instance at width 8 against 0.311 at width 7 — near-identical, which
+      is what padded-width-dominated cost looks like). Fixing it pays twice.
+
+      One tooling gap behind all of this: **there is no schedule bench for this Op.** Every other
+      route table here has one (`bench/ops/q4_q5_attn_input_schedule_bench.cu` is the closest
+      sibling) and `q4_q5_gdn_input` does not, which is why its boundary carried no measurement for
+      so long. Write it before tuning a new tile.
 
 - [ ] **`w8_pair` medium discards its schedule entirely on sm_86.**
       `w8_pair_gemm_splitk.cu:133` is `(void)schedule` under `NINFER_SM8X_COMPAT`, so every

--- a/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.cpp
+++ b/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.cpp
@@ -25,6 +25,31 @@ struct RouteSpec {
     Q4Q5GdnInputScheduleId schedule;
 };
 
+// The 1..6 / 7..32 boundary is measured, and it is not where the kernels' own limits suggest.
+// q4_q5_gdn_input_independent.cu accepts T up to 15 -- launch_q4 and launch_q5 both carry a
+// dedicated R8C8 route for 5..15 -- so widths 7..15 look like a free extension of the cheap
+// direct path. Tried it (2026-09-09, {{1, 15}} / {{16, 32}}) and it is a net regression. Measured
+// through DFlash2 draft counts on the 27B, which is the workload that walks these widths one at a
+// time; verification width is k+1, and k=4/5 stay inside 1..6 in both tables so they calibrate the
+// ~3% between-process drift between the two builds:
+//
+//   k      4      5      6      7      8     10
+//   width  5      6      7      8      9     11
+//   direct route to 15, normalised against k=4,5:
+//         0.0%  +0.0%  -3.6%  +1.3% -23.8% -13.2%
+//
+// So the grouped MMA tile wins from width 7 upward and wins overwhelmingly from 9. Width 8 is the
+// one place the direct path is competitive, by 1.3%, which is the R8C8 tile fitting exactly; 9
+// needs two passes through an 8-wide tile and collapses.
+//
+// The useful part is why. The grouped tile wins at width 7 *despite* padding 7 live columns into
+// 32 -- so the MMA path is not merely better per column, it is better by more than 4.6x of wasted
+// width. That says the opportunity here is a narrower grouped tile (R64C8 or R64C16), which would
+// keep the MMA efficiency and stop paying for 25 dead columns, not a wider direct route. Two
+// separate measurements want it: DFlash2 loses 15% crossing this boundary at k=5->6, and a C8
+// decode cohort spends 13.8 ms of a 56.3 ms round in this exact kernel at width 8. See TODO
+// sections 2c and 3.
+//
 // Above the direct route the cost of a grouped MMA tile is set by its padded column width,
 // not by the live token count, so the tile is chosen to be the narrowest one that still
 // covers the extent in a single pass. Decode extents (C8 with MTP3 is 32) get the 32-wide


### PR DESCRIPTION
TODO §3 said the cliff "looks like a block-geometry boundary — seven forms block length eight". It is not that. This finds the actual cause, tests the obvious fix, and records that the fix is a regression so nobody retries it.

## The cliff

Reproduces exactly on the 27B DFlash2 artifact, greedy, `--max-new 256` on a prose prompt, four repetitions each within ±0.1 tok/s. Round cost is what makes it readable:

| k | tok/s | tok/round | ms/round | step |
|---|---|---|---|---|
| 3 | 59.1 | 2.55 | 43.1 | — |
| 4 | 59.5 | 2.95 | 49.6 | +6.4 |
| 5 | 59.2 | 3.07 | 51.9 | +2.3 |
| 6 | 50.0 | 2.97 | 59.4 | **+7.5** |
| 7 | 48.2 | 2.93 | 60.8 | +1.4 |
| 8 | 47.1 | 3.45 | 73.2 | +12.5 |

Accepted tokens per round is **flat at ~3.0 from k=4 onward**, so nothing past four draft tokens pays for itself — the measured reason for the count `docs/cli.md` already recommends.

## The cause

nsys per-round diff at k=5 vs k=6 (83 and 86 rounds, both deterministic): kernel time per round goes 58.22 → 66.21 ms, matching the +7.5 from throughput. `q4_rowsplit_gemm_simt` (5.17 ms) and `q5_rowsplit_gemm_simt_split4` (6.43) vanish; `rowsplit_grouped_mma_kernel` (15.82) appears on ~51 instances per round — the 27B's GDN layer count, not its 17 attention layers.

That is `q4_q5_gdn_input_plan.cpp`:

```
{{1, 6},  IndependentDirectFixed},
{{7, 32}, GroupedMixedMmaR64C32},
```

Verification width is k+1, so k=5 is the last count inside the direct route and k=6 the first to cross into a **32-wide** tile whose cost — as that file's own comment says — is set by padded width. Width 7 pays for 32 columns.

## The obvious fix is a regression

`launch_q4` and `launch_q5` both accept T up to 15, with a dedicated R8C8 route for 5..15, so widening the direct band looks free. Measured `{{1, 15}}` / `{{16, 32}}` end to end, normalised against k=4/5 (unchanged in both tables, and they calibrate a ~3% between-process drift):

| k | width | before | after | normalised |
|---|---|---|---|---|
| 4 | 5 | 59.3 | 61.0 | −0.0% |
| 5 | 6 | 57.6 | 59.3 | +0.0% |
| 6 | 7 | 48.6 | 48.2 | **−3.6%** |
| 7 | 8 | 46.8 | 48.8 | +1.3% |
| 8 | 9 | 45.8 | 35.9 | **−23.8%** |
| 10 | 11 | 41.1 | 36.7 | **−13.2%** |

The `{1,6}` boundary is right. Width 8 is the one place the direct path is competitive, which is the R8C8 tile fitting exactly; 9 needs two passes and collapses. **No behaviour change in this PR** — the route table is reverted to master and the negative result is recorded in the file.

## What to build instead

A `GroupedMixedMmaR64C8` or `R64C16`. The grouped tile wins at width 7 *despite* padding 7 columns into 32, so the MMA path beats the SIMT direct path by more than 4.6× of wasted width — the prize is that efficiency without the dead columns.

**Two independent measurements want the same kernel.** §2c's 8-lane entry arrived at this from the other direction: a C8 decode cohort spends **13.8 ms of a 56.3 ms round** in this exact kernel at width 8, at 0.300 ms per instance against 0.311 ms at width 7 — near-identical, which is what padded-width-dominated cost looks like. Cross-referenced both ways.

One tooling gap behind all of it: `q4_q5_gdn_input` is the only route table here with **no schedule bench** (`q4_q5_attn_input_schedule_bench.cu` is the closest sibling), which is why its boundary carried no measurement. Noted as the thing to write before tuning a tile.