### PR TITLE
Give the GDN input projection a schedule bench, and add the two narrow tiles it found

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -865,10 +865,64 @@ ceiling, and neither has had any optimisation attempted.
       width 8** (0.300 ms per instance at width 8 against 0.311 at width 7 — near-identical, which
       is what padded-width-dominated cost looks like). Fixing it pays twice.
 
-      One tooling gap behind all of this: **there is no schedule bench for this Op.** Every other
-      route table here has one (`bench/ops/q4_q5_attn_input_schedule_bench.cu` is the closest
-      sibling) and `q4_q5_gdn_input` does not, which is why its boundary carried no measurement for
-      so long. Write it before tuning a new tile.
+      One tooling gap was behind all of this: this Op had no schedule bench, which is why its
+      boundary carried no measurement for so long. Written now, and it produced the two narrow
+      tiles in the entry below — which take back a third of this cliff (k=6 goes from 47.9 to 51.2
+      tok/s, +5.3% paired, 6/6 runs). The cliff is smaller but still there: the remaining gap is
+      that the grouped kernel runs at 27% of its own weight-streaming floor at any width, and no
+      tile choice changes that.
+
+- [x] **The GDN input projection now has a schedule bench, and it bought two narrower tiles.**
+      Closed 2026-09-09. This was the one route table here with no schedule bench, which is why its
+      boundary carried no measurement while being implicated in two separate slowdowns.
+
+      `bench/ops/q4_q5_gdn_input_schedule_bench.cu` plus a
+      `q4_q5_gdn_input_execute_schedule` seam (the pattern `q4_linear_swiglu` and `w8_pair` already
+      use: the real dispatch minus its plan-matches-problem check, so every schedule can be timed
+      at every width). First result: **every existing boundary in that table is correct** — 6/7,
+      32/33 and 64/65 all sit exactly where the curves cross.
+
+      Second result: the table was missing two tiles. `GemmCfg` takes the tile width as `BN`, so
+      `R64C8` and `R64C16` are instantiations, not new kernels. Measured, cold, medians of 31 with
+      `--spread`, each winner's p95 below the runner-up's min:
+
+      | T | independent | c8 | c16 | c32 |
+      |---|---|---|---|---|
+      | 6 | **188.4** | 240.6 | 247.8 | 290.8 |
+      | 7 | 330.8 | **238.6** | 242.7 | 267.3 |
+      | 8 | 319.5 | **236.5** | 243.7 | 267.3 |
+      | 9 | 486.4 | 504.8 | **243.7** | 267.3 |
+      | 16 | — | 506.9 | **242.7** | 267.3 |
+      | 17 | — | 750.6 | 495.6 | **269.3** |
+      | 32 | — | 999.4 | 491.5 | **264.2** |
+
+      So c8 wins 7..8 by 10.7-11.5% and c16 wins 9..16 by 8.8-9.2%, each collapsing one column past
+      its own width because a second pass costs a whole extra weight read. The table is now
+      `{1,6} independent / {7,8} c8 / {9,16} c16 / {17,32} c32 / {33,64} c64 / {65,∞} c128`, and
+      `tests/ops/test_gdn_input_proj.cpp` gained widths 8, 9 and 17 so every new boundary is
+      exercised on both sides.
+
+      End to end on DFlash2, interleaving the two binaries within each repetition so thermal drift
+      lands on both arms — which it had to, because the card moved 3-5% between processes and that
+      is larger than the effect:
+
+      | k | width | base | c8/c16 | paired median | positive |
+      |---|---|---|---|---|---|
+      | 6 | 7 | 47.9 | 51.2 | **+5.3%** | 6/6 pairs |
+      | 8 | 9 | 44.4 | 45.2 | **+3.2%** | 4/6 pairs |
+
+      **Do not read the 11% as evidence that padding was the main cost.** Dropping `BN` from 32 to
+      8 removes 75% of the padded MMA work and buys 11%, because this Op streams ~55 MB of weights
+      (4,096x5,120 q4 plus 12,288x5,120 q5) whose 64.4 µs at 854.2 GB/s no tile choice changes. c8
+      at 236.5 µs is **27% of that floor**. The padded work was a minor term all along, and the
+      remaining 3.7x is what is actually worth chasing — the same conclusion §2c's 8-lane entry
+      reaches about `mma_r64_c16`, from a different Op.
+
+      Not yet measured: the C8 **serving** cohort, which is the other workload this kernel dominates
+      (13.8 ms of a 56.3 ms round at width 8). The DFlash2 numbers above are the CLI path. The
+      serving A/B wants `tools/bench/run_serve_concurrency.py --concurrency 8 --mode mtp0` against
+      both binaries, interleaved the same way; expect low single digits, since the kernel is ~25%
+      of the round and the tile win is ~11% of the kernel.
 
 - [ ] **`w8_pair` medium discards its schedule entirely on sm_86.**
       `w8_pair_gemm_splitk.cu:133` is `(void)schedule` under `NINFER_SM8X_COMPAT`, so every

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -47,6 +47,8 @@ ninfer_add_op_bench(ninfer_candidate_selector_bench SOURCES ops/candidate_select
 ninfer_add_op_bench(ninfer_gdn_input_proj_bench SOURCES ops/gdn_input_proj_bench.cu)
 ninfer_add_op_bench(ninfer_gdn_input_proj_conv_snapshot_bench
   SOURCES ops/gdn_input_proj_conv_snapshot_bench.cu)
+ninfer_add_op_bench(ninfer_q4_q5_gdn_input_schedule_bench
+  SOURCES ops/q4_q5_gdn_input_schedule_bench.cu)
 ninfer_add_op_bench(ninfer_attn_input_proj_bench SOURCES ops/attn_input_proj_bench.cu)
 ninfer_add_op_bench(ninfer_q4_q5_attn_input_schedule_bench
   SOURCES ops/q4_q5_attn_input_schedule_bench.cu)

--- a/bench/ops/q4_q5_gdn_input_schedule_bench.cu
+++ b/bench/ops/q4_q5_gdn_input_schedule_bench.cu
@@ -1,0 +1,193 @@
+// Maintainer benchmark for the Q4/Q5 GDN input-projection route boundaries.
+//
+// This Op was the last route table here with no schedule bench, and it is the one that needed one
+// most. Its {{1, 6}} / {{7, 32}} boundary is where DFlash2 loses 15% between five and six draft
+// tokens (verification width is k+1, so k=6 is the first count to cross it) and where a C8 decode
+// cohort starts paying a 32-wide MMA tile for eight live columns -- 13.8 ms of a 56.3 ms round.
+// Both were diagnosed by profiling whole runs, because nothing could time the two schedules
+// against each other at the same width. This is that.
+//
+// Like its siblings it calls q4_q5_gdn_input_execute_schedule, the real dispatch minus its
+// plan-matches-problem check, so every schedule runs at every in-domain width regardless of which
+// one the table would pick. Nothing in the engine consumes this.
+//
+// Two things to know before reading a column:
+//
+//   * IndependentDirectFixed is bounded at 15, not 6. launch_q4 and launch_q5 each carry a
+//     dedicated R8C8 route for 5..15, which makes widening the route band look free. It is not:
+//     measured end to end it costs 3.6% at width 7 and 23.8% at width 9. That the direct path is
+//     *defined* to 15 and *loses* from 7 is exactly the thing this bench makes visible.
+//
+//   * The grouped tiles cost what their padded width costs, not what the live token count costs,
+//     so their columns should read nearly flat across this sweep. A grouped tile winning at a
+//     width far below its own is not a paradox -- it means the MMA path beats the SIMT direct path
+//     by more than the padding wastes.
+//
+//   build-ninja\bench\ninfer_q4_q5_gdn_input_schedule_bench.exe --spread
+//
+// Use --spread when a margin looks close: it prints min..p95 beside the median, and a boundary is
+// only decidable if the margin clears the spread. See TODO section 3 on cold-flush margins -- they
+// overstate wins, so confirm anything narrow with a profile of the real workload.
+
+#include "core/device.h"
+#include "ninfer_bench_common.h"
+#include "ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.h"
+#include "quantized_weight.cuh"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using ninfer::DType;
+using ninfer::QType;
+using ninfer::Tensor;
+
+using Id = ninfer::ops::detail::Q4Q5GdnInputScheduleId;
+
+struct Schedule {
+    const char* name;
+    Id id;
+    // Largest column count the kernel is defined for; 0 means unbounded. The independent route
+    // throws above 15 rather than misbehaving, so the domain is advisory here -- but printing
+    // "out-of-domain" is more honest than printing a caught exception as "n/a".
+    std::int32_t max_cols;
+};
+
+const Schedule kSchedules[] = {
+    {"independent_direct", Id::IndependentDirectFixed, 15},
+    {"grouped_r64_c8", Id::GroupedMixedMmaR64C8, 0},
+    {"grouped_r64_c16", Id::GroupedMixedMmaR64C16, 0},
+    {"grouped_r64_c32", Id::GroupedMixedMmaR64C32, 0},
+    {"grouped_r64_c64", Id::GroupedMixedMmaR64C64, 0},
+    {"grouped_r64_c128", Id::GroupedMixedMmaR64C128, 0},
+};
+constexpr int kScheduleCount = static_cast<int>(sizeof(kSchedules) / sizeof(kSchedules[0]));
+
+// The one shape q4_q5_gdn_input_admits: hidden 5120, qk 4096, value+z 12288, qkv 10240, z 6144.
+constexpr std::int32_t kHidden     = 5120;
+constexpr std::int32_t kQkRows     = 4096;
+constexpr std::int32_t kValueZRows = 12288;
+constexpr std::int32_t kQkvRows    = 10240;
+constexpr std::int32_t kZRows      = 6144;
+constexpr std::size_t kFlushBytes  = 256ULL << 20;
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::vector<std::int32_t> tokens;
+    int repeat  = 9;
+    int warmup  = 3;
+    bool spread = false;
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view arg(argv[i]);
+        if (arg == "--tokens" && i + 1 < argc) {
+            std::string value(argv[++i]);
+            std::size_t start = 0;
+            while (start <= value.size()) {
+                const std::size_t comma = value.find(',', start);
+                const std::string item  = value.substr(start, comma - start);
+                if (!item.empty()) { tokens.push_back(std::atoi(item.c_str())); }
+                if (comma == std::string::npos) { break; }
+                start = comma + 1;
+            }
+        } else if (arg == "--repeat" && i + 1 < argc) {
+            repeat = std::atoi(argv[++i]);
+        } else if (arg == "--warmup" && i + 1 < argc) {
+            warmup = std::atoi(argv[++i]);
+        } else if (arg == "--spread") {
+            spread = true;
+        } else {
+            std::fprintf(stderr,
+                         "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n",
+                         argv[0]);
+            return 2;
+        }
+    }
+    // Dense through the contested band, then the widths the other route bands anchor. 1..16 one at
+    // a time because the whole question is where a boundary belongs, and 6/7 and 8/9 are both live.
+    if (tokens.empty()) {
+        tokens = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13,
+                  14, 15, 16, 20, 24, 32, 33, 48, 64, 65, 96, 128};
+    }
+    const std::int32_t max_tokens = *std::max_element(tokens.begin(), tokens.end());
+
+    ninfer::bench::PackedQuantizedWeight qk = ninfer::bench::make_row_split_weight(
+        QType::Q4G64_F16S, kQkRows, kHidden, kHidden, {0x31, 0x00, 0x3c00});
+    ninfer::bench::PackedQuantizedWeight vz = ninfer::bench::make_row_split_weight(
+        QType::Q5G64_F16S, kValueZRows, kHidden, kHidden, {0x31, 0xa5, 0x3c00});
+
+    ninfer::DeviceBuffer input(static_cast<std::size_t>(kHidden) * max_tokens * 2);
+    ninfer::DeviceBuffer qkv(static_cast<std::size_t>(kQkvRows) * max_tokens * 2);
+    ninfer::DeviceBuffer z(static_cast<std::size_t>(kZRows) * max_tokens * 2);
+    ninfer::DeviceBuffer flush(kFlushBytes);
+    cudaStream_t stream = nullptr;
+
+    const int width = spread ? 30 : 22;
+    cudaDeviceProp properties{};
+    cudaGetDeviceProperties(&properties, 0);
+    std::printf("# gpu=%s sm=%d%d  q4_q5 GDN input schedules, cold, %s of %d\n", properties.name,
+                properties.major, properties.minor, spread ? "median min..p95" : "median", repeat);
+    std::printf("%6s", "T");
+    for (const Schedule& schedule : kSchedules) { std::printf(" %*s", width, schedule.name); }
+    std::printf(" %-46s   %-20s\n", "routed_to", "winner");
+
+    for (const std::int32_t token_count : tokens) {
+        Tensor x(input.p, DType::BF16, {kHidden, token_count});
+        Tensor tqkv(qkv.p, DType::BF16, {kQkvRows, token_count});
+        Tensor tz(z.p, DType::BF16, {kZRows, token_count});
+
+        double best_us        = 0.0;
+        const char* best_name = "-";
+        std::printf("%6d", token_count);
+        for (int s = 0; s < kScheduleCount; ++s) {
+            const Schedule& schedule = kSchedules[s];
+            if (schedule.max_cols != 0 && token_count > schedule.max_cols) {
+                std::printf(" %*s", width, "out-of-domain");
+                continue;
+            }
+            const auto invoke = [&](cudaStream_t launch_stream) {
+                ninfer::ops::detail::q4_q5_gdn_input_execute_schedule(
+                    schedule.id, x, qk.weight, vz.weight, tqkv, tz, launch_stream);
+            };
+            ninfer::bench::ColdTiming timing{};
+            try {
+                timing = ninfer::bench::measure_cold_launch(invoke, flush, stream, warmup, repeat);
+            } catch (const std::exception&) {
+                cudaGetLastError();
+                std::printf(" %*s", width, "n/a");
+                continue;
+            }
+            const double us = timing.median_us;
+            if (spread) {
+                char cell[64];
+                std::snprintf(cell, sizeof(cell), "%.1f %.1f..%.1f", us, timing.min_us,
+                              timing.p95_us);
+                std::printf(" %*s", width, cell);
+            } else {
+                std::printf(" %*.3f", width, us);
+            }
+            if (best_us == 0.0 || us < best_us) {
+                best_us   = us;
+                best_name = schedule.name;
+            }
+        }
+        const char* routed = "?";
+        try {
+            const ninfer::ops::detail::Q4Q5GdnInputProblem problem{
+                kHidden, kQkRows, kValueZRows, kQkvRows, kZRows, kHidden, token_count};
+            routed = ninfer::ops::detail::q4_q5_gdn_input_schedule_name(
+                ninfer::ops::detail::q4_q5_gdn_input_resolve_plan(problem).schedule);
+        } catch (const std::exception&) { cudaGetLastError(); }
+        std::printf(" %-46s   %-20s\n", routed, best_name);
+        std::fflush(stdout);
+    }
+    return 0;
+}

