### PR TITLE
ncu on the MoE gather: latency-bound, and two obvious fixes refuted; plus the 315 W cap costs nothing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -797,39 +797,58 @@ ceiling, and neither has had any optimisation attempted.
       d4**, with only 1.1-1.6 eligible warps per scheduler against 8-10 resident. Warps are there
       and stalled, not absent.
 
-      **The binding constraint is registers, and the arithmetic is small.** Both kernels report
-      `Block Limit Registers = 5` against a shared-memory limit of 12 and 7 — so registers, not
-      shared memory, is what caps blocks per SM. At 288 threads per block:
+      **The binding constraint is the 9-warp block, and it is structural.** `Block Limit Warps` is
+      **also 5** — the same as `Block Limit Registers` — so registers are tied with the warp limit,
+      not binding beyond it, and cutting them buys nothing on its own. sm_86 allows 48 warps per
+      SM; a 9-warp block gives `48 / 9 = 5` blocks and 45 resident warps, which is exactly the
+      93.75% theoretical the counters report.
 
-      | registers/thread | registers/block | blocks/SM |
-      |---|---|---|
-      | 40 (d4 today) | 11,520 | 5 |
-      | 36 (d3 today) | 10,368 | 6 |
-      | 32 | 9,216 | 7 |
-      | 28 | 8,064 | 8 |
+      Nine warps is not a tuning choice. In both kernels warps 0..7 each take one of the top-8
+      routed experts through `RoutedCodec`, and **warp 8 takes the shared expert** through
+      `W8Codec` — `kTopK + 1`. Eight warps would have nowhere to put the shared expert. So the
+      6.25% of theoretical occupancy lost to 45-of-48 warps is the price of top-8-plus-shared, and
+      it is the small part anyway.
 
-      Getting d3 to 32 and d4 to 32 would take both from 5 blocks to 7 — **+40% more warps resident
-      to hide the same latency**, without touching the algorithm. That is a `__launch_bounds__` and
-      register-pressure exercise, which is the cheapest thing on this list and should be tried
-      first.
+      **What actually costs d3 is the wave tail, and the arithmetic matches to within 2 points.**
+      512 blocks (one per `kIntermediate` column) over 82 SMs at 5 blocks each is 410 slots: one
+      full wave of 410, then a second wave only 102 blocks deep, i.e. **25% full**. Average
+      occupancy across the two waves is `(410 + 102) / (2 x 410) = 62.4%` against a measured
+      **60.16%**. d3's occupancy shortfall is that tail and essentially nothing else. d4 launches
+      2,048 blocks (5.00 waves), where a tail of the same absolute size is a fifth as costly, and it
+      duly reaches 78.91%.
 
-      **d3 has a second, independent problem: 1.25 waves per SM.** 512 blocks against 82 SMs at 5
-      blocks each is 410 block slots, so the grid fills the machine once and the *tail wave is a
-      quarter full*. d4 runs 2,048 blocks (5.00 waves) and is correspondingly healthier on every
-      occupancy metric. Splitting d3's work into more, smaller blocks would remove the tail; this is
-      separate from the register question and both apply.
+      **And there is a load imbalance inside the block that the source already names.** The shared
+      W8 path is heavier than a routed Q4 path, but the block cannot retire until all nine warps
+      finish, so eight completed routed warps sit holding registers and warp slots while warp 8
+      drains. That is the 44.6% / 58.6% "no eligible warp" directly, and it is not a guess:
+      `sparse_moe_d3_path_tiled_kernel` in the same file exists for this reason and says so —
+      *"Three path CTAs per token/output row expose enough blocks for the 170-SM target and keep the
+      heavier shared W8 path from holding eight completed routed warps resident."* That kernel is
+      written for the multi-token path and takes a `tokens` argument; single-token decode does not
+      use it.
 
