### PR TITLE
Rule out memory and dequantization for prefill's MLP GEMMs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1049,6 +1049,35 @@ ceiling, and neither has had any optimisation attempted.
       are the target. The MLP pair is 68% of prefill FLOPs, which makes this the largest
       compute-side opportunity in the file.
 
+      **Two more explanations ruled out 2026-09-09, both analytically, which narrows this to the MMA
+      pipeline itself.** Working from the chunk-640 profile — `q4a8_swiglu` takes 1,212.20 ms over
+      512 calls, so 2.368 ms per call at the 27B's `34,816 x 5,120` MLP shape with 640 columns:
+
+      | | |
+      |---|---:|
+      | work | 228.2 GOP |
+      | weights read | 94.7 MB (4-bit codes plus one FP16 scale per 64) |
+      | activations | 47.8 MB |
+      | achieved | **96.4 TOPS = 31%** of the 314.8 TOPS ceiling |
+      | compute floor at the ceiling | 0.725 ms |
+      | memory floor at 854.2 GB/s | 0.167 ms |
+
+      **Not memory.** The kernel is compute-bound over its own memory floor by **4.3x** at this
+      shape, so no amount of bandwidth work touches it. Worth stating because "30% of peak" invites
+      the assumption that something is starving.
+
+      **Not dequantization.** Unpacking every one of the 178M 4-bit codes costs 0.020 ms at 2 int
+      ops per code, 0.040 ms at 4, and 0.080 ms at 8 — **1%, 2% and 3% of the 2.368 ms call**,
+      against the 3090's 17.8 T int-op/s CUDA-core rate. Even a pessimistic unpack cannot account
+      for a 69% shortfall. This was the natural next hypothesis after the tile-shape one and it is
+      also wrong.
+
+      So the gap is inside the MMA pipeline: issue rate, shared-memory feeding, or occupancy, and
+      those three need counters to separate. `scripts/sweeps/admin-profile.ps1` now collects them
+      (section 3 of that script, `ComputeWorkloadAnalysis` and `InstructionStats` alongside the
+      usual occupancy and scheduler sections) — it needs one elevated run, since GPU performance
+      counters are administrator-only on Windows.
+
       Two small things fall out. The default chunk of 1,024 is 1.0% off the plateau, so 2,048 is
       free throughput *if* the extra workspace is affordable — worth checking against the memory
       model in `docs/config-calculator.html` before changing a default. And 256 costs 6.9%, which