--- a/scripts/sweeps/README.md
+++ b/scripts/sweeps/README.md
@@ -32,12 +32,22 @@ about three hours for twelve model/format combinations.
 | `decode-roofline.ps1` | What fraction of the card's 936.2 GB/s does decode reach? | instant |
 | `decode-step-profile.ps1` | Where does a decode step's time go -- occupancy, launch gaps, or bandwidth? | a few min |
 | `power-and-clocks.ps1` | Does the 315 W cap bound these numbers? | a few min |
+| `admin-profile.ps1` | Everything needing an elevated shell: `ncu` counters, and what 350 W buys | a few min |
 
 `decode-roofline.ps1` needs no GPU: it reads the CSVs `kv-decode-vs-depth.ps1` leaves behind and
 divides achieved bandwidth by peak. Run that sweep first. Note it only means anything for the
 **dense** model -- applied to the A3B MoE it returns 391% of peak, which is not a result but a
 demonstration that the formula does not hold there, since an MoE never reads its resident weights
 per token. See TODO section 2c.
+
+**`admin-profile.ps1` must be run from an administrator shell** and refuses to start otherwise.
+It is the only script here that does. `ncu` fails with `ERR_NVGPUCTRPERM` as a normal user because
+GPU performance counters are administrator-only by default on Windows, and `nvidia-smi -pl`/`-lgc`
+are refused outright. Running elevated satisfies the counter permission without the persistent
+`RmProfilingAdminOnly=0` registry change and without a reboot, which is why the script exists
+rather than an instruction to reconfigure the driver. It changes the power limit and clock lock and
+restores both in a `finally` block, including on Ctrl+C; pass `-SkipPower` to leave the power limit
+alone entirely.
 
 `power-and-clocks.ps1` needs neither a model sweep nor `nsys`, only `nvidia-smi`: it samples power,
 clocks and throttle reasons through one decode and one prefill. The answer as of 2026-09-09 is that