-      **One more thing the counters exposed: over-fetch.** ncu measured 12.12 MB of DRAM traffic on
-      d3 and 12.27 MB on d4, where #50's artifact inventory attributes **8.91 MB** and **5.58 MB**
-      of useful weight bytes — 1.36x and **2.20x**. Some of that is sector granularity on a gather
-      that lands on 8 scattered blocks, and it means the effective bandwidth figures above flatter
-      the kernels: d4 moves 2.2x the bytes it needs. Worth confirming with
-      `dram__bytes_read.sum` directly before optimising against it, since the byte attribution and
-      the ncu run are different measurements.
+      So the order to try things, revised:
+
+      1. **Give d3 a grid that tiles 82 SMs.** Its 512 blocks are `kIntermediate`, a power of two,
+         and 410 slots is not — any power-of-two block count tiles 82 badly. This is the largest
+         single effect on the list and it is a launch-geometry change, not a kernel rewrite.
+      2. **Split the shared path out of the block**, along the lines `path_tiled` already takes, so
+         the routed warps are not held by the W8 warp. `PathsPerBlock` there is constrained to
+         divide `kTopK + 1 = 9`, so 3 is the natural choice: 3-warp blocks give 16 blocks per SM and
+         100% theoretical occupancy, and the shared path stops gating eight finished warps.
+      3. **Over-fetch.** ncu measured 12.12 MB of DRAM traffic on d3 and 12.27 MB on d4 where #50's
+         artifact inventory attributes **8.91 MB** and **5.58 MB** of useful weight bytes — 1.36x
+         and **2.20x**. Confirm with `dram__bytes_read.sum` before optimising against it, since the
+         attribution and the ncu run are separate measurements.
+
+      Registers are *not* on that list, which is the correction: an earlier draft of this entry
+      claimed `Block Limit Registers = 5` was the constraint and that 32 registers per thread would
+      give 7 blocks per SM. At 288 threads it would give 7 by the register rule, but the warp rule
+      still caps it at 5, so the change would measure as exactly nothing. Read both limits before
+      believing either.
 
       Closing even half the gap to the contiguous kernels is still worth roughly 15-20% on the
-      recommended model. The order to try things is now: registers, then d3's wave tail, then the
-      over-fetch.
+      recommended model, and nothing here has been attempted yet.
 
       Not yet collected: the contiguous-kernel reference from the same elevated run.
       `admin-profile.ps1` passed `-k 'regex:a|b'` and PowerShell parsed the `|` as a pipe, so that

--- a/TODO.md
+++ b/TODO.md
@@ -568,6 +568,20 @@ roofline finally acquired a denominator; read them before the rest.
       entries, and neither the wider direct route nor a routing change gets it — that was measured
       and refused, see §3.
 
+      **The 35B MoE is now measured on the same curve, and it scales worse: 3.22x at eight lanes.**
+      164.4 / 273.2 / 400.0 / 529.7 tok/s at C1/2/4/8, same harness and settings. That is the
+      opposite of what "the MoE is work-starved at one token, so a cohort should fill the machine"
+      predicts, and the reason is worth carrying here: **a dense model amortises its weight read
+      across the cohort, an MoE with per-token routing does not.** Each token brings its own top-8
+      of 256, so the expected distinct routed experts per round goes 8.0 / 15.8 / 30.5 / **57.4** —
+      7.18x the routed weight bytes for 8x the tokens. Only the shared expert and the dense layers
+      amortise at all. §3's MoE entry has the full working.
+
+      So the 3.6x here and the 3.22x there have different causes and want different fixes, which is
+      worth knowing before anyone treats "batched decode should be nearly free" as a general rule.
+      On the dense 27B it nearly should be, and the gap is the narrow-extent kernels below. On the
+      MoE it should not be, and no kernel work changes that.
+
       Two notes on how this entry used to read. The numbers it quoted (C1 78.71 vs C8 250.26 tok/s)
       came from README's cohort table, which is end-to-end **with MTP3 enabled** — tokens per round
       is roughly `1 + 3 x acceptance` rather than 1, so dividing them into a bandwidth figure gives
@@ -827,28 +841,69 @@ ceiling, and neither has had any optimisation attempted.
       written for the multi-token path and takes a `tokens` argument; single-token decode does not
       use it.
 
-      So the order to try things, revised:
+      So the order to try things, revised — and the first item is a refutation of the obvious fix.
 
