### PR TITLE
compute-sanitizer and ncu both work — and one installed copy reports a false pass

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1132,19 +1132,47 @@ ceiling, and neither has had any optimisation attempted.
       control column to be readable at all. That is a measurement-hygiene fix, not a performance
       one, and it is independent of the power limit.
 
-- [ ] **`compute-sanitizer` cannot launch this repository's test binaries.** It reports "Target
-      application doesn't exist or is not a valid executable" for `ninfer_*_test.exe` — absolute
-      path, `.bat` wrapper and direct `.exe` all tried — while launching a small standalone CUDA
-      executable from the same shell without complaint. The test binaries are large (575 MB for
-      `ninfer_qwen3_6_27b_score_real_test.exe`) and statically link everything, which is the
-      obvious suspect but is unconfirmed.
+- [x] **`compute-sanitizer` and `ncu` both work. Closed 2026-09-09 — this entry was wrong about
+      both, and the way it was wrong is worth keeping.**
 
-      This cost real time: `initcheck` was the right tool for the fp8 corruption in #49 and could
-      not be pointed at it, so the diagnosis came from a `--cuda-graph-trace` timeline and a
-      hand-built reproducer instead. `ncu.exe` is also missing from the Nsight Compute 2025.1.0
-      install directory, so per-kernel occupancy and L2 counters — exactly what the MoE expert
-      gather in §2c needs next — are currently unavailable too. Worth half an hour to fix before
-      the next kernel investigation, not during one.
+      **`compute-sanitizer`: there are two copies installed and one of them lies.**
+
+      | copy | version | result on `ninfer_gdn_input_proj_test.exe` |
+      |---|---|---|
+      | `CUDA\v12.4\compute-sanitizer\` | 2024.1.0 | **exit 0, "ERROR SUMMARY: 0 errors", and the test never ran** |
+      | `CUDA\v12.8\compute-sanitizer\` | current | runs to completion, real test output, 0 errors |
+
+      The v12.4 copy produces two lines of output — the banner and a clean error summary — and exits
+      0 without executing a single line of the binary. **That is a false pass, which is worse than
+      the failure this entry described**: a sanitizer run that reports success having checked
+      nothing. The v12.8 copy runs everything. `compute-sanitizer` on `PATH` resolves to
+      `CUDA\v12.8\bin\compute-sanitizer.bat`, which is the good one, so an unqualified invocation is
+      fine — but an absolute path to the v12.4 directory is not, and that is presumably how this
+      went wrong.
+
+      Verified working on v12.8: `memcheck` and `initcheck` both run `ninfer_gdn_input_proj_test`
+      and `ninfer_linear_swiglu_fp8_test` to completion, 0 errors. **`initcheck` also runs clean on
+      `ninfer_softmax_attention_test`, which is the Op #49 fixed** — the exact investigation this
+      entry says had to be done by hand instead.
+
+      Size is not the problem either. The 598 MB
+      `ninfer_qwen3_6_27b_score_real_test.exe` this entry named launches fine; it skips because
+      `NINFER_QWEN3_6_27B_WEIGHTS` is unset, and compute-sanitizer then says *"Target application
+      terminated before first instrumented API call"* — which is a consequence of the test making
+      no CUDA calls, not a launch failure. That message is easy to read as one.
+
+      **`ncu`: present, and the blocker was a permission, not a missing file.** The entry says
+      "`ncu.exe` is also missing from the Nsight Compute 2025.1.0 install directory". True as
+      written and misleading: the launcher is `ncu.bat` at the top of that directory, with the
+      binary under `target\windows-desktop-win7-x64\`. It runs. What actually stopped it is
+      `ERR_NVGPUCTRPERM` — **GPU performance counters are administrator-only by default on
+      Windows** — which is a permission, fixable per-run by an elevated shell with nothing
+      persistent and no reboot. `scripts\sweeps\admin-profile.ps1` exists for that and produced
+      §2c's MoE counters on the first try.
+
+      The lesson for the next investigation: when a tool appears not to work, check whether a
+      second copy is shadowing it and whether the failure is a permission. Neither of the two
+      things this entry called broken was broken.
 
 - [ ] **The perplexity harness drifts 0.019% from the published figures and nobody knows why.**
       Re-measuring all six KV formats (#63) moved the three formats #49 does not touch by

--- a/tests/README.md
+++ b/tests/README.md
@@ -86,10 +86,11 @@ statistics still drive the normal verdict. Passing tests remain quiet without it
 Invoke it unqualified so `PATH` resolves it:
 
 ```bash