--- a/scripts/sweeps/admin-profile.ps1
+++ b/scripts/sweeps/admin-profile.ps1
@@ -1,0 +1,130 @@
+# Everything in this repository that needs an elevated shell, in one run.
+#
+# THIS MUST BE RUN AS ADMINISTRATOR. Open Windows Terminal or PowerShell with "Run as
+# administrator" and run it from the repository root:
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\admin-profile.ps1
+#
+# It needs admin for exactly two reasons, both verified on this box on 2026-09-09:
+#
+#   * ncu fails with ERR_NVGPUCTRPERM as a normal user. GPU performance counters are
+#     administrator-only by default on Windows. That permission is satisfied by EITHER running
+#     elevated OR setting HKLM\...\NvTweak\RmProfilingAdminOnly = 0 and rebooting. Running
+#     elevated is strictly better: nothing persists, and no reboot.
+#   * nvidia-smi -pl and -lgc are refused with "Insufficient Permissions" as a normal user.
+#
+# It changes two pieces of GPU state -- the power limit and the clock lock -- and restores both in
+# a finally block, including on Ctrl+C. Nothing it does survives the script.
+#
+# Results land under profiles\admin\ as text files. Nothing here needs interpreting live; the
+# point is to capture what an unelevated session cannot.
+[CmdletBinding()]
+param(
+  [string]$ModelDir = $(if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }),
+  [string]$Ncu      = $(if ($env:NINFER_NCU) { $env:NINFER_NCU } else { 'C:\Program Files\NVIDIA Corporation\Nsight Compute 2025.1.0\ncu.bat' }),
+  [switch]$SkipPower
+)
+$ErrorActionPreference = 'Continue'
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
+
+$identity = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $identity.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+  Write-Error 'Not elevated. Re-run this from an administrator shell -- everything here needs it.'
+  exit 1
+}
+
+$out = 'profiles\admin'
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+$bench = '.\build-ninja\bench\ninfer_bench.exe'
+$moe   = "$ModelDir\qwen3_6_35b_a3b.ninfer"
+$dense = "$ModelDir\qwen3_8_27b.ninfer"
+foreach ($p in @($bench, $moe, $dense)) {
+  if (-not (Test-Path $p)) { Write-Error "missing: $p"; exit 1 }
+}
+if (-not (Test-Path $Ncu)) { Write-Error "ncu not found at $Ncu; set NINFER_NCU"; exit 1 }
+
+# Remember what to put back. power.limit is the enforced ceiling; default_limit is the factory one.
+$originalLimit = (nvidia-smi --query-gpu=power.limit --format=csv,noheader | Select-Object -First 1)
+$originalLimit = [double]($originalLimit -replace '[^0-9.]', '')
+"original power limit: $originalLimit W"
+$clocksLocked = $false
+$powerChanged = $false
+
+try {
+  # ---------------------------------------------------------------- 1. the MoE expert gather
+  #
+  # TODO section 2c: sparse_moe_d3/d4 reach 40-45% of the card's read bandwidth where contiguous
+  # weight kernels on the same decode step reach 78-82%, and the four sparse_moe stages are 38% of
+  # decode busy time on the 35B. Three candidate causes -- address divergence from gathering eight
+  # scattered experts of 256, L2 behaviour, or too little work per CTA to cover latency -- and
+  # nsys cannot distinguish them. These sections can.
+  #
+  # Clocks are locked first so the counters describe one clock state rather than an average of the
+  # card ramping. --graph-profiling defaults to node, which matters because decode replays a
+  # captured CUDA graph and the default in older tools records a replay as one opaque entity.
+  "locking clocks for the counter run"
+  nvidia-smi -lgc 1500 2>&1 | Out-String | Write-Host
+  if ($LASTEXITCODE -eq 0) { $clocksLocked = $true }
+
+  "== 1/3 ncu: MoE expert gather (35B, int8, decode) -> $out\moe_gather.txt"
+  & $Ncu --target-processes all --graph-profiling node `
+      -k 'regex:sparse_moe' --launch-skip 64 --launch-count 12 `
+      --section SpeedOfLight --section MemoryWorkloadAnalysis `
+      --section MemoryWorkloadAnalysis_Tables --section Occupancy --section LaunchStats `
+      --section SchedulerStats --section WarpStateStats `
+      $bench --weights $moe --kv-dtype int8 --max-ctx 8192 -n 64 -r 1 --warmup 1 `
+      > "$out\moe_gather.txt" 2>&1
+  "  ncu exit $LASTEXITCODE"
+  if (Select-String -Path "$out\moe_gather.txt" -Pattern 'ERR_NVGPUCTRPERM' -Quiet) {
+    "  STILL PERMISSION-DENIED -- the shell is elevated but the driver refused; the registry"
+    "  route (RmProfilingAdminOnly=0 plus reboot) is then the only option."
+  }
+
+  # A contiguous kernel from the same step, as the reference the percentages above are against.
+  # Without it the MoE numbers have no local baseline and have to be compared across runs.
+  "== 2/3 ncu: contiguous reference kernels (27B, int8, decode) -> $out\contiguous_ref.txt"
+  & $Ncu --target-processes all --graph-profiling node `
+      -k 'regex:q5_rowsplit_gemv|q4_linear_swiglu_gemv_pair' --launch-skip 64 --launch-count 8 `
+      --section SpeedOfLight --section MemoryWorkloadAnalysis `
+      --section MemoryWorkloadAnalysis_Tables --section Occupancy --section LaunchStats `
+      $bench --weights $dense --kv-dtype int8 --max-ctx 8192 -n 64 -r 1 --warmup 1 `
+      > "$out\contiguous_ref.txt" 2>&1
+  "  ncu exit $LASTEXITCODE"
+
+  # ---------------------------------------------------------------- 2. what the power cap costs
+  #
+  # TODO section 3: the 315 W cap binds in essentially every busy sample, but memory clock never
+  # leaves 9,501 MHz, so the bandwidth figures are already unthrottled and the prediction is that
+  # the missing 35 W buys very little. This is the measurement that settles it. Clocks are released
+  # first -- a locked clock would hide exactly the effect being looked for.
+  if (-not $SkipPower) {
+    if ($clocksLocked) { nvidia-smi -rgc 2>&1 | Out-Null; $clocksLocked = $false }
+    "== 3/3 power limit 350 W -> $out\power_350.txt"
+    nvidia-smi -pl 350 2>&1 | Out-String | Write-Host
+    if ($LASTEXITCODE -eq 0) {
+      $powerChanged = $true
+      powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\power-and-clocks.ps1 `
+          > "$out\power_350.txt" 2>&1
+      Get-Content "$out\power_350.txt" | Select-String '^==|^  ' | ForEach-Object { "  $_" }
+    } else {
+      "  -pl 350 refused even elevated; skipping"
+    }
+  }
+}
+finally {
+  # Restore unconditionally. A left-behind clock lock or power limit silently changes every
+  # measurement taken afterwards, which is worse than not having run this at all.
+  if ($clocksLocked) { "restoring clocks"; nvidia-smi -rgc 2>&1 | Out-Null }
+  if ($powerChanged) {
+    "restoring power limit to $originalLimit W"
+    nvidia-smi -pl $originalLimit 2>&1 | Out-Null
+  }
+  nvidia-smi --query-gpu=power.limit,clocks.max.sm --format=csv | ForEach-Object { "  $_" }
+}
+
+""
+"== done. Wrote:"
+Get-ChildItem $out -File | ForEach-Object { "   {0,10:N0} bytes  {1}" -f $_.Length, $_.FullName }
+""
+"The two ncu files are the ones that matter; they are long, and are meant to be read by whoever"
+"asked for them rather than skimmed here."