-      1. **Give d3 a grid that tiles 82 SMs.** Its 512 blocks are `kIntermediate`, a power of two,
-         and 410 slots is not — any power-of-two block count tiles 82 badly. This is the largest
-         single effect on the list and it is a launch-geometry change, not a kernel rewrite.
-      2. **Split the shared path out of the block**, along the lines `path_tiled` already takes, so
-         the routed warps are not held by the W8 warp. `PathsPerBlock` there is constrained to
-         divide `kTopK + 1 = 9`, so 3 is the natural choice: 3-warp blocks give 16 blocks per SM and
-         100% theoretical occupancy, and the shared path stops gating eight finished warps.
-      3. **Over-fetch.** ncu measured 12.12 MB of DRAM traffic on d3 and 12.27 MB on d4 where #50's
+      1. **Launch geometry does not help, and no block shape does.** d3's 512 blocks over 82 SMs at
+         5 blocks each is 410 slots, which reads like a fixable tiling problem. It is not: total
+         work is 512 columns x 9 warp-paths = **4,608 warp-units against the card's 3,936 warp
+         slots**, so the kernel is only **1.17 machine-fulls of work** and every partitioning gives
+         two waves. Efficiency `N / (slots x ceil(N/slots))` comes out at 62.4% for 9-warp blocks,
+         58.5% for 3-warp, 58.5% for 1-warp. There is no scheduling trick that makes a 1.17-full
+         kernel efficient. **d3 is not badly written; it is too small for this card at one token.**
+
+      2. **Batching does not rescue it either — measured, and this refuted a prediction.** If the
+         gather were merely work-starved, a cohort should fill the machine and the MoE should scale
+         *better* with concurrency than a dense model. Measured 2026-09-09, mtp0, int8 KV, 512
+         decode tokens, both models through `run_serve_concurrency.py`:
+
+         | C | 35B MoE tok/s | vs C1 | 27B dense tok/s | vs C1 |
+         |---|---|---|---|---|
+         | 1 | 164.4 | 1.00x | 36.8 | 1.00x |
+         | 2 | 273.2 | 1.66x | 61.1 | 1.66x |
+         | 4 | 400.0 | 2.43x | 101.0 | 2.75x |
+         | 8 | 529.7 | **3.22x** | 132.9 | **3.62x** |
+
+         The MoE scales *worse*, and the reason is structural rather than a kernel defect. **A dense
+         model amortises its weight read across the cohort — the same bytes serve every lane — but
+         an MoE with per-token routing does not.** Each token brings its own top-8 of 256, so the
+         expected number of distinct routed experts a round must read grows almost linearly with
+         the cohort: 8.0 at C1, 15.8 at C2, 30.5 at C4, **57.4 at C8** — `7.18x` the routed weight
+         bytes for `8x` the tokens. Only the shared expert and the dense layers amortise. The
+         marginal cost per added row bears it out: 1.29 ms/row on a 6.08 ms base for the MoE (21%
+         of base) against 4.71 ms/row on 27.20 ms for the dense model (17%).
+
+         This is worth stating plainly because it is the opposite of the usual intuition about
+         batching, and it means **the 35B's ~51% of achievable is not a bug to be fixed by
+         batching or by tiling.** It is what top-8-of-256 routing costs on a card whose per-layer
+         MoE work is a single machine-full.
+
+      3. **Split the shared path out of the block.** This one still stands, and the source already
+         names it: the shared W8 path is heavier than a routed Q4 path, the block cannot retire
+         until all nine warps finish, and eight completed routed warps sit holding warp slots while
+         warp 8 drains — which is the 44.6% / 58.6% "no eligible warp" reading directly.
+         `sparse_moe_d3_path_tiled_kernel` in the same file exists for exactly this and says so:
+         *"Three path CTAs per token/output row expose enough blocks for the 170-SM target and keep
+         the heavier shared W8 path from holding eight completed routed warps resident."* It is
+         written for the multi-token path and takes a `tokens` argument; single-token decode does
+         not use it. This does not add work to the machine, so item 1 does not apply — it removes a
+         serialisation inside a block that is already resident.
+
+      4. **Over-fetch.** ncu measured 12.12 MB of DRAM traffic on d3 and 12.27 MB on d4 where #50's
          artifact inventory attributes **8.91 MB** and **5.58 MB** of useful weight bytes — 1.36x
-         and **2.20x**. Confirm with `dram__bytes_read.sum` before optimising against it, since the
-         attribution and the ncu run are separate measurements.
+         and **2.20x**. If real, d4 moves over twice the bytes it needs and that is worth more than
+         anything else here. Confirm with `dram__bytes_read.sum` before optimising against it,
+         since the attribution and the ncu run are separate measurements.
 
       Registers are *not* on that list, which is the correction: an earlier draft of this entry
       claimed `Block Limit Registers = 5` was the constraint and that 32 registers per thread would
       give 7 blocks per SM. At 288 threads it would give 7 by the register rule, but the warp rule
