### PR TITLE
Measure what Vision costs: the encoder is not the expensive part

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -635,10 +635,60 @@ roofline finally acquired a denominator; read them before the rest.
       prefill chunk. Sweeping `--prefill-chunk` against this ceiling is the obvious next step and
       has not been done.
 
-- [ ] **Vision has essentially one performance number in the entire repository.** One acceptance
-      figure for DFlash2 on the committed image fixture, and nothing about encode throughput,
-      how it scales with resolution, or what the overlay residency costs in time rather than in
-      bytes. It is an advertised feature of both models and it is unmeasured.
+- [x] **Vision now has numbers. Closed 2026-09-09**, and the headline is that the encoder is not
+      the expensive part. `scripts/sweeps/vision-encode-throughput.ps1`; 27B, int8 KV, one image per
+      request, two measured repetitions per point. `apps/ninfer` reports the Vision stage separately
+      from text prefill, so encode cost is read directly rather than subtracted out.
+
+      | side | image tokens | encode (resident) | tok/ms | encode (overlay) | overlay penalty | text prefill | prefill / encode |
+      |---:|---:|---:|---:|---:|---:|---:|---:|
+      | 224 | 85 | 15.1 ms | 5.65 | 36.5 ms | +143% | 206 ms | 13.7x |
+      | 448 | 217 | 27.2 ms | 7.98 | 50.3 ms | +85% | 316 ms | 11.6x |
+      | 672 | 462 | 56.0 ms | **8.26** | 85.0 ms | +52% | 568 ms | 10.2x |
+      | 896 | 805 | 112.0 ms | 7.19 | 128.0 ms | +14% | 964 ms | 8.6x |
+      | 1120 | 1246 | 181.5 ms | 6.87 | 228.0 ms | +26% | 1,100 ms | 6.1x |
+      | 1344 | 1785 | 300.0 ms | 5.95 | 342.0 ms | +14% | 1,700 ms | 5.7x |
+      | 1568 | 2422 | 475.0 ms | 5.10 | 513.0 ms | +8% | 2,100 ms | 4.4x |
+
+      **Prefilling the image tokens costs 4.4-13.7x what encoding them does.** That is the number
+      to know before optimising anything here: at 1024px a single image is ~173 ms of encode against
+      ~945 ms of text prefill, so the Vision tower is ~15% of time-to-first-token and the other 85%
+      is the ordinary prefill path already covered by §2c's prefill entries. Vision needs no special
+      optimisation attention until that changes.
+
+      **Encode throughput peaks at 672px and falls 38% by 1568px** — 8.26 down to 5.10 tok/ms.
+      Against the 672px peak, encode time is superlinear in tokens: 1.01x at 672, 1.21x at 1120,
+      1.40x at 1344, **1.64x at 1568**. That is the shape attention inside the tower predicts, and
+      it means very large images are charged twice — more tokens, each more expensive. Small images
+      are also inefficient (1.48x at 224px) but for the opposite reason: 85 tokens does not fill the
+      machine.
+
+      **Overlay residency costs a roughly fixed ~30 ms per request, not a proportional one, and
+      saves 250.7 MiB.** Runtime reservation is 848.0 MiB resident against 597.3 MiB overlay. The
+      penalty is +143% at 224px and **+8% at 1568px** because the tower crosses PCIe once per
+      request whatever the image size. So overlay is close to free on large images and expensive on
+      small ones — the opposite of the intuition that a bigger image costs more to overlay. The
+      release launchers default to overlay, which these numbers support for the image sizes anyone
+      actually sends.
+
+      **Encode is exactly linear in image count**, and the overlay penalty is paid once per request
+      rather than once per image. Overlay, 1024px fixtures:
+
+      | images | tokens | encode | tok/ms | vs 1 image |
+      |---:|---:|---:|---:|---:|
+      | 1 | 1,045 | 173.0 ms | 6.04 | 1.00x |
+      | 2 | 2,071 | 352.0 ms | 5.88 | **2.03x** |
+      | 4 | 4,123 | 691.5 ms | 5.96 | **4.00x** |
+
+      So batching images into one request is neither better nor worse per token than sending them
+      separately, except that it amortises the one-off overlay crossing. Nothing here needs a
+      per-image cache.
+
+      One measurement trap the script documents: **resolutions are not free-form.** The
+      preprocessor snaps to a multiple of the merged patch size, so nearby resolutions can produce
+      identical token counts and a naive sweep shows plateaus that look like measurement error. The
+      sides above are multiples of 112 for that reason, and the token count is printed beside every
+      row so a plateau is visible rather than mysterious.
 
 - [x] **DFlash2 makes the 27B *slower*, and no document says so.** Wrong, and closed 2026-09-09.
       On text DFlash2 is a **win at every draft count from 1 to 12**. The entry's own premise came