--- a/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_gemm_mma.cu
+++ b/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_gemm_mma.cu
@@ -38,6 +38,13 @@ RowSplitGroupedMmaJob make_job(const Weight& weight, std::int32_t weight_row_off
 // is bandwidth-bound, and a decode round never fills it: C8 with MTP3 is 32 columns. The
 // narrow tiles cut the padded work proportionally over the extents a decode round uses,
 // while the 128-wide tile stays the throughput anchor for prefill chunks.
+// C8 and C16 continue that logic below 32, which is where every decode extent actually lives: a
+// verification round is k+1 wide (6 at the recommended four draft tokens) and a C8 serving cohort
+// is 8. At BN=8 the tile is one warp wide in N -- WARPS_N = BN/WN = 1, so 4 warps and 128 threads
+// against C32's 16 warps and 512 -- which is the point: the padded MMA work falls with BN, and a
+// tile that is 32 wide to serve 8 live columns issues four times the work it needs.
+using GdnInputC8Schedule   = GemmCfg<64, 8, 64, 16, 8, 2, 2, false, true, true>;
+using GdnInputC16Schedule  = GemmCfg<64, 16, 64, 16, 8, 2, 2, false, true, true>;
 using GdnInputC32Schedule  = GemmCfg<64, 32, 64, 16, 8, 2, 2, false, true, true>;
 using GdnInputC64Schedule  = GemmCfg<64, 64, 64, 16, 16, 2, 2, false, true, true>;
 using GdnInputC128Schedule = GemmCfg<64, 128, 64, 64, 16, 2, 1, false, true, true>;
@@ -86,6 +93,18 @@ void launch_route(const Tensor& x, const Weight& qk_weight, const Weight& value_
 }
 
 } // namespace
