### PR TITLE
Rewrite TODO for handoff to another machine, and file three gaps found this cycle

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,23 +1,215 @@
 # TODO
 
-State as of 2026-09-09, after a correctness pass that closed nine items and found three defects
-nobody had filed.
+State as of 2026-09-09, at the end of a profiling pass that closed six more items and refuted five
+of its own hypotheses. **34 items closed, 17 open.** If you are picking this up on different
+hardware, read "Handing this off to another machine" below before anything else.
 
 Released: **v0.9.0-rtx3090** (Windows + Linux). Full suite **126/126** on this box.
 
-**The headline is that three of the six KV formats were quietly wrong.** fp8, nvfp4 and k8v4
-attention was missing a block barrier between `cp_wait<0>()` and a whole-tile shared-memory read,
-and it corrupted every prefill output column except the last — by up to 26 in logprob. Greedy
-decode reads only the last column, so generation stayed byte-identical and nothing noticed. Every
-published perplexity figure for those three formats was measured through it. See §5.
+**One speedup shipped this pass, and it was small and cheap.** The GDN input projection was routing
+everything from 7 to 32 columns through a 32-wide MMA tile; adding C8 and C16 tiles is worth
+**+5.7% on the C8 serving profile** (3 of 3 runs, arms not overlapping) and +5.3% on DFlash2 at four
+draft tokens. That is the only behaviour change; everything else this pass produced was measurement.
 
-**The decode roofline now has a denominator**, and it is not the one this file used for a cycle.
-The card sustains 854 GB/s on reads, not its advertised 936; and a token reads far less than
-`weights_capacity_bytes`. On that accounting the dense 27B sits at ~66-70% of achievable and the
-**35B MoE at ~51%, flat across depth** — the larger prize, on the recommended model. See §2c.
+**The five biggest opportunities are all now located rather than suspected**, and three of them
+turned out to be the opposite of what this file assumed:
 