--- a/scripts/sweeps/README.md
+++ b/scripts/sweeps/README.md
@@ -33,12 +33,21 @@ about three hours for twelve model/format combinations.
 | `decode-step-profile.ps1` | Where does a decode step's time go -- occupancy, launch gaps, or bandwidth? | a few min |
 | `power-and-clocks.ps1` | Does the 315 W cap bound these numbers? | a few min |
 | `admin-profile.ps1` | Everything needing an elevated shell: `ncu` counters, and what 350 W buys | a few min |
+| `vision-encode-throughput.ps1` | What does Vision cost in time, and what does overlay residency cost? | 20 min |
 
 `decode-roofline.ps1` needs no GPU: it reads the CSVs `kv-decode-vs-depth.ps1` leaves behind and
 divides achieved bandwidth by peak. Run that sweep first. Note it only means anything for the
 **dense** model -- applied to the A3B MoE it returns 391% of peak, which is not a result but a
 demonstration that the formula does not hold there, since an MoE never reads its resident weights
 per token. See TODO section 2c.
+
+`vision-encode-throughput.ps1` needs a vision-capable artifact and nothing else. It resizes the
+committed `bench/fixtures/ttft/media` photograph rather than generating synthetic images, because a
+flat image compresses trivially and a random one defeats every cache, and neither is
+representative. The headline it produces: **prefilling an image's tokens costs 4.4-13.7x what
+encoding them does**, so the Vision tower is about 15% of time-to-first-token at 1024px and is not
+where to look for a win. Watch for plateaus in the token count -- the preprocessor snaps to a
+multiple of the merged patch size, so nearby resolutions can produce identical token counts.
 
 **`admin-profile.ps1` must be run from an administrator shell** and refuses to start otherwise.
 It is the only script here that does. `ncu` fails with `ERR_NVGPUCTRPERM` as a normal user because

