### PR TITLE
The narrow-extent MMA tile was built for q5_linear_add and it is worse — a negative result

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -562,6 +562,36 @@ roofline finally acquired a denominator; read them before the rest.
       C8 is the profile the 27B release recommends for multi-user serving, and all three dominant
       families sit at 1.9-2.5x their T=1 cost for 8x the rows.
 
+      **The narrow-extent MMA kernel was built and it is worse. Measured 2026-09-09.** Added an
+      `R64C8` to `q5_linear_add` — `BlockCols` 8 with `WarpCols` 8, so one warp column, 4 warps and
+      128 threads against C16's 8 and 256 — on exactly the reasoning above. It loses to `c16` at
+      every width tested (us, medians of 21-31, k=6144):
+
+      | T | 2 | 4 | 6 | 8 | 10 | 16 |
+      |---|---:|---:|---:|---:|---:|---:|
+      | `c8` | 131.1 | 116.7 | 115.7 | 108.5 | 133.1 | 126.0 |
+      | `c16` | 114.7 | 103.4 | 102.4 | 102.4 | 103.4 | 95.2 |
+      | `split2_exact` | 36.9 | 44.0 | 56.3 | 76.8 | 96.3 | — |
+
+      6-32% worse than `c16`, and still far behind `split2_exact` below 11. Same story at k=17408.
+      Reverted; the route table is unchanged and the schedule is not registered. The numbers are
+      recorded in `src/ops/linear_add/q5/q5_linear_add_plan.cpp` beside the table so it is not
+      retried.
+
+      **Why it fails here and works elsewhere is the transferable part.** The same change succeeds
+      on the GDN input projection — C8 and C16 beat C32 by 9-11% there, and that shipped. The
+      difference is what dominates each kernel. The GDN projection's cost is padded MMA work, so
+      cutting `BN` cuts real work. `q5_linear_add` is already weight-read-bound: `c16` sits at 24%
+      of the 25.3 µs its weight costs to stream once, so cutting `BN` removes no work and halves
+      the warps available to hide the read. **Narrowing a tile helps when padding is the cost and
+      hurts when bandwidth is** — and this Op is the second kind.
+
+      So the 4x between `c16` and the weight-streaming floor is real and still worth having, but it
+      is not a tile-width problem and the prize stated above is not reachable that way. What
+      `rk8v4` proves in §2c's KV entry applies here too: something reaches a much larger fraction of
+      the floor at narrow extents, so the ceiling is not the obstacle — but the mechanism is not
+      tile geometry.
+
       **Part of this is now attributed.** §3's DFlash2 cliff entry chased the same kernel from the
       other direction and landed on `rowsplit_grouped_mma_kernel`, which is 13.78 ms of the 56.29 ms
       C8 round here. It is the GDN input projection, and at C8 it runs the `{{7, 32}}` route from

--- a/src/ops/linear_add/q5/q5_linear_add_plan.cpp
+++ b/src/ops/linear_add/q5/q5_linear_add_plan.cpp
@@ -50,6 +50,34 @@ constexpr std::array<SupportSpec, 2> kSupports{{
 // The T=1 GEMV reaches 41.0 us, 62% of that floor. A narrow-extent kernel with c16's flatness at
 // the GEMV's efficiency is worth most of the C1-to-C8 scaling loss; see TODO section 2c.
 //
+// **A narrower tile than C16 does not help here, and that is not obvious.** Tried an R64C8 --
+// BlockCols 8 with WarpCols 8, so one warp column, 4 warps and 128 threads against C16's 8 and
+// 256 -- on the reasoning that a serving cohort of 8 and a k+1 verification round both land at
+// extents this narrow and should not pay for 16 padded columns. Measured 2026-09-09, cold,
+// medians of 21-31 (us):
+//
+//   T                   2      4      6      8     10     12     16
+//   k=6144   c8      131.1  116.7  115.7  108.5  133.1  133.1  126.0
+//            c16     114.7  103.4  102.4  102.4  103.4  102.4   95.2
+//            split2   36.9   44.0   56.3   76.8   96.3     --     --
+//   k=17408  c8         --  315.4     --  301.1     --     --  352.3
+//            c16        --  289.8     --  291.8     --     --  285.7
+//            split2     --  120.8     --  192.5     --     --     --
+//
+// c8 loses to c16 at every width and both lose to split2 below 11, so the route table is unchanged
+// and the schedule is not registered.
+//
+// The reason is worth keeping, because the same change *works* on the GDN input projection (see
+// q4_q5_gdn_input_plan.cpp, where C8 and C16 beat C32 by 9-11%). There, cost is dominated by
+// padded MMA work, so cutting BN cuts the work. Here the kernel is already weight-read-bound --
+// c16 sits at 24% of the 25.3 us this weight costs to stream once -- so cutting BN removes no
+// work and halves the warps available to hide the read. Narrowing a tile helps when padding is the
+// cost and hurts when bandwidth is.
+//
+// So TODO section 2c's stated prize -- "a narrow-extent MMA kernel that keeps mma_r64_c16's
+// flatness at the GEMV's fraction of bandwidth" -- is not reachable by narrowing BN. The 4x
+// between c16 and the weight-streaming floor is still there and still worth having; it just is not
+// a tile-width problem.
 // A tile narrower than the live extent repeats the whole weight pass per column slice, so
 // above 16 columns the 32-wide tile covers a decode round in one pass instead of two.
 // Measured on sm_86 with bench/ops/q5_linear_add_schedule_bench.cu, cold, medians of 9-15.


### PR DESCRIPTION
§2c's eight-lane entry named the prize as *"a narrow-extent MMA kernel that keeps `mma_r64_c16`'s flatness at the GEMV's fraction of bandwidth"*. I built it. It loses.

An `R64C8` — `BlockCols` 8 with `WarpCols` 8, so one warp column, 4 warps and 128 threads against C16's 8 and 256. Cold, medians of 21–31, k=6144 (µs):

| T | 2 | 4 | 6 | 8 | 10 | 16 |
|---|---:|---:|---:|---:|---:|---:|
| `c8` | 131.1 | 116.7 | 115.7 | 108.5 | 133.1 | 126.0 |
| `c16` | 114.7 | 103.4 | 102.4 | 102.4 | 103.4 | 95.2 |
| `split2_exact` | 36.9 | 44.0 | 56.3 | 76.8 | 96.3 | — |

**6–32% behind `c16` at every width**, and still far behind `split2_exact` below 11. Same story at k=17408 (301.1 vs 291.8 at T=8).

Reverted — the route table is unchanged and the schedule is not registered, so **this PR changes no behaviour.** The numbers go in the file beside the route table so it is not retried.

## Why it fails here and works elsewhere

The same change **succeeds** on the GDN input projection — C8 and C16 beat C32 by 9–11% there, and that shipped in #74/#77 for +5.7% on the C8 serving profile. So "narrow the tile" is not simply wrong; it is conditional.

The difference is what dominates each kernel:

- The GDN projection is dominated by **padded MMA work**. Cutting `BN` cuts real work, so it wins.
- `q5_linear_add` is already **weight-read-bound**: `c16` sits at **24% of the 25.3 µs** its weight costs to stream once. Cutting `BN` removes no work and **halves the warps available to hide the read**, so it loses.

**Narrowing a tile helps when padding is the cost and hurts when bandwidth is.** That is the rule worth carrying, and it is why two Ops that looked like the same problem needed opposite answers.

The 4× between `c16` and the weight-streaming floor is still real and still worth having — it just is not a tile-width problem, and the entry no longer claims it is.