-Every route table in the tree has been measured on sm_86; that work is finished. What remains is
-profiling, measurement debt, and coverage needing hardware this box does not have.
+- The **MoE expert gather** is latency-bound, not divergence-bound. 31.1 of 32 threads per warp are
+  active, so there is no divergence to fix; and neither tiling nor batching helps, because the
+  kernel is 1.17 machine-fulls of work and an MoE with per-token routing does not amortise its
+  routed weight read across a cohort — 8 tokens touch ~57 distinct experts, not 8. The 35B's ~51%
+  of achievable is what top-8-of-256 costs, not a bug.
+- The **KV decode falloff** is 3.21x the per-key cost in the decode attention kernel — 5.89 ns
+  against int8's 1.83 ns — and it belongs to the three formats that stage dequantized tiles in
+  shared memory. `KeyBlock` was not the difference.
+- **Prefill's MLP GEMMs** at 31% of INT8 peak are not limited by memory (compute-bound over their
+  own memory floor by 4.3x), tile shape, or dequantization (1-3% of the call). What is left needs
+  counters.
+- **Eight lanes** buy 3.83x, and the gap is a narrow-extent kernel that reaches 24% of its
+  weight-streaming floor. A narrower tile was built for it and lost.
+- The **315 W power cap costs nothing** — +35 W buys +3% SM clock and 0% throughput, because memory
+  clock never leaves 9,501 MHz at either limit.
+
+Two pieces of tooling were believed broken and were not: `compute-sanitizer` (two copies installed,
+and the older one reports `0 errors` without executing the binary) and `ncu` (a permission, not a
+missing file). Both now work; see §3.
+
+Every route table in the tree has been measured on sm_86 and every one of them has a schedule
+bench. What remains is four kernel problems, some measurement debt, and two items needing hardware
+or artifacts this box does not have.
+
+---
+
+## Handing this off to another machine
+
+Written 2026-09-09 for an agent picking this up on different hardware. The section after this one
+("Start here if you are new to this box") is about *this* box; read this one first, because it says
+which of that still applies.
+
+### What every number in this file is, and is not
+
+All of it is one machine: **RTX 3090, `sm_86`, 24,576 MiB, CUDA 12.8, MSVC 14.44.35207, Windows 11,
+board power capped at 315 W.** Three measured ceilings are used throughout and none of them is a
+datasheet figure:
+
+| ceiling | value | note |
+|---|---:|---|
+| achievable read bandwidth | **854.2 GB/s** | not the advertised 936.1; every roofline here divides by this |
+| INT8 MMA | **314.8 TOPS** | `tools/tensor_core_rate_probe.cu` |
+| BF16 MMA, f32 accumulate | **67.6 TFLOPS** | same probe |
+
+**Re-measure those three first on new hardware.** Every percentage in §2c is a ratio against them,
+and carrying them across cards would repeat exactly the mistake this fork found in upstream's
+inherited tables.
+
+**The 315 W cap does not need reproducing.** Measured both ways: at 350 W decode is 37.15 tok/s
+against 37.16-37.55 at 315 W, and prefill 1,228.5 against 1,204-1,255 — so +35 W buys +3% SM clock
+and 0% throughput. Memory clock never leaves 9,501 MHz at either limit, which is why. See §3.
+
+### What definitely does not transfer
+
+**Every route table in the tree was measured on `sm_86` and is expected to be wrong elsewhere.**
+That is not a caveat, it is the main finding of the last two cycles: upstream's tables were
+inherited from `sm_120` and were wrong here by up to 52.8%. The tables, each with its own schedule
+bench under `bench/ops/`:
+
+| route table | bench | boundaries |
+|---|---|---|
+| `src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp` | `q4_linear_swiglu_schedule_bench` | 1 / 2..24 / 25..40 / 41..48 / 49..∞ |
+| `src/ops/linear_add/q5/q5_linear_add_plan.cpp` | `q5_linear_add_schedule_bench` | 1 / 2..10 / 11..16 / 17..24 / 25.. / 104.. / 128..∞ |
+| `src/ops/attn_input_proj/q4_q5/q4_q5_attn_input_plan.cpp` | `q4_q5_attn_input_schedule_bench` | see file |
+| `src/ops/gdn_input_proj/q4_q5/q4_q5_gdn_input_plan.cpp` | `q4_q5_gdn_input_schedule_bench` | 1..6 / 7..8 / 9..16 / 17..32 / 33..64 / 65..∞ |
+| `src/ops/linear_pair/w8/…` (`w8_pair`) | `w8_pair_schedule_bench` | see file |
+| DFlash2 w8 | `w8_dflash2_schedule_bench` | see file |
+
+Every one of those benches takes `--tokens`, `--repeat`, `--warmup` and **`--spread`**. Use
+`--spread`: it prints `median min..p95` per cell, and a boundary is only decidable when the winner's
+p95 clears the runner-up's min. A boundary in §5 went unresolved for a cycle because the harness
+printed medians only.
+
+Two rules learned the hard way about those tables, both with worked numbers in the files:
+
+- **Narrowing a tile helps when padding is the cost and hurts when bandwidth is.** Adding C8/C16 to
+  the GDN input projection won 9-11% and shipped; the identical change to `q5_linear_add` lost 6-32%,
+  because that kernel is already at 24% of its weight-streaming floor and a narrower tile removes no
+  work while halving the warps hiding the read.
+- **Cold-flush margins overstate the win.** These benches flush 256 MiB through L2 per repetition,
+  which is the right default, but a margin measured that way is not a speedup — one 7.5% bench
+  margin was 2.4% in situ. §3 has the entry; confirm anything under ~5% with a profile.
+
+### What must be re-established before any of this is reproducible
+
+1. **Model artifacts.** Paths, sizes and which-is-which are in the next section. They are ~18-23 GB
+   each and are not in the repo. The real-model tests take them by environment variable; the
+   sweeps take `NINFER_MODEL_DIR`.
+2. **Build environment.** Windows needs the VS 2022 BuildTools `vcvars64.bat` shell; the recipe is
+   in the next section. `cmake --build --target A B` **silently builds only A** on this generator —
+   pass one `--target` per name or you will measure a stale binary. That mistake produced a
+   "verified" result against a binary four hours older than its source.
+3. **GPU performance counters, if you want `ncu`.** On Windows they are administrator-only and
+   `ncu` fails with `ERR_NVGPUCTRPERM`. Running from an elevated shell satisfies it per-run with
+   nothing persistent and no reboot; `scripts/sweeps/admin-profile.ps1` refuses to start unelevated
+   and collects everything that needs it in one pass. The persistent alternative is
+   `HKLM\SOFTWARE\NVIDIA Corporation\Global\NvTweak\RmProfilingAdminOnly = 0` plus a reboot.
+4. **Clock stability.** See below — this is the single biggest threat to reproducing any A/B here.
+
+### Measurement hygiene, which is where the time actually goes
+
+**This card drifts 3-5% between processes, and that is larger than most effects in this file.** Two
+comparisons this cycle came out with opposite-signed drift (+2.9% then −3.8%) on code paths that had
+not changed. Consequences, all of them load-bearing:
+
+- **Interleave A/B arms within each repetition**, not all of one then all of the other. Build both
+  binaries, alternate them inside the loop, and report the *paired* median. `scripts/` has no
+  committed harness for this; the pattern is three lines of shell and it is not optional.
+- **Keep a control** — a configuration whose code path did not change between the two arms — and
+  normalise against it. In the GDN tile A/B, draft counts 4 and 5 stay on an unchanged route and
+  calibrated the drift; without them the result was unreadable.
+- **`nvidia-smi -lgc <clock>`** would remove this entirely and needs an elevated shell. It is the
+  cheapest measurement improvement available and it is still not done — §3 carries it.
+- Two identical-looking runs differing by <3% have measured nothing.
+
+Three more that each cost hours here:
+
+- **`nsys` needs `--cuda-graph-trace node`.** Decode replays a captured CUDA graph and the default
+  records the replay as one opaque entity, which reported 99.3% GPU idle. The tell was 807 launches
+  over 128 steps of a 64-layer model.
+- **`ninfer_bench` has no concurrency option.** Multi-lane numbers come from
+  `tools/bench/run_serve_concurrency.py`. An earlier entry claimed otherwise and sent the work the
+  wrong way.
+- **Never measure speculation on `bench/fixtures/bench_corpus.ids`.** It is 65,536 tokens over 682
+  distinct ids with 98.4% of bigrams repeated, and DFlash2 reports *exactly 100% acceptance at every
+  draft count from 1 to 12* on it. Any acceptance or tokens-per-round figure from that path is a
+  statement about the fixture. Use the serving path on generated prose; `scripts/sweeps/dflash2-draft-tokens-realtext.ps1`
+  is the pattern.
+
+And one reassurance, because it saves a whole class of worry: **MMA tile choice does not perturb
+perplexity.** Routing width 1024 in `q5_linear_add` from `C128` to `C64` moved the score rate
+568.9 → 535.8 tok/s, so a different kernel demonstrably ran, and perplexity came back bit-identical
+to twelve figures. Route changes are not a quality risk.
+
+### Tooling traps specific to Windows, all hit this cycle
+
+- **`compute-sanitizer` has two installed copies and one lies.** The 2024.1.0 copy under
+  `CUDA/v12.4/` prints its banner and `ERROR SUMMARY: 0 errors`, exits 0, and **never executes the
+  binary** — a clean report having checked nothing. The v12.8 copy works, and is what
+  `compute-sanitizer` on `PATH` resolves to. Never call it by an absolute v12.4 path.
+- **`-k 'regex:a|b'` in PowerShell** is parsed as a pipeline before `ncu` sees it. One
+  `--kernel-name` pattern per invocation.
+- **`apps/ninfer` writes its logs UTF-16LE.** `grep` finds nothing in them; decode first.
+- **`Get-FileHash` is unavailable** under the `powershell` on this box, which silently breaks the
+  hashing step of `dflash2-draft-tokens-realtext.ps1` (non-fatal, one error per iteration).
+- **Copying a built `.exe` out of `build-ninja/apps/`** breaks DLL resolution: exit 127 with an
+  empty log, which reads exactly like a model failure. Keep A/B binaries in that directory under
+  different names.
+- **Heredocs through this agent harness mangle `\n` and `\v`** inside Python strings. A `\v` in a
+  path became a literal vertical tab in committed Markdown. Write files with a file-write tool
+  rather than a heredoc when the content contains backslash escapes.
+
+### Work in flight that does not transfer
+
+- **Two `ncu` profiles are outstanding on this box** and a new machine simply re-runs
+  `scripts/sweeps/admin-profile.ps1 -SkipPower` there: section 2 (the contiguous-kernel baseline the
+  MoE's 40-45% figures are compared against, which failed first time on the PowerShell `|` bug) and
+  section 3 (the prefill MLP GEMMs, where memory, tile shape and dequantization are all already
+  ruled out and only issue rate / shared-memory feeding / occupancy remain). §2c has both.
+- **The perplexity drift bisect is scoped and unstarted**: 392 commits, ~nine steps at 20-30 minutes
+  each, about four hours of exclusive GPU time. It is a repository question rather than a hardware
+  one, but the baseline figures it bisects against were measured here. §3 has the constraints,
+  including that three candidates are already eliminated.
+- **`ninfer_qwen3_6_27b_score_real_test`** and its siblings need `NINFER_*_WEIGHTS` set or they skip.
+  A skip is not a pass, and under `compute-sanitizer` a skip surfaces as
+  *"Target application terminated before first instrumented API call"*.
+
+### The seventeen open items, and the next concrete action for each
+
+Ordered by expected value, not by section.
+
+| item | § | next action | needs |
+|---|---|---|---|
+| MoE expert gather is latency-bound | 2c | split the shared W8 path out of the 9-warp block, as `sparse_moe_d3_path_tiled_kernel` already does for multi-token; then confirm the 2.2x over-fetch on d4 with `dram__bytes_read.sum` | kernel work; `ncu` for the confirm |
+| Prefill MLP GEMMs at ~30% of INT8 peak | 2c | run `admin-profile.ps1` section 3 and read issue rate vs shared-memory feeding vs occupancy | one elevated run |
+| Eight lanes buy 3.6x (3.83x since the GDN tiles) | 2c | the 4x between `mma_r64_c16` and its weight-streaming floor is the target; **not** by narrowing the tile, which was tried and lost | kernel work |
+| KV decode falloff, 3.21x per-key on fp8 | 2c | attack the per-key dequant-into-shared cost; `rk8v4` proves the floor is reachable without a shared arena | kernel work |
+| DFlash2 5→6 cliff | 2c/3 | remainder after the GDN tiles is the grouped kernel sitting at 27% of its own weight-streaming floor | same kernel as the KV item |
+| Routed prefill pipeline-depth threshold 7/4 | 2c | sweep the constant through the product on this card — the method the source comment endorses over the operator fixture | GPU time only |
+| `w8_pair` medium discards its schedule on sm_86 | 3 | write one genuinely sm_86-specific tiling and bench it against the generic chunked loop | kernel work |
+| sm_86 fallback constants chosen to fit | 2c | sweep the alternatives at the eleven `NINFER_SM8X_COMPAT` sites | GPU time only |
+| Cold-flush margins overstate wins | 3 | profile the narrow boundaries in situ; the method is in §5's q4 SwiGLU entry | GPU time only |
+| Perplexity drift 0.019% | 3 | the scoped four-hour bisect | exclusive GPU time |
+| Speculative decoding not bit-identical to greedy | 3 | decide whether it should be; the divergence is a reduction-order effect in k+1-column verification and MTP reproduces it, so it predates DFlash2 | judgement, not measurement |
+| DFlash2 corpus acceptance on real text | 3 | bake a diverse corpus with `make_bench_corpus.py --source-text`, or extend the real-text sweep to report acceptance | a local HF tokenizer, which this box lacks |
+| `27b_load_plan` DFlash2 binding matrix | 3 | needs the *old* Qwen3.8 artifacts and the NVFP4 DFlash2 artifact | artifacts nobody has |
+| DFlash2 + multi-GPU expert offload | 2 | genuinely blocked | a second GPU |
+| No committed interleaved-A/B harness | 3 | ~40 lines in `tools/bench/`; the pattern is written out in the item | nothing |
+| `Get-FileHash` missing breaks a sweep's hash column | 3 | swap for `certutil -hashfile` | nothing |
+| Host memory pressure invalidates 35B runs | 3 | give the other sweeps the 24 GiB guard `moe-prefill-pipeline-depth.ps1` has | nothing |
+
+Two of those seventeen are hard-blocked on things no amount of work here provides (a second GPU, and
+artifacts that no longer exist). One is a judgement call rather than a measurement. The remaining
+fourteen are all actionable — three of them need no GPU at all, and four are kernel work on two
+closely related problems: narrow-extent weight streaming in `q5_linear_add`/`gdn_input`, and
+dequant-into-shared in the quantized attention kernels.
 
 ---
 
@@ -128,28 +320,45 @@ question, and which one produced a wrong answer and why.
 
 ## 0. Next up, in this order
 
-1. **Profile one decode step** (§2c). The MoE runs at ~51% of the card's *achievable* read
-   bandwidth and is flat across depth; the dense path at ~66-70%. Both denominators now exist and
-   neither path has ever been profiled. `scripts/sweeps/decode-step-profile.ps1` captures exactly
-   one measured repetition under nsys and reports GPU-busy against window-wall first, because a
-   launch gap is not recoverable by kernel tuning and rules itself in or out in one run.
-2. **Re-measure perplexity for fp8, k8v4 and nvfp4** (§5). Those three numbers were scored
-   through the attention race #49 fixed. They are not "single runs that probably averaged out";
-   they are measurements of a broken kernel, and the format ranking built on them means nothing
-   until they are redone. Include int8 as a control.
-3. **The KV decode falloff still wants an explanation** (§2c). #49 removed the tidy theory
-   without moving the numbers: fp8/k8v4/nvfp4 still fall off two to three times as fast as
-   int8/rk8v4.
-4. **DFlash2 costs 20% on the 27B and no draft count below 7 has ever been tried** (§2c).
-   `scripts/sweeps/dflash2-draft-tokens.ps1` sweeps 1..12 with and without the draft head.
-5. **The calculator's speculative-memory gap** (§2b). Live on master and linked from README, so
-   every speculative configuration it reports is roughly 170 MiB optimistic.
-   `scripts/sweeps/speculative-memory-terms.ps1` reads every term the page needs in about ten
-   minutes; this is implementing, not investigating.
-6. **The two test-criterion outliers** (§4). Small, and neither needs hardware this box lacks.
+Every item in the previous version of this list is now closed. What follows is what a fresh agent
+should do first, and the ordering is by expected value rather than by section. The full
+seventeen-item table with what each one needs is in "Handing this off to another machine" above.
 
-Only one open item now needs hardware this box does not have (§2). The rest is measurement debt
-(§3), calibration (§4) or policy calls (§6).
+1. **Run `scripts/sweeps/admin-profile.ps1 -SkipPower` from an elevated shell.** Two `ncu` profiles
+   are outstanding and both are cheap: the prefill MLP GEMMs (§2c — memory, tile shape and
+   dequantization are all already ruled out, so only issue rate, shared-memory feeding and
+   occupancy remain, and those need counters) and the contiguous-kernel baseline the MoE gather's
+   40-45% figures are compared against. This is minutes of GPU time and it unblocks the largest
+   compute-side item in the file.
+2. **Lock clocks for measurement: `nvidia-smi -lgc 1500`** (§3, elevated). The card drifts 3-5%
+   between processes, which is larger than most effects here — it forced every A/B this cycle to
+   interleave its two binaries within each repetition and carry an unchanged control. This is the
+   cheapest improvement to every future measurement in this repository and it is one line.
+3. **Two related kernel problems, and they are the real prizes** (§2c). Both are narrow-extent
+   weight streaming and both have a measured target:
+   - `q5_linear_add`'s `mma_r64_c16` sits at **24%** of what its weight costs to stream once, flat
+     from T=4 to T=16. Closing that is most of the eight-lane gap. **Not** by narrowing the tile —
+     that was built and lost 6-32%.
+   - the quantized attention kernels pay **3.21x** int8's per-key cost (5.89 ns against 1.83 ns),
+     which is the whole KV decode falloff. `rk8v4` reaches the flattest curve of all six formats
+     with no shared arena at all, so the floor is demonstrably reachable.
+4. **Split the shared W8 path out of the MoE's 9-warp block** (§2c). The source already names this
+   — `sparse_moe_d3_path_tiled_kernel` exists for it and says so — and it is what the 44.6%/58.6%
+   "no eligible warp" reading measures. Do not chase launch geometry or batching first: both were
+   measured this cycle and neither helps, because the kernel is 1.17 machine-fulls of work and an
+   MoE does not amortise its routed weight read across a cohort.
+5. **Sweep the routed prefill pipeline-depth constant through the product** (§2c). `7/4` is
+   upstream's RTX 5090 number and an RTX 5090 has 16x this card's L2. Sweeping the constant is the
+   method the source comment endorses over the operator fixture, which disagrees with the server by
+   6x. GPU time only, no new code.
+6. **The perplexity drift bisect** (§3), when four hours of exclusive GPU time are available. Three
+   candidates are already eliminated and the current value is exactly reproducible, so the
+   remaining work is mechanical.
+
+Two of the seventeen open items are hard-blocked — one on a second GPU (§2), one on artifacts that
+no longer exist (§3) — and one is a judgement call about whether speculative decoding should be
+bit-identical to greedy rather than a measurement (§3). Everything else is actionable, and three of
+the newest items (§3: the A/B harness, a hash call, and a memory guard) need no GPU at all.
 
 **Keep `investigate/small-t-upstream` until the next catch-up.** It is merged, but it is the clean
 record of how upstream's small-T was adopted and what had to be fixed (`19c7617c` and its
@@ -1248,6 +1457,54 @@ ceiling, and neither has had any optimisation attempted.
 ---
 
 ## 3. Measurement debt
+
+- [ ] **There is no committed harness for an interleaved A/B, and every comparison in this file
+      needed one.** The card drifts 3-5% between processes, so measuring all of arm A then all of
+      arm B is not a comparison — two runs this cycle came out with opposite-signed drift (+2.9%
+      then −3.8%) on code paths that had not changed. The working pattern, hand-rolled three
+      separate times this cycle:
+
+      1. build both binaries and place them **inside `build-ninja/apps/`** under different names,
+         because an executable copied elsewhere fails DLL resolution with exit 127 and an empty
+         log, which reads exactly like a model failure;
+      2. alternate the two inside one repetition loop, not one arm then the other;
+      3. report the **paired** median — the median of per-repetition ratios — and how many pairs
+         were positive, not the ratio of the two medians;
+      4. keep a control configuration whose code path is identical in both arms, and normalise
+         against it. In the GDN tile A/B, draft counts 4 and 5 stay on an unchanged route and are
+         what made the result readable.
+
+      Worth ~40 lines in `tools/bench/` taking two executable paths and a command template. It
+      would also stop the next person rediscovering that the ratio of two medians and the median of
+      ratios disagree here by more than the effects being measured. `nvidia-smi -lgc` (§3) reduces
+      the need for this but does not remove it, and needs an elevated shell.
+
+- [ ] **`scripts/sweeps/dflash2-draft-tokens-realtext.ps1` calls `Get-FileHash`, which does not
+      exist under this box's `powershell`.** It errors once per iteration — 26 iterations, 26 error
+      blocks in the output — and the `content_sha256` column comes out empty. Non-fatal, and the
+      throughput numbers it prints are unaffected, but the hash column is the entire mechanism by
+      which that script lets a reader check whether two configurations produced identical text,
+      which its own header says is the point. Replace it with `certutil -hashfile <path> SHA256`, or
+      call `[System.Security.Cryptography.SHA256]::Create()` directly, either of which works here.
+
+- [ ] **Host memory pressure can silently invalidate any 35B measurement on this box, and did.**
+      `vmmemWSL` holds up to **27 GiB of the 64 GiB** of host RAM while WSL is running, and the 35B
+      artifact is 22.8 GB — so loading it contends directly with WSL's footprint, the machine pages,
+      and timings become noise. A first attempt at the pipeline-depth sweep was abandoned for
+      exactly this. `wsl --shutdown` reclaims it.
+
+      `scripts/sweeps/moe-prefill-pipeline-depth.ps1` now refuses to start below 24 GiB free, and
+      **every other sweep here should grow the same guard** — none of them currently checks, and a
+      paging run produces plausible-looking numbers rather than an error. Related: this box's C:
+      drive sits at 98% full (45 GB free) and hit *zero* bytes earlier in the cycle, which failed a
+      build with `C1085 ... No space left on device`. Two artifacts were byte-identical duplicates
+      (19 GB recovered) and WSL crash dumps held another 12 GB.
+
+      **Reading today's numbers in light of this:** the paired interleaved A/Bs are robust to it,
+      because both arms met the same conditions — the GDN tile results (+5.7% C8 serving, 3 of 3
+      non-overlapping; +5.3% DFlash2 k=6, 6 of 6 pairs) and the route-boundary bench sweeps are
+      safe. Single-shot end-to-end figures taken during the same window are the ones to treat as
+      provisional and re-run under the guard.
 
 - [ ] **Every route boundary in the repository was decided on cold-flush margins, which overstate
       the win.** `bench/ops/schedule_sweep.cuh` and its siblings call `measure_cold_launch`, which

--- a/bench/ops/q4_q5_attn_input_schedule_bench.cu
+++ b/bench/ops/q4_q5_attn_input_schedule_bench.cu
@@ -61,8 +61,11 @@ constexpr std::size_t kFlushBytes = 128u << 20;
 
 int main(int argc, char** argv) {
     std::vector<std::int32_t> tokens;
-    int repeat = 9;
-    int warmup = 3;
+    int repeat  = 9;
+    int warmup  = 3;
+    // A route boundary is only decidable if the margin clears the two schedules' own spread, and
+    // ColdTiming carries min and p95 already. See TODO section 3 on cold-flush margins.
+    bool spread = false;
     for (int i = 1; i < argc; ++i) {
         const std::string_view arg(argv[i]);
         if (arg == "--tokens" && i + 1 < argc) {
@@ -79,6 +82,8 @@ int main(int argc, char** argv) {
             repeat = std::atoi(argv[++i]);
         } else if (arg == "--warmup" && i + 1 < argc) {
             warmup = std::atoi(argv[++i]);
+        } else if (arg == "--spread") {
+            spread = true;
         } else {
             std::fprintf(stderr, "usage: %s [--tokens T,...] [--repeat N] [--warmup N] [--spread]\n", argv[0]);
             return 2;
@@ -108,12 +113,14 @@ int main(int argc, char** argv) {
     ninfer::DeviceBuffer flush(kFlushBytes);
     cudaStream_t stream = nullptr;
 
+    const int width = spread ? 30 : 20;
     cudaDeviceProp properties{};
     cudaGetDeviceProperties(&properties, 0);
-    std::printf("# gpu=%s sm=%d%d  q4_q5 attention-input schedules, median of %d\n", properties.name,
-                properties.major, properties.minor, repeat);
+    std::printf("# gpu=%s sm=%d%d  q4_q5 attention-input schedules, %s of %d\n", properties.name,
+                properties.major, properties.minor, spread ? "median min..p95" : "median",
+                repeat);
     std::printf("%6s", "T");
-    for (const Schedule& schedule : kSchedules) { std::printf(" %20s", schedule.name); }
+    for (const Schedule& schedule : kSchedules) { std::printf(" %*s", width, schedule.name); }
     // public_op is the same measurement through attn_input_proj(); a gap between it and
     // the schedule the router picked is dispatch overhead, not kernel cost.
     std::printf(" %12s %-22s   %-20s\n", "public_op", "routed_to", "winner");
@@ -131,22 +138,29 @@ int main(int argc, char** argv) {
         for (int s = 0; s < kScheduleCount; ++s) {
             const Schedule& schedule = kSchedules[s];
             if (schedule.max_cols != 0 && token_count > schedule.max_cols) {
-                std::printf(" %20s", "out-of-domain");
+                std::printf(" %*s", width, "out-of-domain");
                 continue;
             }
             const auto invoke = [&](cudaStream_t launch_stream) {
                 schedule.launch(x, qk.weight, gv.weight, tq, tg, tk, tv, launch_stream);
             };
-            double us = 0.0;
+            ninfer::bench::ColdTiming timing{};
             try {
-                us = ninfer::bench::measure_cold_launch(invoke, flush, stream, warmup, repeat)
-                         .median_us;
+                timing = ninfer::bench::measure_cold_launch(invoke, flush, stream, warmup, repeat);
             } catch (const std::exception&) {
                 cudaGetLastError();
-                std::printf(" %20s", "n/a");
+                std::printf(" %*s", width, "n/a");
                 continue;
             }
-            std::printf(" %20.3f", us);
+            const double us = timing.median_us;
+            if (spread) {
+                char cell[64];
+                std::snprintf(cell, sizeof(cell), "%.1f %.1f..%.1f", us, timing.min_us,
+                              timing.p95_us);
+                std::printf(" %*s", width, cell);
+            } else {
+                std::printf(" %*.3f", width, us);
+            }
             if (best_us == 0.0 || us < best_us) {
                 best_us   = us;
                 best_name = schedule.name;

--- a/scripts/sweeps/README.md
+++ b/scripts/sweeps/README.md
@@ -34,6 +34,7 @@ about three hours for twelve model/format combinations.
 | `power-and-clocks.ps1` | Does the 315 W cap bound these numbers? | a few min |
 | `admin-profile.ps1` | Everything needing an elevated shell: `ncu` counters, and what 350 W buys | a few min |
 | `vision-encode-throughput.ps1` | What does Vision cost in time, and what does overlay residency cost? | 20 min |
+| `moe-prefill-pipeline-depth.ps1` | Where does the routed prefill Spread/Packed crossing sit on this card? | 70 min |
 
 `decode-roofline.ps1` needs no GPU: it reads the CSVs `kv-decode-vs-depth.ps1` leaves behind and
 divides achieved bandwidth by peak. Run that sweep first. Note it only means anything for the

--- a/scripts/sweeps/moe-prefill-pipeline-depth.ps1
+++ b/scripts/sweeps/moe-prefill-pipeline-depth.ps1
@@ -1,0 +1,94 @@
+# Where does the routed prefill gate/up Spread/Packed crossing actually sit on this card?
+#
+# TODO section 2c: sparse_moe_prefill_kernels.cu's kGateUpDeepJobsNum/Den (7/4) picks between a
+# 2-stage "Spread" and a 6-stage "Packed" pipeline for the narrow routed gate/up kernel, based on
+# jobs-per-expert crossing that ratio. The constant is upstream's, measured on an RTX 5090 whose L2
+# is 16x this card's (96 MB against 6 MB), and the crossing depends on L2 size. Wrong constant means
+# the wrong pipeline depth, not wrong output -- a performance risk, not a correctness one.
+#
+# **This sweeps the constant through the product, which is the method that source comment endorses
+# over its own operator fixture.** The comment is explicit that the two disagree by about six times
+# depending on L2 warmth, and that upstream picked 7/4 by sweeping the threshold through the server
+# rather than by trusting the microbenchmark. So do the same thing here rather than porting the
+# fixture: it needs no new code, and it measures the thing that matters.
+#
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\moe-prefill-pipeline-depth.ps1
+#
+# About 70 minutes: five ratios, each a rebuild of one .cu plus a link, then one 35B load and four
+# prompt lengths. It edits the constant in place and restores it in a finally block, including on
+# Ctrl+C -- check `git diff` afterwards anyway, because a constant left changed silently alters
+# every later measurement.
+#
+# Read the prompt lengths separately. The comment says the effect is 0.10-0.17 points of server
+# prefill "on prompts below the wide-plan bound" against +0.01-0.02 above it, and that null control
+# is the point: a ratio that moves both is measuring something else.
+#
+# Two things about this box that can invalidate a run, both hit while writing this script:
+#   * vmmemWSL can hold 27 GiB of the 64 GiB of host RAM, and the 35B artifact is 22.8 GB. Under
+#     that pressure the machine pages and the numbers are noise. Check free RAM first; the script
+#     refuses below 24 GiB.
+#   * the card drifts 3-5% between processes, and each ratio here is a separate process. Five
+#     ratios spread over an hour is exactly the shape that drift corrupts, so the sweep repeats the
+#     7/4 baseline as its LAST point as well as measuring it in sequence -- if the two 7/4 readings
+#     disagree by more than the ratio spread, the run is void. See TODO section 3 on locking clocks.
+$ErrorActionPreference = 'Continue'
+Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
+
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
+$bench    = '.\build-ninja\bench\ninfer_bench.exe'
+$model    = "$modelDir\qwen3_6_35b_a3b.ninfer"
+$source   = 'src\ops\sparse_moe\prefill\sparse_moe_prefill_kernels.cu'
+New-Item -ItemType Directory -Force -Path $out | Out-Null
+foreach ($p in @($bench, $model, $source)) { if (-not (Test-Path $p)) { throw "missing: $p" } }
+
+$os = Get-CimInstance Win32_OperatingSystem
+$freeGiB = $os.FreePhysicalMemory / 1MB
+"# host RAM free: {0:N1} GiB" -f $freeGiB
+if ($freeGiB -lt 24) {
+  # -f binds tighter than +, so the format must be applied to the whole string, not the last piece.
+  throw ("only {0:N1} GiB of host RAM free; the 35B artifact is 22.8 GB and this run will page. Check vmmemWSL (wsl --shutdown reclaims it) and retry." -f $freeGiB)
+}
+
+$original = Get-Content $source -Raw
+# 7/4 appears twice: once in sequence, once repeated at the end as the drift control.
+$ratios = @(
+  @{ num = 3;  den = 2 }, @{ num = 25; den = 16 }, @{ num = 13; den = 8 },
+  @{ num = 7;  den = 4 }, @{ num = 2;  den = 1 },  @{ num = 7;  den = 4 }
+)
+
+"ratio,num,den,pass,prompt,prefill_tok_s"
+try {
+  $pass = 0
+  foreach ($r in $ratios) {
+    $pass++
+    $text = $original `
+      -replace 'constexpr int kGateUpDeepJobsNum = \d+;', "constexpr int kGateUpDeepJobsNum = $($r.num);" `
+      -replace 'constexpr int kGateUpDeepJobsDen = \d+;', "constexpr int kGateUpDeepJobsDen = $($r.den);"
+    Set-Content -Path $source -Value $text -NoNewline
+    $ratio = '{0:N4}' -f ($r.num / $r.den)
+
+    cmd /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat`" >nul 2>&1 && cmake --build build-ninja --target ninfer_bench > `"$out\depth_build.log`" 2>&1"
+    if ($LASTEXITCODE -ne 0) {
+      "$ratio,$($r.num),$($r.den),$pass,BUILD_FAILED,"
+      Get-Content "$out\depth_build.log" -Tail 5 | ForEach-Object { "#   $_" }
+      continue
+    }
+
+    $log = "$out\depth_$($r.num)_$($r.den)_$pass.log"
+    & $bench --weights $model --kv-dtype int8 --max-ctx 16384 `
+        -p 1024,2048,4096,8192 -r 3 --warmup 1 > $log 2>&1
+    # Emit per row as it is parsed, so a long run shows progress instead of buffering to the end.
+    Get-Content $log | Where-Object { $_ -match '^pp(\d+)\s' } | ForEach-Object {
+      $f = ($_ -split '\s+') | Where-Object { $_ }
+      "$ratio,$($r.num),$($r.den),$pass,$($f[0] -replace '^pp',''),$($f[3])"
+    }
+  }
+}
+finally {
+  # Restore unconditionally. A constant left changed here silently alters every later measurement
+  # in the repository, which is a far worse outcome than an incomplete sweep.
+  Set-Content -Path $source -Value $original -NoNewline
+  "# restored $source"
+  git diff --stat -- $source | ForEach-Object { "#   $_" }
+}


### PR DESCRIPTION
This repository is being handed to an agent on different hardware, so TODO.md needed a section about what does and does not transfer. Also fixes a flag I broke, adds one sweep script, and files three gaps this cycle turned up.

## The handoff section

New `## Handing this off to another machine`, ahead of the existing box-specific section. It covers, in order:

- **The three measured ceilings every percentage in this file is a ratio against** — 854.2 GB/s achievable read (not the advertised 936.1), 314.8 TOPS INT8, 67.6 TFLOPS BF16 — and that they must be re-measured before any §2c figure means anything on new hardware. Carrying them across cards is exactly the mistake this fork found in upstream's inherited tables.
- **Every route table was measured on `sm_86` and is expected to be wrong elsewhere**, with each table's schedule bench named, and the two rules learned about them: *narrowing a tile helps when padding is the cost and hurts when bandwidth is* (C8/C16 won 9–11% on the GDN projection and lost 6–32% on `q5_linear_add`), and *cold-flush margins overstate the win* (one 7.5% bench margin was 2.4% in situ).
- **What must be re-established** before anything is reproducible: artifacts, the BuildTools shell, the `ncu` counter permission, clock stability. Includes that `cmake --build --target A B` silently builds only A on this generator, which once produced a "verified" result against a four-hour-old binary.
- **Measurement hygiene, which is where the time actually goes.** The card drifts 3–5% between processes; two runs this cycle came out with opposite-signed drift on unchanged code paths. Plus `nsys` needing `--cuda-graph-trace node`, `ninfer_bench` having no concurrency option, and never measuring speculation on the committed corpus (100% DFlash2 acceptance at every draft count from 1 to 12).
- **The Windows tooling traps**, all hit this cycle — including that `compute-sanitizer` has two installed copies and the older one reports `0 errors` without executing the binary.
- **A seventeen-row table** giving the next concrete action for every open item and what it needs.

The header and §0 are rewritten too; both still described the previous cycle.

## Three new items

- **There is no committed harness for an interleaved A/B**, and every comparison in this file needed one. The pattern was hand-rolled three separate times. The item writes it out, including that the median of per-repetition ratios and the ratio of two medians disagree here by more than the effects being measured, and that an executable copied out of `build-ninja/apps/` fails DLL resolution with exit 127 and an empty log.
- **`dflash2-draft-tokens-realtext.ps1` calls `Get-FileHash`**, which does not exist under this box's `powershell`. Its `content_sha256` column — the entire mechanism by which that script lets a reader check whether two configurations produced identical text — comes out empty behind 26 error blocks.
- **Host memory pressure can silently invalidate any 35B measurement.** `vmmemWSL` holds up to 27 of this box's 64 GiB and the artifact is 22.8 GB, so loading it pages and timings become noise. That abandoned a first pipeline-depth run. The item says which of this cycle's results are robust to it (the paired interleaved A/Bs) and which are provisional.

## Two code changes

**`q4_q5_attn_input_schedule_bench` now implements the `--spread` it already advertised.** When the flag went into the shared harness its usage string was updated, but this bench has its own argument loop and never implemented it — so the documented flag fell through to the usage error. My bug; now matching the other four benches.

**`scripts/sweeps/moe-prefill-pipeline-depth.ps1`** for §2c's `kGateUpDeepJobsNum/Den` item. It sweeps the constant through the product, which is the method that kernel's own comment endorses over its operator fixture — the comment says the two disagree by about 6× depending on L2 warmth, and that upstream picked 7/4 by sweeping the server. Two guards, both from failures while writing it:

- refuses to start below **24 GiB free host RAM**, because of the `vmmemWSL` problem above;
- repeats the 7/4 baseline as its **last** point as well as in sequence, so the 3–5% drift is visible — if the two 7/4 readings disagree by more than the ratio spread, the run is void.

The constant is restored in a `finally` block including on Ctrl+C, and the script prints `git diff --stat` on the file afterwards, because a constant left changed there silently alters every later measurement in the repository.

**Not yet run:** the guard correctly refuses at 18.8 GiB free on this box right now, which is the honest state rather than a number taken under paging.