-compute-sanitizer --tool initcheck --error-exitcode 9   build/tests/ninfer_softmax_attention_test
+compute-sanitizer --tool initcheck --error-exitcode 9 \
+  build/tests/ninfer_softmax_attention_test
 ```
 
-**Do not call the copy under `CUDA12.4\compute-sanitizer\` by absolute path.** Two copies are
+**Do not call the copy under `CUDA/v12.4/compute-sanitizer/` by absolute path.** Two copies are
 installed on a typical toolkit layout, and the 2024.1.0 one in v12.4 prints its banner and
 `ERROR SUMMARY: 0 errors`, exits 0, and **never executes the binary** — a clean report having
 checked nothing. `PATH` resolves `compute-sanitizer` to the v12.8 launcher, which is the working

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,6 +80,34 @@ Every participating comparison emits one `OP_ERROR_STATS` record containing the 
 actual error, active limit, and error-to-limit ratio. The switch changes reporting only; the same
 statistics still drive the normal verdict. Passing tests remain quiet without it.
 
+## Running a test under compute-sanitizer
+
+`memcheck` and `initcheck` both work on these binaries, including the large statically linked ones.
+Invoke it unqualified so `PATH` resolves it:
+
+```bash
+compute-sanitizer --tool initcheck --error-exitcode 9   build/tests/ninfer_softmax_attention_test
+```
+
+**Do not call the copy under `CUDA12.4\compute-sanitizer\` by absolute path.** Two copies are
+installed on a typical toolkit layout, and the 2024.1.0 one in v12.4 prints its banner and
+`ERROR SUMMARY: 0 errors`, exits 0, and **never executes the binary** — a clean report having
+checked nothing. `PATH` resolves `compute-sanitizer` to the v12.8 launcher, which is the working
+one, so the unqualified form above is safe.
+
+Two messages that look like failures and are not:
+
+- *"Target application terminated before first instrumented API call"* — the test made no CUDA
+  calls, usually because it skipped for a missing `NINFER_*_WEIGHTS` environment variable. Set the
+  variable, or pick a test that does not need one.
+- A single `-k 'regex:a|b'`-style argument disappearing in PowerShell: `|` is parsed as a pipeline
+  before the tool sees it. One pattern per invocation.
+
+`ncu` needs one thing more: GPU performance counters are administrator-only by default on Windows
+and it fails with `ERR_NVGPUCTRPERM` otherwise. Run it from an elevated shell — that satisfies the
+permission per-run, with nothing persistent and no reboot.
+`scripts/sweeps/admin-profile.ps1` does this for the profiles the maintainer notes reference.
+
 The variable-width DFlash2 target-attention subset can be run with
 `./build/tests/ninfer_softmax_attention_test --dflash2-only`. It covers D256/Q24/KV4 across all five
 cache codecs, W=2..16, B=1..8, request-local prefixes, cache effects, and Graph metadata/input


### PR DESCRIPTION
Closes TODO §3's tooling item, which claimed `compute-sanitizer` could not launch this repo's test binaries and that `ncu.exe` was missing. Neither is true, and **how** each was wrong is the part worth keeping.

## compute-sanitizer: two copies are installed and one lies

| copy | version | result on `ninfer_gdn_input_proj_test.exe` |
|---|---|---|
| `CUDA/v12.4/compute-sanitizer/` | 2024.1.0 | **exit 0, `ERROR SUMMARY: 0 errors`, and the test never ran** |
| `CUDA/v12.8/compute-sanitizer/` | current | runs to completion, real test output, 0 errors |

The v12.4 copy emits two lines — banner and a clean error summary — and exits 0 without executing a single line of the binary. **That's a false pass, which is worse than the failure the entry described:** a sanitizer reporting success having checked nothing.

`compute-sanitizer` on `PATH` resolves to `CUDA/v12.8/bin/compute-sanitizer.bat`, the good one, so an unqualified invocation was always fine. An absolute path into the v12.4 directory is not, and that is presumably how this went wrong.

Verified on v12.8: `memcheck` and `initcheck` both run `ninfer_gdn_input_proj_test` and `ninfer_linear_swiglu_fp8_test` to completion with 0 errors. **`initcheck` also runs clean on `ninfer_softmax_attention_test`** — the Op #49 fixed, i.e. the exact investigation the entry says had to be done by hand with a `--cuda-graph-trace` timeline instead.

Size wasn't the problem either. The 598 MB `ninfer_qwen3_6_27b_score_real_test.exe` the entry named launches fine; it skips for an unset `NINFER_QWEN3_6_27B_WEIGHTS`, and compute-sanitizer then reports *"Target application terminated before first instrumented API call"* — a consequence of the test making no CUDA calls, not a launch failure. It reads like one.

## ncu: present, and the blocker was a permission

The entry says "`ncu.exe` is also missing from the Nsight Compute 2025.1.0 install directory". True as written and misleading — the launcher is `ncu.bat` at the top of that directory with the binary under `target/`. It runs. What actually stopped it is `ERR_NVGPUCTRPERM`: GPU performance counters are administrator-only by default on Windows. That's fixable per-run from an elevated shell, with nothing persistent and no reboot, which is what `scripts/sweeps/admin-profile.ps1` does — and it produced §2c's MoE counters on the first try.

## Also

Adds a `Running a test under compute-sanitizer` section to `tests/README.md` so the next person finds this before spending the half hour the entry budgeted: how to invoke it, why not to use the v12.4 path, and the two messages that look like failures and aren't.

The lesson, recorded in the closed entry: when a tool appears broken, check whether a second copy is shadowing it and whether the failure is a permission. Neither of the two things called broken here was broken.