### PR TITLE
Say what --host-kv-mib 8192 actually gets on each platform

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1610,18 +1610,38 @@ shape the entries described.
       occurrences. Device-side `__FILE__` from nvcc's own frontend is not covered either -- there
       is no documented flag for it.
 
-- [ ] **The shipped `-maxctx` launchers ask for a host-KV pin they cannot have.**
-      `run-qwen38-c1-maxctx` and `run-qwen36-35b-a3b-c1-maxctx`, both `.bat` and `.sh`, pass
-      `--host-kv-mib 8192` explicitly, and both deliberately fill the card with KV. Per the
-      measured table above, at that residency the largest pin that succeeds on Windows is a small
-      fraction of 8 GiB — they could never have had it, before or after #45. Since #45 the request
-      is clamped rather than fatal, so the launchers do work; they are asking for something
-      impossible and the flag reads as though it were doing something.
+- [x] **The shipped `-maxctx` launchers ask for a host-KV pin they cannot have. Closed 2026-09-09 —
+      by documenting it, because the behaviour is right and the flag is not.**
 
-      Decide what they should say. A realistic figure, or drop the flag and take the clamped
-      default, or `--no-prefix-reuse` if prefix reuse is not worth any VRAM at maximum context —
-      which is a real question at these residencies and has not been measured either. Whichever
-      way, the four launchers should agree with each other and with README's launcher table.
+      All four launchers pass `--host-kv-mib 8192` and they already agree with each other, so the
+      "make them agree" half of this entry was moot. What they do *not* do is agree across
+      platforms, and nothing said so. The clamp is `#if defined(_WIN32)` only:
+
+      | launcher | platform | free after startup | pinned host KV |
+      |---|---|---:|---:|
+      | `run-qwen38-c1-maxctx.sh` | Linux | — | **8,192 MiB**, honoured in full |
+      | `run-qwen36-35b-a3b-c1-maxctx.sh` | Linux | — | **8,192 MiB**, honoured in full |
+      | `run-qwen38-c1-maxctx.bat` | Windows | 1.59 GiB | **302 MiB** |
+      | `run-qwen36-35b-a3b-c1-maxctx.bat` | Windows | 184-344 MiB | **0 — none at all** |
+
+      `clamp_host_kv_reservation_bytes` takes `(free VRAM − 1 GiB) / 2`, so the 35B maxctx profile
+      falls entirely under the 1 GiB floor and the flag is a **complete no-op** there. On the 27B it
+      delivers 3.7% of what it asks for.
+
+      **The three options this entry offered were all based on a wrong premise, which is why none of
+      them was right.** It assumed the pin competes with context — "both deliberately fill the card
+      with KV". It does not. The clamp reads `cudaMemGetInfo` *after* the KV cache is allocated
+      (`program_impl.h:1030`), so the pin takes from the slack that is left over and **costs no
+      context at all**. A realistic figure would be wrong on the next machine, dropping the flag
+      changes nothing because the default is also 8192, and `--no-prefix-reuse` would trade away
+      something that is currently free.
+
+      So the behaviour needs no change and the flag needs no correction — it is right on Linux and
+      harmless on Windows. What was wrong is that a reader had no way to know any of that. Each of
+      the four launchers now carries the measured table above and states plainly, on the Windows
+      side, not to read "8192" as a description of the machine; and on the Linux side, that the same
+      flag really does pin 8 GiB of host RAM there and why the platforms differ from identical
+      arguments.
 
 ---
 

--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.bat
@@ -171,7 +171,24 @@ echo Cache: 8 shared / 8 private / 32 host states  ^|  automatic prefix grid on
 echo API: http://%HOST%:%PORT%/v1
 echo.
 
+rem WHAT --host-kv-mib 8192 ACTUALLY GETS ON WINDOWS, which is not 8 GiB. WDDM maps a pinned host
+rem allocation into the GPU's address space and charges it against the card, so the runtime clamps
+rem the request to (free VRAM - 1 GiB) / 2 before the first cudaMallocHost -- it cannot ask and back
+rem off, because one failure poisons every later attempt in the process. At this profile's measured
+rem residency that resolves to:
+
 rem --- Profile A: speculation on. ~240 tok/s decode. ---
+rem
+rem   launcher                        free after startup   pinned host KV
+rem   -------------------------------------------------------------------
+rem   run-qwen38-c1-maxctx (this)           1.59 GiB           302 MiB
+rem   run-qwen36-35b-a3b-c1-maxctx        184-344 MiB        0 -- none at all
+rem
+rem The flag is kept rather than corrected because it is right on the .sh launchers, where Linux
+rem pins the full 8 GiB of host RAM, and because it is harmless here: the clamp takes what is
+rem actually free after the KV cache is allocated, so it costs no context, and prefix reuse falls
+rem back to device pages when the pin is zero. Do not read "8192" as a description of this machine.
+
 "%SERVER%" "%MODEL%" ^
   --host %HOST% --port %PORT% ^
   --max-concurrency 1 ^

--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
@@ -127,6 +127,12 @@ printf 'Qwen3.6-35B-A3B  |  C%s  |  context %s  |  KV pool %s  |  rk8v4  |  %s  
 printf 'Cache: 8 shared / 8 private / 32 host states  |  automatic prefix grid on\n'
 printf 'API: http://%s:%s/v1\n\n' "$HOST" "$PORT"
 