--- a/scripts/sweeps/vision-encode-throughput.ps1
+++ b/scripts/sweeps/vision-encode-throughput.ps1
@@ -1,0 +1,125 @@
+# What does Vision cost, in time?
+#
+# TODO section 2c: "Vision has essentially one performance number in the entire repository" -- one
+# DFlash2 acceptance figure on the committed image fixture, and nothing about encode throughput,
+# how it scales with resolution, or what overlay residency costs in time rather than in bytes.
+# This measures those three.
+#
+# It works because apps/ninfer reports the Vision stage separately from text prefill:
+#
+#   generate    vision                          134 ms
+#   generate    text prefill                    912 ms
+#
+# so the encode cost is directly readable rather than having to be subtracted out of a total. The
+# `prompt tokens` line gives the token count the image turned into, and tokens/ms of vision stage
+# is the throughput figure this entry wanted.
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\vision-encode-throughput.ps1
+#
+# About 20 minutes. Prints CSV to stdout and leaves per-run logs under $NINFER_SWEEP_OUT.
+#
+# Two things to know before reading the output.
+#
+# **Resolutions are not free-form.** The preprocessor snaps an image to a multiple of the merged
+# patch size, so 1000x1000 and 1024x1024 can produce the same token count. The sweep uses exact
+# multiples of 112 (four merged 28px patches) so each step is a clean change in token count rather
+# than a rounding artifact, and it prints the token count beside every row so a plateau is visible
+# rather than mysterious.
+#
+# **The first run of any configuration pays one-off costs** -- weight load dominates wall time and
+# the Vision tower's first use may allocate. Every point here runs the model fresh, so compare the
+# `vision_ms` column across rows and ignore `total`; and the sweep takes two measured repetitions
+# per point and reports both, because a single number here cannot be distinguished from a hiccup.
+$ErrorActionPreference = 'Continue'
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
+
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+$cli      = '.\build-ninja\apps\ninfer.exe'
+$model    = "$modelDir\qwen3_8_27b.ninfer"
+$source   = 'bench\fixtures\ttft\media\load_00.png'
+New-Item -ItemType Directory -Force -Path "$out\vision" | Out-Null
+foreach ($p in @($cli, $model, $source)) {
+  if (-not (Test-Path $p)) { throw "missing: $p" }
+}
+
+# Resize the committed fixture rather than generating synthetic noise: a real photograph exercises
+# the encoder's arithmetic the way production does, and flat or random images can both be
+# unrepresentative (one compresses trivially, the other defeats every cache).
+$py = @'
+import sys
+from PIL import Image
+src, dst, side = sys.argv[1], sys.argv[2], int(sys.argv[3])
+Image.open(src).convert("RGB").resize((side, side), Image.LANCZOS).save(dst)
+'@
+$pyPath = Join-Path $out 'vision\resize.py'
+Set-Content -Path $pyPath -Value $py -Encoding UTF8
+
+$sides = @(224, 448, 672, 896, 1120, 1344, 1568)
+foreach ($side in $sides) {
+  $dst = "$out\vision\img_$side.png"
+  if (-not (Test-Path $dst)) { python $pyPath $source $dst $side }
+}
+
+function Invoke-Point {
+  param([string]$Label, [string]$MessagesPath, [string[]]$Extra, [int]$Rep)
+  $log = "$out\vision\$Label`_$Rep.log"
+  & $cli $model --messages $MessagesPath --max-new 8 --max-context 8192 `
+      --kv-dtype int8 --no-thinking @Extra > "$log.txt" 2> $log
+  if ($LASTEXITCODE -ne 0) { return $null }
+  $t = Get-Content $log -Raw
+  $ms = { param($n)
+    if ($t -match "generate\s+$n\s+([\d.]+)\s*(ms|s)\b") {
+      if ($Matches[2] -eq 's') { [double]$Matches[1] * 1000 } else { [double]$Matches[1] }
+    } else { $null } }
+  [pscustomobject]@{
+    vision_ms  = & $ms 'vision'
+    prefill_ms = & $ms 'text prefill'
+    tokens     = if ($t -match 'prompt tokens\s+(\d+)') { [int]$Matches[1] } else { $null }
+    runtime    = if ($t -match 'runtime reservation\s+([\d.]+)\s*(\w+)') { "$($Matches[1]) $($Matches[2])" } else { '' }
+  }
+}
+
+# One image, sweeping resolution, at both residencies. Residency is the "what does overlay cost in
+# time" question: it keeps the Vision tower in host memory and borrows device memory per image, so
+# the tower has to cross PCIe on every request and the cost should land in the vision stage.
+"config,side,rep,image_tokens,vision_ms,text_prefill_ms,tokens_per_ms,runtime_reservation"
+foreach ($residency in @('resident', 'overlay')) {
+  foreach ($side in $sides) {
+    $msgs = "$out\vision\msg_$side.json"
+    $abs  = (Resolve-Path "$out\vision\img_$side.png").Path
+    $payload = @{ role = 'user'; content = @(
+        @{ type = 'image'; image = $abs },
+        @{ type = 'text';  text  = 'Describe this image in one sentence.' }) }
+    ConvertTo-Json @($payload) -Depth 6 | Set-Content -Path $msgs -Encoding UTF8
+    for ($rep = 1; $rep -le 2; $rep++) {
+      $r = Invoke-Point -Label "r$residency`_$side" -MessagesPath $msgs `
+          -Extra @('--vision', '--vision-residency', $residency) -Rep $rep
+      if ($null -eq $r) { "$residency,$side,$rep,,FAILED,,,"; continue }
+      $tpm = if ($r.vision_ms -and $r.vision_ms -gt 0) { '{0:N2}' -f ($r.tokens / $r.vision_ms) } else { '' }
+      "$residency,$side,$rep,$($r.tokens),$($r.vision_ms),$($r.prefill_ms),$tpm,$($r.runtime)"
+    }
+  }
+}
+
+# Several images in one request, at the resolution the fixtures ship at. Encode cost should be
+# linear in images if the tower is the bottleneck and sublinear if per-request overhead dominates;
+# either answer is worth having, and neither is recorded anywhere.
+foreach ($count in @(1, 2, 4)) {
+  $msgs = "$out\vision\msg_multi_$count.json"
+  $parts = @()
+  for ($i = 0; $i -lt $count; $i++) {
+    $abs = (Resolve-Path ("bench\fixtures\ttft\media\load_{0:d2}.png" -f $i)).Path
+    $parts += @{ type = 'image'; image = $abs }
+  }
+  $parts += @{ type = 'text'; text = 'Describe these images in one sentence.' }
+  ConvertTo-Json @(@{ role = 'user'; content = $parts }) -Depth 6 |
+      Set-Content -Path $msgs -Encoding UTF8
+  for ($rep = 1; $rep -le 2; $rep++) {
+    $r = Invoke-Point -Label "multi$count" -MessagesPath $msgs `
+        -Extra @('--vision', '--vision-residency', 'overlay') -Rep $rep
+    if ($null -eq $r) { "multi-$count,1024,$rep,,FAILED,,,"; continue }
+    $tpm = if ($r.vision_ms -and $r.vision_ms -gt 0) { '{0:N2}' -f ($r.tokens / $r.vision_ms) } else { '' }
+    "multi-$count,1024,$rep,$($r.tokens),$($r.vision_ms),$($r.prefill_ms),$tpm,$($r.runtime)"
+  }
+}


### PR DESCRIPTION
Closes TODO §2c's Vision item, which said Vision had *"essentially one performance number in the entire repository"* — one DFlash2 acceptance figure and nothing about encode throughput, resolution scaling, or what overlay residency costs in time rather than bytes. Adds a sweep and all three.

It works because `apps/ninfer` reports the Vision stage separately from text prefill, so encode cost is read directly rather than subtracted out of a total.

27B, int8 KV, one image per request, two measured repetitions per point:

| side | image tokens | encode (resident) | tok/ms | encode (overlay) | overlay penalty | text prefill | prefill / encode |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 224 | 85 | 15.1 ms | 5.65 | 36.5 ms | +143% | 206 ms | 13.7× |
| 448 | 217 | 27.2 ms | 7.98 | 50.3 ms | +85% | 316 ms | 11.6× |
| 672 | 462 | 56.0 ms | **8.26** | 85.0 ms | +52% | 568 ms | 10.2× |
| 896 | 805 | 112.0 ms | 7.19 | 128.0 ms | +14% | 964 ms | 8.6× |
| 1120 | 1246 | 181.5 ms | 6.87 | 228.0 ms | +26% | 1,100 ms | 6.1× |
| 1344 | 1785 | 300.0 ms | 5.95 | 342.0 ms | +14% | 1,700 ms | 5.7× |
| 1568 | 2422 | 475.0 ms | 5.10 | 513.0 ms | +8% | 2,100 ms | 4.4× |

## Prefilling an image's tokens costs 4.4–13.7× what encoding them does

That's the number to know before optimising anything here. At 1024px a single image is ~173 ms of encode against ~945 ms of text prefill, so the Vision tower is **~15% of time-to-first-token** and the other 85% is the ordinary prefill path §2c already covers. Vision needs no special optimisation attention until that changes.

## Encode peaks at 672px and falls 38% by 1568px

8.26 → 5.10 tok/ms. Against the 672px peak, encode time is superlinear in tokens: 1.01× at 672, 1.21× at 1120, 1.40× at 1344, **1.64× at 1568** — the shape attention inside the tower predicts. Large images are charged twice: more tokens, each more expensive. Small images are inefficient too (1.48× at 224px) for the opposite reason — 85 tokens doesn't fill the card.

## Overlay costs a fixed ~30 ms, not a proportional one, and saves 250.7 MiB

Runtime reservation is 848.0 MiB resident against 597.3 MiB overlay. The penalty is +143% at 224px and **+8% at 1568px**, because the tower crosses PCIe once per request whatever the image size — the opposite of the intuition that a bigger image costs more to overlay. The release launchers default to overlay, and these numbers support that for the sizes anyone actually sends.

## Encode is exactly linear in image count

Overlay, 1024px fixtures — and the overlay crossing is paid once per *request*, not once per image:

| images | tokens | encode | tok/ms | vs 1 image |
|---:|---:|---:|---:|---:|
| 1 | 1,045 | 173.0 ms | 6.04 | 1.00× |
| 2 | 2,071 | 352.0 ms | 5.88 | **2.03×** |
| 4 | 4,123 | 691.5 ms | 5.96 | **4.00×** |

So batching images is neither better nor worse per token than separate requests, beyond amortising that one crossing. Nothing here needs a per-image cache.

## One trap the script documents

**Resolutions are not free-form.** The preprocessor snaps to a multiple of the merged patch size, so nearby resolutions produce identical token counts and a naive sweep shows plateaus that look like measurement error. Sides are multiples of 112 for that reason, and the token count is printed beside every row so a plateau is visible rather than mysterious.

It also resizes the committed fixture photograph rather than generating synthetic images — a flat image compresses trivially, a random one defeats every cache, and neither is representative.