-      still caps it at 5, so the change would measure as exactly nothing. Read both limits before
-      believing either.
+      caps it at 5 regardless, so the change would measure as exactly nothing. Read both limits
+      before believing either.
 
-      Closing even half the gap to the contiguous kernels is still worth roughly 15-20% on the
-      recommended model, and nothing here has been attempted yet.
+      What is left after all that is items 3 and 4 — a block-level serialisation and a possible 2x
+      over-fetch — not the 15-20% "close half the gap to the contiguous kernels" this entry used to
+      promise. That framing compared an 8-of-256 gather against kernels that stream contiguous
+      weights, and items 1 and 2 are why that comparison was never going to close.
 
       Not yet collected: the contiguous-kernel reference from the same elevated run.
       `admin-profile.ps1` passed `-k 'regex:a|b'` and PowerShell parsed the `|` as a pipe, so that

--- a/TODO.md
+++ b/TODO.md
@@ -757,29 +757,84 @@ The two entries below are the largest identified speed opportunities in the repo
 out of #53's profile and #50's byte accounting, both have a measured gap against a measured
 ceiling, and neither has had any optimisation attempted.
 
-- [ ] **The MoE expert gather runs at 40-45% of the card's read bandwidth while contiguous weight
-      kernels on the same decode step reach 78-82%.** This is the single biggest number left in
-      this file. Measured (#53), bytes attributed from the artifact inventory:
+- [ ] **The MoE expert gather is latency-bound, not divergence-bound or bandwidth-bound.** Still
+      the biggest number left in this file, but it now has a cause. `ncu` counters collected
+      2026-09-09 via `scripts/sweeps/admin-profile.ps1` (elevated; the counters are
+      administrator-only on Windows and that was the whole blocker), 35B, int8 KV, decode, clocks
+      locked at 1,500 MHz, `--graph-profiling node`:
 
-      | kernel | bytes | time | achieved | % of achievable |
-      |---|---:|---:|---:|---:|
-      | `sparse_moe_d3_nine_warp` (routed gate_up, 8/256) | 8.91 MB | 23.4 µs | 381 GB/s | **44.6%** |
-      | `sparse_moe_d4_nine_warp` (routed down, 8/256) | 5.58 MB | 16.4 µs | 340 GB/s | **39.9%** |
-      | `w8_k2048_decode` (gdn qkv_z, contiguous) | 26.74 MB | 38.2 µs | 700 GB/s | 81.9% |
-      | `q6_rowsplit_gemm_simt` (output head, contiguous) | 397.31 MB | 595.6 µs | 667 GB/s | 78.1% |
+      | | `d3_nine_warp` (gate_up) | `d4_nine_warp` (down) |
+      |---|---|---|
+      | duration | 28.45 µs | 25.18 µs |
+      | memory throughput | 425.9 GB/s (**49.9%** of achievable) | 487.5 GB/s (**57.1%**) |
+      | DRAM throughput | 46.79% | 53.56% |
+      | compute (SM) throughput | 35.69% | 36.55% |
+      | **avg. active threads per warp** | **31.11 / 32** | **29.06 / 32** |
+      | L1/TEX hit rate | 31.67% | 87.58% |
+      | L2 hit rate | 5.89% | 15.96% |
+      | **schedulers with no eligible warp** | **44.57%** | **58.63%** |
+      | eligible warps per scheduler | 1.62 (of 8.28 active) | 1.13 (of 10.25 active) |
+      | achieved / theoretical occupancy | 60.16% / 93.75% | 78.91% / 93.75% |
+      | **block limit: registers** | **5** | **5** |
+      | block limit: shared memory | 12 | 7 |
+      | registers per thread | 36 | 40 |
+      | waves per SM | **1.25** | 5.00 |
 
-      The four `sparse_moe` stages are **38% of decode busy time** on the 35B, and that model sits
-      at ~51% of achievable overall against the dense 27B's ~66-70%. A further **15.5%** of its
-      decode window is GPU idle between kernels (corrected in #60 from the 12.6% first reported),
-      which its mean kernel duration of 12.3 µs against the 27B's 40.3 µs explains: the MoE
-      launches three times as many, three times shorter, so per-launch overhead lands three times
-      as hard. Eight scattered expert blocks
-      per layer per token is the shape; whether the cost is address divergence, L2 behaviour, or
-      too little work per CTA to cover the latency is unknown — `ncu` would say, and is installed
-      but has no `ncu.exe` at the expected path (see the tooling entry in §3).
+      This entry listed three candidate causes. The counters settle all three.
 
-      Closing even half the gap between the expert kernels and the contiguous ones is worth
-      roughly 15-20% on the recommended model. Nothing here has been tried.
+      **Address divergence — ruled out.** 31.11 and 29.06 active threads per warp out of 32. The
+      8-of-256 expert selection happens at *block* granularity, so lanes within a warp still walk
+      one expert's weights contiguously. There is no lane divergence to fix, and that was the
+      leading hypothesis.
+
+      **L2 behaviour — real, inherent, and not a bug.** 5.89% and 15.96% hit rates are close to
+      zero reuse, but an expert's weights are read once per token and there is nothing to hit. No
+      tuning recovers this; it is what top-8-of-256 costs.
+
+      **Too little work in flight — confirmed, and this is the answer.** Neither DRAM (46.79/53.56%)
+      nor SM (35.69/36.55%) is anywhere near saturated, which is the textbook signature. The
+      schedulers say it directly: **no warp is eligible to issue 44.6% of cycles on d3 and 58.6% on
+      d4**, with only 1.1-1.6 eligible warps per scheduler against 8-10 resident. Warps are there
+      and stalled, not absent.
+
+      **The binding constraint is registers, and the arithmetic is small.** Both kernels report
+      `Block Limit Registers = 5` against a shared-memory limit of 12 and 7 — so registers, not
+      shared memory, is what caps blocks per SM. At 288 threads per block:
+
+      | registers/thread | registers/block | blocks/SM |
+      |---|---|---|
+      | 40 (d4 today) | 11,520 | 5 |
+      | 36 (d3 today) | 10,368 | 6 |
+      | 32 | 9,216 | 7 |
+      | 28 | 8,064 | 8 |
+
+      Getting d3 to 32 and d4 to 32 would take both from 5 blocks to 7 — **+40% more warps resident
+      to hide the same latency**, without touching the algorithm. That is a `__launch_bounds__` and
+      register-pressure exercise, which is the cheapest thing on this list and should be tried
+      first.
+
+      **d3 has a second, independent problem: 1.25 waves per SM.** 512 blocks against 82 SMs at 5
+      blocks each is 410 block slots, so the grid fills the machine once and the *tail wave is a
+      quarter full*. d4 runs 2,048 blocks (5.00 waves) and is correspondingly healthier on every
+      occupancy metric. Splitting d3's work into more, smaller blocks would remove the tail; this is
+      separate from the register question and both apply.
+
+      **One more thing the counters exposed: over-fetch.** ncu measured 12.12 MB of DRAM traffic on
+      d3 and 12.27 MB on d4, where #50's artifact inventory attributes **8.91 MB** and **5.58 MB**
+      of useful weight bytes — 1.36x and **2.20x**. Some of that is sector granularity on a gather
+      that lands on 8 scattered blocks, and it means the effective bandwidth figures above flatter
+      the kernels: d4 moves 2.2x the bytes it needs. Worth confirming with
+      `dram__bytes_read.sum` directly before optimising against it, since the byte attribution and
+      the ncu run are different measurements.
+
+      Closing even half the gap to the contiguous kernels is still worth roughly 15-20% on the
+      recommended model. The order to try things is now: registers, then d3's wave tail, then the
+      over-fetch.
+
+      Not yet collected: the contiguous-kernel reference from the same elevated run.
+      `admin-profile.ps1` passed `-k 'regex:a|b'` and PowerShell parsed the `|` as a pipe, so that
+      half produced only an error. Fixed in the script; re-run it to get the local baseline these
+      percentages are compared against.
 
 - [ ] **Prefill's MLP GEMMs run at ~30% of the card's INT8 tensor-core rate**, and the obvious
       excuse for that has been measured and ruled out.
@@ -957,51 +1012,51 @@ ceiling, and neither has had any optimisation attempted.
       different winners, which is documented at the top of `schedule_sweep.cuh`. The point is that
       a narrow cold-flush margin is a reason to profile, not a decision.
 
-- [ ] **The 315 W power cap binds continuously, but it does not touch memory clock — so most of
-      this file is unaffected.** Measured 2026-09-09 with `scripts/sweeps/power-and-clocks.ps1`,
-      which samples `nvidia-smi` at 2 Hz through a 27B `tg1024` decode and a `pp8192` prefill,
-      int8 KV. Three runs, medians and full ranges over busy samples (utilization > 50%):
+- [x] **The 315 W power cap costs nothing measurable. Closed 2026-09-09.** Measured both ways with
+      `scripts/sweeps/power-and-clocks.ps1`, and then at 350 W from an elevated shell:
 
-      | | decode (162-168 samples) | prefill (52-53 samples) |
+      | | 315 W (cap) | 350 W (default) |
       |---|---|---|
-      | board power | 314 W median | 314 W median |
-      | `sw_power_cap` active | **161-168 of 162-168** | **51-52 of 52-53** |
-      | SM clock | **1,500-1,515 MHz** median | **1,635-1,650 MHz** median |
-      | memory clock | **9,501 MHz in every sample** | **9,501 MHz in every sample** |
-      | temperature | 63-74 °C median, 75 max | 68-76 °C median, 77 max |
-      | thermal throttle | **0 samples, all runs** | **0 samples, all runs** |
+      | decode `tg1024` | 37.16-37.55 tok/s | **37.15 tok/s** |
+      | prefill `pp8192` | 1,204-1,255 tok/s | **1,228.5 tok/s** |
+      | decode SM clock | 1,500-1,515 MHz median | 1,545 MHz median |
+      | prefill SM clock | 1,635-1,650 MHz median | 1,680 MHz median |
+      | memory clock | 9,501 MHz, every sample | 9,501 MHz, every sample |
+      | board power | 314 W median | 342-349 W median |
+      | `sw_power_cap` active | 161-168 of 162-168 | **161 of 163** |
+      | thermal throttle | 0 samples | 0 samples |
 
-      The cap is genuinely and permanently binding — power pins within 1 W of the limit whenever
-      the card is busy — and it is the *only* thing throttling. No thermal slowdown appears in any
-      sample of any run, at any temperature reached.
+      **+35 W (+11% of budget) buys +3% SM clock and 0% throughput, in both phases.** Decode is
+      identical to within 0.4%; prefill is inside its own run-to-run spread. So the cap can stay
+      where it is, and every number in this file stands without an asterisk.
 
-      What it costs is a narrower question than this entry assumed. **Memory never leaves 9,501 MHz
-      in either phase, in any run**, which is the full 19 Gbps spec, so every bandwidth number in
-      this file — the 854.2 GB/s achievable figure, the decode roofline, the whole of §2c's decode
-      analysis — is measured at unthrottled memory and the cap does not bound it. SM clock is what
-      pays: decode sits about 11% below the 3090's 1,695 MHz rated boost, prefill about 3%. Decode
-      is bandwidth-bound so 11% of SM clock buys little there, and prefill — the phase where SM
-      clock would matter — is the phase where the cap costs least.
+      Why it costs nothing is the useful part. The memory clock **never leaves 9,501 MHz** — the
+      full 19 Gbps spec — at either power limit, in any sample of any run. Decode is
+      bandwidth-bound, so SM clock is not what it is waiting for; prefill is the phase where SM
+      clock could matter and it is the phase the cap squeezes least (1,635 vs 1,680 MHz, 2.8%).
+      Nothing was ever thermally throttled either, at any temperature reached, up to 80 °C.
 
-      The compute ratios are self-cancelling: prefill's "~30% of INT8 MMA peak" (§2c) divides a
-      capped measurement by a ceiling probe run under the same cap, so lifting the limit moves
-      numerator and denominator together.
+      Note the cap is still *binding* at 350 W — `sw_power_cap` is active in 161 of 163 busy
+      samples there too — so this is not "the cap stopped mattering", it is "this workload does not
+      convert board power into throughput". Lifting to the 400 W maximum would not change that
+      conclusion for decode, which cannot go faster than its memory clock allows.
 
-      **Careful with the maxima.** Individual samples reach 1,740-1,935 MHz on both phases. Those
-      are the first sample or two of a run, before the cap clamps a cold card, and quoting one as a
-      steady clock is wrong — the first version of this script reported `Measure-Object -Average`
-      under a column labelled "median" and that is exactly the mistake it invites. This entry
-      previously claimed the SM clock "swings 1,665-1,755 MHz"; both ends of that are wrong for
-      steady state in either phase.
+      The compute ratios were self-cancelling as predicted: prefill's "~30% of INT8 MMA peak"
+      divides a capped measurement by a ceiling probe run under the same cap.
 
-      **Still open, and still needs an elevated shell.** `nvidia-smi -pl 350` is refused with
-      "Insufficient Permissions" from this session, re-confirmed 2026-09-09, so the residual
-      question stands: what would the missing 35 W buy on prefill? With SM clock already at 97% of
-      rated boost there, the honest prior is "very little" — but that is a prediction. Re-run the
-      script after `-pl 350` to settle it. The second half of this entry is the more valuable one:
-      `nvidia-smi -lgc` to lock clocks would collapse the 3-5% between-process spread that made the
-      27B hard to read this cycle, and that spread is now known to be the largest source of noise
-      in every end-to-end comparison here (see §3's cold-flush entry).
+      Also corrects the figures this entry originally carried. It claimed the SM clock "swings
+      1,665-1,755 MHz"; steady state is 1,500-1,515 on decode and 1,635-1,650 on prefill at 315 W.
+      Individual samples do reach 1,905-1,935 MHz, but only in the first sample or two before the
+      cap clamps a cold card — the first draft of the sampling script reported
+      `Measure-Object -Average` under a column labelled "median", which is exactly how a boost
+      spike gets quoted as a steady clock, so it now takes a real median and says why.
+
+      **Still worth doing, and not blocked on anything: `nvidia-smi -lgc` for measurement runs.**
+      The 3-5% between-process spread is now the largest source of noise in every end-to-end
+      comparison here. It forced the DFlash2 tile A/B to interleave the two binaries within each
+      repetition rather than run one build then the other, and it made an earlier comparison need a
+      control column to be readable at all. That is a measurement-hygiene fix, not a performance
+      one, and it is independent of the power limit.
 
 - [ ] **`compute-sanitizer` cannot launch this repository's test binaries.** It reports "Target
       application doesn't exist or is not a valid executable" for `ninfer_*_test.exe` — absolute

--- a/scripts/sweeps/admin-profile.ps1
+++ b/scripts/sweeps/admin-profile.ps1
@@ -82,9 +82,15 @@ try {
 
   # A contiguous kernel from the same step, as the reference the percentages above are against.
   # Without it the MoE numbers have no local baseline and have to be compared across runs.
+  #
+  # One kernel pattern, not an alternation. The first version passed -k 'regex:a|b' and PowerShell
+  # parsed the | as a pipeline separator before ncu ever saw it, so the invocation became
+  # "ncu ... regex:a" piped into a command named b. It died with "'b' is not recognized as an
+  # internal or external command" and wrote an empty report -- which reads like an ncu problem and
+  # is not one. Single pattern, via --kernel-name.
   "== 2/3 ncu: contiguous reference kernels (27B, int8, decode) -> $out\contiguous_ref.txt"
   & $Ncu --target-processes all --graph-profiling node `
-      -k 'regex:q5_rowsplit_gemv|q4_linear_swiglu_gemv_pair' --launch-skip 64 --launch-count 8 `
+      --kernel-name 'regex:q5_rowsplit_gemv' --launch-skip 64 --launch-count 8 `
       --section SpeedOfLight --section MemoryWorkloadAnalysis `
       --section MemoryWorkloadAnalysis_Tables --section Occupancy --section LaunchStats `
       $bench --weights $dense --kv-dtype int8 --max-ctx 8192 -n 64 -r 1 --warmup 1 `


### PR DESCRIPTION
Both results come from the elevated `ncu`/`nvidia-smi` run that `scripts/sweeps/admin-profile.ps1` exists to make possible. GPU performance counters are administrator-only on Windows, and that permission was the entire blocker on the biggest item in TODO.

## The MoE expert gather — §2c's largest item

35B, int8 KV, decode, clocks locked at 1,500 MHz, `--graph-profiling node`:

| | `d3_nine_warp` (gate_up) | `d4_nine_warp` (down) |
|---|---|---|
| duration | 28.45 µs | 25.18 µs |
| memory throughput | 425.9 GB/s (**49.9%** of achievable) | 487.5 GB/s (**57.1%**) |
| DRAM throughput | 46.79% | 53.56% |
| compute (SM) throughput | 35.69% | 36.55% |
| **avg. active threads per warp** | **31.11 / 32** | **29.06 / 32** |
| L1/TEX hit rate | 31.67% | 87.58% |
| L2 hit rate | 5.89% | 15.96% |
| **schedulers with no eligible warp** | **44.57%** | **58.63%** |
| eligible warps per scheduler | 1.62 (of 8.28 active) | 1.13 (of 10.25 active) |
| achieved / theoretical occupancy | 60.16% / 93.75% | 78.91% / 93.75% |
| **block limit: registers** | **5** | **5** |
| block limit: shared memory | 12 | 7 |
| registers per thread | 36 | 40 |
| waves per SM | **1.25** | 5.00 |

The entry listed three candidate causes. All three are now settled.

**Address divergence — ruled out**, and it was the leading hypothesis. 31.11 and 29.06 active threads per warp out of 32. The 8-of-256 selection happens at *block* granularity, so lanes within a warp still walk one expert's weights contiguously.

**L2 behaviour — real, inherent, not a bug.** 5.89% and 15.96% is near-zero reuse, but an expert's weights are read once per token and there is nothing to hit.

**Too little work in flight — confirmed.** Neither DRAM nor SM is near saturated, which is the signature, and the schedulers say it outright: no warp is eligible to issue **44.6%** of cycles on d3 and **58.6%** on d4, with 1.1–1.6 eligible warps per scheduler against 8–10 resident. Warps are resident and stalled, not absent.

**The binding constraint is registers, and the fix is small.** `Block Limit Registers = 5` for both, against shared-memory limits of 12 and 7. At 288 threads/block:

| registers/thread | registers/block | blocks/SM |
|---|---|---|
| 40 (d4 today) | 11,520 | 5 |
| 36 (d3 today) | 10,368 | 6 |
| 32 | 9,216 | 7 |
| 28 | 8,064 | 8 |

Getting both to 32 takes them from 5 blocks to 7 — **+40% more warps resident to hide the same latency**, without touching the algorithm. A `__launch_bounds__` and register-pressure exercise, and the cheapest thing to try first.

**d3 has a second, independent problem: 1.25 waves per SM.** 512 blocks against 82 SMs at 5 blocks each is 410 slots, so the grid fills the machine once and the tail wave is a quarter full. d4 runs 2,048 blocks (5.00 waves) and is healthier on every occupancy metric.

**Over-fetch, newly visible:** 12.12 MB of DRAM traffic on d3 and 12.27 MB on d4, where #50's artifact inventory attributes **8.91 MB** and **5.58 MB** of useful weight bytes — 1.36× and **2.20×**. Flagged as wanting `dram__bytes_read.sum` to confirm, since those are two different measurements.

Order to try things is now registers → d3's wave tail → over-fetch.

## The 315 W power cap — closed

| | 315 W (cap) | 350 W (default) |
|---|---|---|
| decode `tg1024` | 37.16–37.55 tok/s | **37.15 tok/s** |
| prefill `pp8192` | 1,204–1,255 tok/s | **1,228.5 tok/s** |
| decode SM clock | 1,500–1,515 MHz | 1,545 MHz |
| prefill SM clock | 1,635–1,650 MHz | 1,680 MHz |
| memory clock | 9,501 MHz every sample | 9,501 MHz every sample |
| `sw_power_cap` active | 161–168 of 162–168 | **161 of 163** |
| thermal throttle | 0 samples | 0 samples |

**+35 W buys +3% SM clock and 0% throughput.** Memory clock never leaves 9,501 MHz — the full 19 Gbps spec — at either limit, so decode isn't waiting on SM clock, and prefill (where it could matter) is the phase the cap squeezes least. The cap is still *binding* at 350 W, so this is not "the cap stopped mattering" but "this workload does not convert board power into throughput". The cap can stay, and every number in the file stands without an asterisk.

This also corrects the entry's own figures — it claimed the SM clock "swings 1,665–1,755 MHz"; steady state is 1,500–1,515 on decode. Samples do reach 1,905–1,935 MHz but only before the cap clamps a cold card.

The clock-lock half of that entry stays open: the 3–5% between-process spread is now the largest noise source in every end-to-end comparison here, and `nvidia-smi -lgc` would remove it.

## Also

Fixes `admin-profile.ps1`'s contiguous-reference run, which passed `-k 'regex:a|b'` and had PowerShell parse the `|` as a pipeline before ncu ever saw it — it failed with "'b' is not recognized as an internal or external command" and wrote an empty report, which reads like an ncu problem and isn't one.