+# --host-kv-mib 8192 is honoured in full here: on Linux this really does pin 8 GiB of host RAM, and
+# it is host RAM, not device memory. The Windows launchers pass the same number and get far less --
+# WDDM charges a pinned host allocation against the card, so the runtime clamps to
+# (free VRAM - 1 GiB) / 2 and the 27B profile ends up with 302 MiB while the 35B gets none at all.
+# That is why the two platforms behave differently from identical flags; see the note in the .bat.
+
 exec "$server" "$MODEL" \
   --host "$HOST" --port "$PORT" \
   --max-concurrency "$CONCURRENCY" \

--- a/scripts/run-qwen38-c1-maxctx.bat
+++ b/scripts/run-qwen38-c1-maxctx.bat
@@ -79,6 +79,22 @@ echo Cache: 8 shared / 8 private / 32 host states  ^|  automatic prefix grid on
 echo API: http://%HOST%:%PORT%/v1
 echo.
 
+rem WHAT --host-kv-mib 8192 ACTUALLY GETS ON WINDOWS, which is not 8 GiB. WDDM maps a pinned host
+rem allocation into the GPU's address space and charges it against the card, so the runtime clamps
+rem the request to (free VRAM - 1 GiB) / 2 before the first cudaMallocHost -- it cannot ask and back
+rem off, because one failure poisons every later attempt in the process. At this profile's measured
+rem residency that resolves to:
+rem
+rem   launcher                        free after startup   pinned host KV
+rem   -------------------------------------------------------------------
+rem   run-qwen38-c1-maxctx (this)           1.59 GiB           302 MiB
+rem   run-qwen36-35b-a3b-c1-maxctx        184-344 MiB        0 -- none at all
+rem
+rem The flag is kept rather than corrected because it is right on the .sh launchers, where Linux
+rem pins the full 8 GiB of host RAM, and because it is harmless here: the clamp takes what is
+rem actually free after the KV cache is allocated, so it costs no context, and prefix reuse falls
+rem back to device pages when the pin is zero. Do not read "8192" as a description of this machine.
+
 "%SERVER%" "%MODEL%" ^
   --host %HOST% --port %PORT% ^
   --max-concurrency %CONCURRENCY% ^

--- a/scripts/run-qwen38-c1-maxctx.sh
+++ b/scripts/run-qwen38-c1-maxctx.sh
@@ -100,6 +100,12 @@ printf 'Qwen3.8-27B  |  C%s  |  context %s  |  KV pool %s  |  %s  |  %s  |  %s\n
 printf 'Cache: 8 shared / 8 private / 32 host states  |  automatic prefix grid on\n'
 printf 'API: http://%s:%s/v1\n\n' "$HOST" "$PORT"
 
+# --host-kv-mib 8192 is honoured in full here: on Linux this really does pin 8 GiB of host RAM, and
+# it is host RAM, not device memory. The Windows launchers pass the same number and get far less --
+# WDDM charges a pinned host allocation against the card, so the runtime clamps to
+# (free VRAM - 1 GiB) / 2 and the 27B profile ends up with 302 MiB while the 35B gets none at all.
+# That is why the two platforms behave differently from identical flags; see the note in the .bat.
+
 exec "$server" "$MODEL" \
   --host "$HOST" --port "$PORT" \
   --max-concurrency "$CONCURRENCY" \


### PR DESCRIPTION
Closes TODO §6's launcher item, which said the `-maxctx` launchers *"ask for a host-KV pin they cannot have"* and asked for a decision between three options.

**All three options rested on a wrong premise, which is why none of them was right.** The premise was that the pin competes with context — *"both deliberately fill the card with KV"*. It doesn't: `clamp_host_kv_reservation_bytes` reads `cudaMemGetInfo` **after** the KV cache is allocated (`program_impl.h:1030`), so the pin takes from leftover slack and **costs no context at all**. A realistic hardcoded figure would be wrong on the next machine; dropping the flag changes nothing because the default is also 8192; and `--no-prefix-reuse` would trade away something currently free.

The four launchers also already agree with each other, so that half of the item was moot. What they *don't* do is agree across platforms, because the clamp is  only — and nothing said so:

| launcher | platform | free after startup | pinned host KV |
|---|---|---:|---:|
| `run-qwen38-c1-maxctx.sh` | Linux | — | **8,192 MiB**, honoured in full |
| `run-qwen36-35b-a3b-c1-maxctx.sh` | Linux | — | **8,192 MiB**, honoured in full |
| `run-qwen38-c1-maxctx.bat` | Windows | 1.59 GiB | **302 MiB** |
| `run-qwen36-35b-a3b-c1-maxctx.bat` | Windows | 184–344 MiB | **0 — none at all** |

`(free VRAM − 1 GiB) / 2` puts the 35B maxctx profile entirely under the 1 GiB floor, so **the flag is a complete no-op there**; the 27B gets 3.7% of what it asks for.

## What this changes

Nothing functional. The behaviour is right and the flag needs no correction — it's correct on Linux and harmless on Windows. What was wrong is that a reader had no way to know any of it.

Each of the four launchers now carries that table and states plainly: on the Windows side, not to read "8192" as a description of the machine; on the Linux side, that the same flag really does pin 8 GiB of host RAM there, and why identical arguments behave differently across platforms.

## Checks

Comments only — no flag or behaviour changes. Both `.sh` files still pass `bash -n`, and neither note sits inside a `^`-continued `cmd` command (verified with a continuation scanner; the only `rem`-inside-continuation hits are the pre-existing commented-out "Profile B" block in the 35B launcher).