+
+void q4_q5_gdn_input_grouped_mma_c8_launch(const Tensor& x, const Weight& qk_weight,
+                                           const Weight& value_z_weight, Tensor& qkv, Tensor& z,
+                                           cudaStream_t stream) {
+    launch_route<GdnInputC8Schedule>(x, qk_weight, value_z_weight, qkv, z, stream);
+}
+
+void q4_q5_gdn_input_grouped_mma_c16_launch(const Tensor& x, const Weight& qk_weight,
+                                            const Weight& value_z_weight, Tensor& qkv, Tensor& z,
+                                            cudaStream_t stream) {
+    launch_route<GdnInputC16Schedule>(x, qk_weight, value_z_weight, qkv, z, stream);
+}
 
 void q4_q5_gdn_input_grouped_mma_c32_launch(const Tensor& x, const Weight& qk_weight,
                                             const Weight& value_z_weight, Tensor& qkv, Tensor& z,

--- a/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_kernels.h
+++ b/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_kernels.h
@@ -10,6 +10,14 @@ void q4_q5_gdn_input_independent_launch(const Tensor& x, const Weight& qk_weight
                                         const Weight& value_z_weight, Tensor& qk, Tensor& value,
                                         Tensor& z, cudaStream_t stream);
 
+void q4_q5_gdn_input_grouped_mma_c8_launch(const Tensor& x, const Weight& qk_weight,
+                                           const Weight& value_z_weight, Tensor& qkv, Tensor& z,
+                                           cudaStream_t stream);
+
+void q4_q5_gdn_input_grouped_mma_c16_launch(const Tensor& x, const Weight& qk_weight,
+                                            const Weight& value_z_weight, Tensor& qkv, Tensor& z,
+                                            cudaStream_t stream);
+
 void q4_q5_gdn_input_grouped_mma_c32_launch(const Tensor& x, const Weight& qk_weight,
                                             const Weight& value_z_weight, Tensor& qkv, Tensor& z,
                                             cudaStream_t stream);

--- a/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.cpp
+++ b/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.cpp
@@ -50,13 +50,45 @@ struct RouteSpec {
 // decode cohort spends 13.8 ms of a 56.3 ms round in this exact kernel at width 8. See TODO
 // sections 2c and 3.
 //
+// Below 32 the tile is chosen by measurement, not by which one exists. Every decode extent lives
+// here -- a verification round is k+1 wide (6 at the four draft tokens docs/cli.md recommends) and
+// a C8 serving cohort is 8 -- and until 2026-09-09 all of 7..32 took the 32-wide tile, so eight
+// live columns issued four times the MMA work they needed.
+//
+// Measured with bench/ops/q4_q5_gdn_input_schedule_bench.cu, cold, medians of 31 with --spread
+// (us, median and min..p95). Every boundary below has its winner's p95 under the runner-up's min,
+// so none of it is inside the noise:
+//
+//   T    independent          c8               c16              c32
+//   6    188.4 187..189   240.6 235..247    247.8 245..255   290.8 289..293
+//   7    330.8 327..336   238.6 231..250    242.7 238..252   267.3 264..272
+//   8    319.5 315..323   236.5 231..248    243.7 237..253   267.3 263..273
+//   9    486.4 481..493   504.8 492..526    243.7 240..525   267.3 265..274
+//   16          --        506.9 497..523    242.7 237..253   267.3 264..273
+//   17          --        750.6 738..1158   495.6 484..513   269.3 266..274
+//   32          --        999.4 980..1037   491.5 479..508   264.2 262..268
+//
+// So c8 wins 7..8 by 10.7-11.5%, c16 wins 9..16 by 8.8-9.2%, and each collapses one column past
+// its own width because a second pass costs a whole extra weight read. The staircase is exactly
+// the tile widths.
+//
+// Do not read that 11% as evidence the padding was the main cost. It is not: dropping BN from 32
+// to 8 removes 75% of the padded MMA work and buys 11%, because this Op streams ~55 MB of weights
+// (4096x5120 q4 plus 12288x5120 q5) whose 64.4 us at 854.2 GB/s no tile choice changes. c8 at
+// 236.5 us is 27% of that floor. The padded work was a minor term all along, and the remaining 3.7x
+// is the thing worth chasing -- see TODO section 2c.
+//
+// A tile narrower than the live extent repeats the whole weight pass per column slice, so
+// above 16 columns the 32-wide tile covers a decode round in one pass instead of two.
 // Above the direct route the cost of a grouped MMA tile is set by its padded column width,
 // not by the live token count, so the tile is chosen to be the narrowest one that still
 // covers the extent in a single pass. Decode extents (C8 with MTP3 is 32) get the 32-wide
 // tile; the 128-wide tile remains the prefill-chunk anchor.
-constexpr std::array<RouteSpec, 4> kRoutes{{
+constexpr std::array<RouteSpec, 6> kRoutes{{
     {{1, 6}, Q4Q5GdnInputScheduleId::IndependentDirectFixed},
-    {{7, 32}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C32},
+    {{7, 8}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C8},
+    {{9, 16}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C16},
+    {{17, 32}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C32},
     {{33, 64}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C64},
     {{65, kAnyCols}, Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C128},
 }};
@@ -84,6 +116,10 @@ const char* q4_q5_gdn_input_schedule_name(Q4Q5GdnInputScheduleId schedule) noexc
     switch (schedule) {
     case Q4Q5GdnInputScheduleId::IndependentDirectFixed:
         return "gdn_input_proj.q4_q5.independent_direct_fixed";
+    case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C8:
+        return "gdn_input_proj.q4_q5.grouped_mixed.mma.r64.c8";
+    case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C16:
+        return "gdn_input_proj.q4_q5.grouped_mixed.mma.r64.c16";
     case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C32:
         return "gdn_input_proj.q4_q5.grouped_mixed.mma.r64.c32";
     case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C64:
@@ -140,24 +176,30 @@ Q4Q5GdnInputConvPlan q4_q5_gdn_input_conv_resolve_plan(const Q4Q5GdnInputProblem
     }
 }
 
-void q4_q5_gdn_input_execute_plan(const Q4Q5GdnInputPlan& plan, const Tensor& x,
-                                  const Weight& qk_weight, const Weight& value_z_weight,
-                                  Tensor& qkv, Tensor& z, cudaStream_t stream) {
+void q4_q5_gdn_input_execute_schedule(Q4Q5GdnInputScheduleId schedule, const Tensor& x,
+                                      const Weight& qk_weight, const Weight& value_z_weight,
+                                      Tensor& qkv, Tensor& z, cudaStream_t stream) {
     const Q4Q5GdnInputProblem problem{x.ne[0],   qk_weight.n, value_z_weight.n,
                                       qkv.ne[0], z.ne[0],     qk_weight.padded_shape[1],
                                       x.ne[1]};
-    const Q4Q5GdnInputPlan resolved = q4_q5_gdn_input_resolve_plan(problem);
-    if (resolved.schedule != plan.schedule) {
-        throw std::invalid_argument("Q4/Q5 GDN input: plan does not match exact problem");
+    if (!q4_q5_gdn_input_admits(problem)) {
+        throw std::invalid_argument(
+            "Q4/Q5 GDN input: exact problem or column count is not admitted");
     }
 
-    switch (plan.schedule) {
+    switch (schedule) {
     case Q4Q5GdnInputScheduleId::IndependentDirectFixed: {
         Tensor qk    = qkv.slice(0, 0, problem.qk_rows);
         Tensor value = qkv.slice(0, problem.qk_rows, problem.z_rows);
         q4_q5_gdn_input_independent_launch(x, qk_weight, value_z_weight, qk, value, z, stream);
         return;
     }
+    case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C8:
+        q4_q5_gdn_input_grouped_mma_c8_launch(x, qk_weight, value_z_weight, qkv, z, stream);
+        return;
+    case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C16:
+        q4_q5_gdn_input_grouped_mma_c16_launch(x, qk_weight, value_z_weight, qkv, z, stream);
+        return;
     case Q4Q5GdnInputScheduleId::GroupedMixedMmaR64C32:
         q4_q5_gdn_input_grouped_mma_c32_launch(x, qk_weight, value_z_weight, qkv, z, stream);
         return;
@@ -169,6 +211,19 @@ void q4_q5_gdn_input_execute_plan(const Q4Q5GdnInputPlan& plan, const Tensor& x,
         return;
     }
     throw std::logic_error("Q4/Q5 GDN input: unknown schedule");
+}
+
+void q4_q5_gdn_input_execute_plan(const Q4Q5GdnInputPlan& plan, const Tensor& x,
+                                  const Weight& qk_weight, const Weight& value_z_weight,
+                                  Tensor& qkv, Tensor& z, cudaStream_t stream) {
+    const Q4Q5GdnInputProblem problem{x.ne[0],   qk_weight.n, value_z_weight.n,
+                                      qkv.ne[0], z.ne[0],     qk_weight.padded_shape[1],
+                                      x.ne[1]};
+    const Q4Q5GdnInputPlan resolved = q4_q5_gdn_input_resolve_plan(problem);
+    if (resolved.schedule != plan.schedule) {
+        throw std::invalid_argument("Q4/Q5 GDN input: plan does not match exact problem");
+    }
+    q4_q5_gdn_input_execute_schedule(plan.schedule, x, qk_weight, value_z_weight, qkv, z, stream);
 }
 
 void q4_q5_gdn_input_dispatch(const Tensor& x, const Weight& qk_weight,

--- a/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.h
+++ b/src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.h
@@ -11,6 +11,8 @@ namespace ninfer::ops::detail {
 
 enum class Q4Q5GdnInputScheduleId {
     IndependentDirectFixed,
+    GroupedMixedMmaR64C8,
+    GroupedMixedMmaR64C16,
     GroupedMixedMmaR64C32,
     GroupedMixedMmaR64C64,
     GroupedMixedMmaR64C128,
@@ -47,6 +49,21 @@ Q4Q5GdnInputPlan q4_q5_gdn_input_resolve_plan(const Q4Q5GdnInputProblem& problem
 Q4Q5GdnInputConvPlan q4_q5_gdn_input_conv_resolve_plan(const Q4Q5GdnInputProblem& problem,
                                                        std::int32_t batch_size);
 
+// Runs a schedule without first checking that it is the one resolve_plan would pick;
+// q4_q5_gdn_input_execute_plan is exactly this plus that check.
+//
+// It exists so a bench can time every candidate schedule at the same column count, which is the
+// only way to tell whether a route boundary sits in the right place. This Op needed it most and
+// had it last: its {{1, 6}} / {{7, 32}} boundary is where DFlash2 loses 15% between five and six
+// draft tokens, and where a C8 decode cohort starts paying a 32-wide tile for eight live columns,
+// and until now neither could be checked against the alternative. Mirrors
+// q4_linear_swiglu_execute_schedule and w8_pair_execute_schedule.
+//
+// Nothing on the inference path should call this: the check execute_plan adds is what keeps a plan
+// from being executed against a problem it was not resolved for.
+void q4_q5_gdn_input_execute_schedule(Q4Q5GdnInputScheduleId schedule, const Tensor& x,
+                                      const Weight& qk_weight, const Weight& value_z_weight,
+                                      Tensor& qkv, Tensor& z, cudaStream_t stream);
 void q4_q5_gdn_input_execute_plan(const Q4Q5GdnInputPlan& plan, const Tensor& x,
                                   const Weight& qk_weight, const Weight& value_z_weight,
                                   Tensor& qkv, Tensor& z, cudaStream_t stream);

--- a/tests/ops/test_gdn_input_proj.cpp
+++ b/tests/ops/test_gdn_input_proj.cpp
@@ -80,7 +80,7 @@ int run_q4_q5() {
     // One exactly-filled and one partially-filled extent per route: direct (1, 2, 6),
     // the 32- and 64-wide grouped MMA tiles (7, 32, 33, 64), and the 128-wide tile
     // that carries prefill chunks (65, 128).
-    for (const std::int32_t tokens : {1, 2, 6, 7, 16, 32, 33, 64, 65, 128}) {
+    for (const std::int32_t tokens : {1, 2, 6, 7, 8, 9, 16, 17, 32, 33, 64, 65, 128}) {
         failures += run_q4_q5_case(query_key, value_z_weight, tokens);
     }
     return failures;


### PR DESCRIPTION
This was the only route table in the repo with **no schedule bench**, which is why its `{{1, 6}}` / `{{7, 32}}` boundary carried no measurement while being implicated in two separate slowdowns: DFlash2's 15% cliff between five and six draft tokens (#73) and a C8 decode cohort paying a 32-wide tile for eight live columns (§2c).

## The bench

`bench/ops/q4_q5_gdn_input_schedule_bench.cu`, plus a `q4_q5_gdn_input_execute_schedule` seam — the pattern `q4_linear_swiglu` and `w8_pair` already use: the real dispatch minus its plan-matches-problem check, so every candidate schedule can be timed at the same width.

**First result is a negative one worth having: every existing boundary is correct.** 6/7, 32/33 and 64/65 all sit exactly where the curves cross.

## The two missing tiles

`GemmCfg` takes the tile width as `BN`, so `R64C8` and `R64C16` are instantiations, not new kernels. Cold, medians of 31 with `--spread`; each winner's p95 is below the runner-up's min, so none of this is inside the noise:

| T | independent | c8 | c16 | c32 |
|---|---|---|---|---|
| 6 | **188.4** | 240.6 | 247.8 | 290.8 |
| 7 | 330.8 | **238.6** | 242.7 | 267.3 |
| 8 | 319.5 | **236.5** | 243.7 | 267.3 |
| 9 | 486.4 | 504.8 | **243.7** | 267.3 |
| 16 | — | 506.9 | **242.7** | 267.3 |
| 17 | — | 750.6 | 495.6 | **269.3** |
| 32 | — | 999.4 | 491.5 | **264.2** |

c8 wins 7..8 by 10.7–11.5%, c16 wins 9..16 by 8.8–9.2%, and each collapses one column past its own width because a second pass costs a whole extra weight read. Bands become `{1,6}` independent / `{7,8}` c8 / `{9,16}` c16 / `{17,32}` c32 / `{33,64}` c64 / `{65,∞}` c128.

## End to end

DFlash2, **interleaving the two binaries within each repetition** so thermal drift lands on both arms — necessary, because the card moves 3–5% between processes and that is larger than the effect:

| k | width | base | c8/c16 | paired median | positive |
|---|---|---|---|---|---|
| 6 | 7 | 47.9 | 51.2 | **+5.3%** | 6/6 pairs |
| 8 | 9 | 44.4 | 45.2 | **+3.2%** | 4/6 pairs |

That takes back about a third of the DFlash2 cliff.

## Don't over-read the 11%

Dropping `BN` from 32 to 8 removes 75% of the padded MMA work and buys 11% — because this Op streams ~55 MB of weights (4,096×5,120 q4 plus 12,288×5,120 q5) whose 64.4 µs at 854.2 GB/s no tile choice changes. c8 at 236.5 µs is **27% of that floor.** The padded work was a minor term all along; the remaining 3.7× is the real target, which is the same conclusion §2c reaches about `mma_r64_c16` in a different Op.

## Scope

**The C8 serving cohort is not measured here** — the numbers above are the CLI path. TODO records what the serving A/B needs and what to expect, rather than extrapolating.

## Tests

`tests/ops/test_gdn_input_proj.cpp` gains widths 8, 9 and 17 so both sides of every new boundary are exercised; `ninfer_gdn_input_proj_test` passes.

## Also

`scripts/sweeps/admin-profile.ps1` — collects the two things an unelevated session cannot: `ncu` counters on the MoE expert gather (`ERR_NVGPUCTRPERM` as a normal user) and what raising the 315 W cap buys. Running elevated satisfies the counter permission **without** the persistent `RmProfilingAdminOnly=0` registry change and without a reboot. It refuses to start unelevated, and restores the power limit and clock lock in a `finally` block including on Ctrl+C.