--- a/scripts/sweeps/admin-profile.ps1
+++ b/scripts/sweeps/admin-profile.ps1
@@ -66,7 +66,7 @@ try {
   nvidia-smi -lgc 1500 2>&1 | Out-String | Write-Host
   if ($LASTEXITCODE -eq 0) { $clocksLocked = $true }
 
-  "== 1/3 ncu: MoE expert gather (35B, int8, decode) -> $out\moe_gather.txt"
+  "== 1/4 ncu: MoE expert gather (35B, int8, decode) -> $out\moe_gather.txt"
   & $Ncu --target-processes all --graph-profiling node `
       -k 'regex:sparse_moe' --launch-skip 64 --launch-count 12 `
       --section SpeedOfLight --section MemoryWorkloadAnalysis `
@@ -88,7 +88,7 @@ try {
   # "ncu ... regex:a" piped into a command named b. It died with "'b' is not recognized as an
   # internal or external command" and wrote an empty report -- which reads like an ncu problem and
   # is not one. Single pattern, via --kernel-name.
-  "== 2/3 ncu: contiguous reference kernels (27B, int8, decode) -> $out\contiguous_ref.txt"
+  "== 2/4 ncu: contiguous reference kernels (27B, int8, decode) -> $out\contiguous_ref.txt"
   & $Ncu --target-processes all --graph-profiling node `
       --kernel-name 'regex:q5_rowsplit_gemv' --launch-skip 64 --launch-count 8 `
       --section SpeedOfLight --section MemoryWorkloadAnalysis `
@@ -97,7 +97,29 @@ try {
       > "$out\contiguous_ref.txt" 2>&1
   "  ncu exit $LASTEXITCODE"
 
-  # ---------------------------------------------------------------- 2. what the power cap costs
+  # ---------------------------------------------------------------- 3. prefill's MLP GEMMs
+  #
+  # TODO section 2c: q4a8_swiglu reaches 96-97 TOPS against a measured 314.8 TOPS INT8 ceiling, so
+  # 31%, where a well-tuned large GEMM on Ampere usually reaches 60-80%. Two explanations have
+  # already been ruled out without counters -- it is not a skinny-tile artifact (chunk 256..4,096
+  # moves prefill 1.0%) and it is not dequantization (unpacking every 4-bit code costs 1-3% of the
+  # call even at 8 int ops per code). It is also not memory: at this shape the kernel is
+  # compute-bound over its memory floor by 4.3x.
+  #
+  # So the gap is inside the MMA pipeline, and these sections are what distinguishes the remaining
+  # candidates: issue rate, shared-memory feeding, and occupancy. The MLP pair is 68% of prefill
+  # FLOPs, which makes it the largest compute-side opportunity in the file.
+  "== 3/4 ncu: prefill MLP GEMMs (27B, int8, prefill) -> $out\prefill_mlp.txt"
+  & $Ncu --target-processes all --graph-profiling node `
+      --kernel-name 'regex:q4a8_swiglu' --launch-skip 8 --launch-count 6 `
+      --section SpeedOfLight --section MemoryWorkloadAnalysis --section Occupancy `
+      --section LaunchStats --section SchedulerStats --section WarpStateStats `
+      --section ComputeWorkloadAnalysis --section InstructionStats `
+      $bench --weights $dense --kv-dtype int8 --max-ctx 8192 -p 4096 -r 1 --warmup 1 `
+      > "$out\prefill_mlp.txt" 2>&1
+  "  ncu exit $LASTEXITCODE"
+
+  # ---------------------------------------------------------------- 4. what the power cap costs
   #
   # TODO section 3: the 315 W cap binds in essentially every busy sample, but memory clock never
   # leaves 9,501 MHz, so the bandwidth figures are already unthrottled and the prediction is that
@@ -105,7 +127,7 @@ try {
   # first -- a locked clock would hide exactly the effect being looked for.
   if (-not $SkipPower) {
     if ($clocksLocked) { nvidia-smi -rgc 2>&1 | Out-Null; $clocksLocked = $false }
-    "== 3/3 power limit 350 W -> $out\power_350.txt"
+    "== 4/4 power limit 350 W -> $out\power_350.txt"
     nvidia-smi -pl 350 2>&1 | Out-String | Write-Host
     if ($LASTEXITCODE -eq 0) {
       $powerChanged = $true


### PR DESCRIPTION
§2c had already ruled out the skinny-tile excuse for `q4a8_swiglu` running at 31% of the INT8 MMA ceiling and concluded *"the shortfall is in the kernels"*. Two more candidates fall analytically, which narrows it usefully — and both were the natural next guesses.

From the chunk-640 profile: `q4a8_swiglu` takes 1,212.20 ms over 512 calls, so **2.368 ms per call** at the 27B's `34,816 × 5,120` MLP shape with 640 columns.

| | |
|---|---:|
| work | 228.2 GOP |
| weights read | 94.7 MB (4-bit codes + one FP16 scale per 64) |
| activations | 47.8 MB |
| achieved | **96.4 TOPS = 31%** of the 314.8 TOPS ceiling |
| compute floor at the ceiling | 0.725 ms |
| memory floor at 854.2 GB/s | 0.167 ms |

## Not memory

The kernel is compute-bound over its own memory floor by **4.3×** at this shape, so no amount of bandwidth work touches it. Worth stating explicitly, because "30% of peak" invites the assumption that something is starving.

## Not dequantization

Unpacking all 178M 4-bit codes costs **0.020 ms at 2 int ops per code, 0.040 ms at 4, 0.080 ms at 8** — 1%, 2% and 3% of the 2.368 ms call, against the 3090's 17.8 T int-op/s CUDA-core rate. Even a pessimistic unpack cannot account for a 69% shortfall.

## What's left

The gap is inside the MMA pipeline: **issue rate, shared-memory feeding, or occupancy**. Those three need counters to separate, so this extends `scripts/sweeps/admin-profile.ps1` with a third profile covering exactly that — `ComputeWorkloadAnalysis` and `InstructionStats` alongside the occupancy and scheduler sections — so one elevated run answers it. (GPU performance counters are administrator-only on Windows; see the closed tooling entry in §3.)

Docs plus the script section; no behaviour change.