### PR TITLE
fix(scripts): default the model directory to this repository's own models/

### DIFF
--- a/scripts/check-linux-scripts.sh
+++ b/scripts/check-linux-scripts.sh
@@ -135,6 +135,21 @@ for entry in 'run-qwen38-c1-maxctx.sh:qwen3_8_27b.ninfer' \
   fi
 done
 
+# The probe must select the candidate that holds the artifact, not the first models/ directory that
+# happens to exist. An archive unpacked below a directory with its own (empty) models/ would
+# otherwise stop at the parent and fail while its own artifact sat beside the launcher.
+decoy="$tmp/decoy"
+mkdir -p -- "$decoy/models" "$decoy/inner/models"
+cp -- "$tmp/ninfer-serve" "$decoy/inner/ninfer-serve"
+: > "$decoy/inner/models/qwen3_8_27b.ninfer"
+cp -- "$root/run-qwen38-c1-maxctx.sh" "$decoy/inner/run-qwen38-c1-maxctx.sh"
+args="$tmp/run-qwen38-c1-maxctx.decoy.args"
+( cd -- "$decoy/inner" && clear_env NINFER_TEST_ARGS="$args" ./run-qwen38-c1-maxctx.sh >/dev/null )
+if ! grep -Fx -- "$decoy/inner/models/qwen3_8_27b.ninfer" "$args" >/dev/null; then
+  printf 'run-qwen38-c1-maxctx.sh stopped at an empty parent models/: %s\n' "$(head -1 -- "$args")" >&2
+  exit 1
+fi
+
 # An explicit NINFER_MODEL_DIR must be honoured verbatim, never probed past. The two-candidate
 # fallback above is for when the caller said nothing; applying it to a directory the caller *named*
 # reports a missing artifact under a path they never mentioned, and hides their typo. Assert the

--- a/scripts/check-linux-scripts.sh
+++ b/scripts/check-linux-scripts.sh
@@ -84,6 +84,17 @@ SERVER
 chmod +x "$tmp/ninfer-serve"
 touch "$tmp/qwen3_8_27b.ninfer" "$tmp/qwen3_6_35b_a3b.ninfer"
 
+# Hermetic fixtures. A developer's shell may already export NINFER_MODEL, NINFER_HOST and friends
+# -- the machine this was written on exports both -- and inheriting them makes every assertion below
+# describe that box rather than the layout under test. The first draft of the archive case failed
+# exactly that way, against a NINFER_MODEL naming a directory that no longer exists. Clear every
+# NINFER_* and pass back only what a case sets deliberately.
+ninfer_clear=()
+while IFS= read -r name; do
+  ninfer_clear+=(-u "$name")
+done < <(env | sed -n 's/^\(NINFER_[A-Za-z0-9_]*\)=.*/\1/p')
+clear_env() { env ${ninfer_clear[@]+"${ninfer_clear[@]}"} "$@"; }
+
 launchers=(
   'run-qwen38-c1.sh:qwen3_8_27b.ninfer:--max-context:65536'
   'run-qwen38-c8.sh:qwen3_8_27b.ninfer:--max-concurrency:8'
@@ -93,11 +104,51 @@ launchers=(
 for entry in "${launchers[@]}"; do
   IFS=: read -r script model expected value <<< "$entry"
   args="$tmp/${script%.sh}.args"
-  NINFER_SERVER="$tmp/ninfer-serve" NINFER_TEST_ARGS="$args" \
+  clear_env NINFER_SERVER="$tmp/ninfer-serve" NINFER_TEST_ARGS="$args" \
     "$root/$script" "$tmp/$model" >/dev/null
   grep -Fx -- "$expected" "$args" >/dev/null
   grep -Fx -- "$value" "$args" >/dev/null
 done
+
+# The two -maxctx launchers ship *inside* the release archive as well as living here, and README
+# calls them the Linux entry point. They resolved both the server and the artifact from
+# `dirname(script)/..` -- the archive's parent once packaged -- so the documented quick start exited
+# before serving, with a "Missing ninfer-serve" naming a path outside the archive. Nothing tested
+# that, because every case above hands the launcher an explicit NINFER_SERVER and model path.
+#
+# So drive them the way a user does: unpack and run, flat layout, no environment overrides beyond
+# the stub hook. The launcher must find the binary beside itself and the artifact under its own
+# models/, not one directory up.
+archive="$tmp/archive"
+mkdir -- "$archive" "$archive/models"
+cp -- "$tmp/ninfer-serve" "$archive/ninfer-serve"
+for entry in 'run-qwen38-c1-maxctx.sh:qwen3_8_27b.ninfer' \
+             'run-qwen36-35b-a3b-c1-maxctx.sh:qwen3_6_35b_a3b.ninfer'; do
+  IFS=: read -r script model <<< "$entry"
+  : > "$archive/models/$model"
+  cp -- "$root/$script" "$archive/$script"
+  args="$tmp/${script%.sh}.archive.args"
+  ( cd -- "$archive" && clear_env NINFER_TEST_ARGS="$args" "./$script" >/dev/null )
+  if ! grep -Fx -- "$archive/models/$model" "$args" >/dev/null; then
+    printf '%s did not resolve its artifact inside the archive: %s\n' "$script" "$(head -1 -- "$args")" >&2
+    exit 1
+  fi
+done
+
+# The other half of the two-candidate lookup: a checkout must still prefer its own build tree and
+# models/ directory. This is the case that regresses if someone "simplifies" the fallback away.
+checkout="$tmp/checkout"
+mkdir -p -- "$checkout/scripts" "$checkout/build-linux/apps" "$checkout/models"
+cp -- "$tmp/ninfer-serve" "$checkout/build-linux/apps/ninfer-serve"
+: > "$checkout/models/qwen3_8_27b.ninfer"
+cp -- "$root/run-qwen38-c1-maxctx.sh" "$checkout/scripts/run-qwen38-c1-maxctx.sh"
+args="$tmp/run-qwen38-c1-maxctx.checkout.args"
+( cd -- "$checkout" && clear_env NINFER_TEST_ARGS="$args" ./scripts/run-qwen38-c1-maxctx.sh >/dev/null )
+if ! grep -Fx -- "$checkout/models/qwen3_8_27b.ninfer" "$args" >/dev/null; then
+  printf 'run-qwen38-c1-maxctx.sh did not resolve the checkout artifact: %s\n' "$(head -1 -- "$args")" >&2
+  exit 1
+fi
+
 
 mkdir -- "$tmp/bin" "$tmp/models"
 # NINFER_TEST_FAKE_SIZE makes the fixture produce a file of exactly the pinned downloaders'

--- a/scripts/check-linux-scripts.sh
+++ b/scripts/check-linux-scripts.sh
@@ -135,6 +135,21 @@ for entry in 'run-qwen38-c1-maxctx.sh:qwen3_8_27b.ninfer' \
   fi
 done
 
+# An explicit NINFER_MODEL_DIR must be honoured verbatim, never probed past. The two-candidate
+# fallback above is for when the caller said nothing; applying it to a directory the caller *named*
+# reports a missing artifact under a path they never mentioned, and hides their typo. Assert the
+# error names the directory that was actually asked for.
+err="$tmp/explicit-dir.err"
+if ( cd -- "$archive" && clear_env NINFER_MODEL_DIR="$tmp/nope" NINFER_TEST_ARGS="$tmp/unused.args" \
+       ./run-qwen38-c1-maxctx.sh >/dev/null 2>"$err" ); then
+  printf 'run-qwen38-c1-maxctx.sh accepted a nonexistent NINFER_MODEL_DIR\n' >&2
+  exit 1
+fi
+if ! grep -Fq -- "$tmp/nope/qwen3_8_27b.ninfer" "$err"; then
+  printf 'run-qwen38-c1-maxctx.sh ignored an explicit NINFER_MODEL_DIR: %s\n' "$(head -1 -- "$err")" >&2
+  exit 1
+fi
+
 # The other half of the two-candidate lookup: a checkout must still prefer its own build tree and
 # models/ directory. This is the case that regresses if someone "simplifies" the fallback away.
 checkout="$tmp/checkout"

--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
@@ -45,10 +45,20 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd -- "$script_dir/.." && pwd)"
-# A checkout keeps its artifacts in the repository's own models/ directory; an unpacked release
-# archive keeps them beside this launcher. Try the checkout first, then the archive.
-model_dir="${NINFER_MODEL_DIR:-$root/models}"
-[[ -d "$model_dir" ]] || model_dir="$script_dir/models"
+# Two layouts reach this script: a checkout, where the artifacts sit in the repository's own
+# models/ directory beside build-linux/, and an unpacked release archive, where the launcher
+# sits next to ninfer-serve and models/. Probe for the checkout first, then the archive -- the
+# same order the server lookup below uses.
+#
+# An explicit NINFER_MODEL_DIR is taken verbatim and never probed. Falling back past a
+# directory the caller named turns their typo into a 'Missing model' error about a path they
+# never mentioned, which is worse than failing on the one they did.
+if [[ -n "${NINFER_MODEL_DIR:-}" ]]; then
+  model_dir="$NINFER_MODEL_DIR"
+else
+  model_dir="$root/models"
+  [[ -d "$model_dir" ]] || model_dir="$script_dir/models"
+fi
 # Override with NINFER_MODEL=... to point at a copy on the Linux filesystem, which loads faster
 # than reading 20.6 GiB across the 9p mount.
 MODEL="${NINFER_MODEL:-$model_dir/qwen3_6_35b_a3b.ninfer}"

--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
@@ -43,9 +43,15 @@
 # ------------------------------------------------------------------------------------------------
 set -euo pipefail
 
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd -- "$script_dir/.." && pwd)"
+# A checkout keeps its artifacts in the repository's own models/ directory; an unpacked release
+# archive keeps them beside this launcher. Try the checkout first, then the archive.
+model_dir="${NINFER_MODEL_DIR:-$root/models}"
+[[ -d "$model_dir" ]] || model_dir="$script_dir/models"
 # Override with NINFER_MODEL=... to point at a copy on the Linux filesystem, which loads faster
 # than reading 20.6 GiB across the 9p mount.
-MODEL="${NINFER_MODEL:-/mnt/c/Ninefer-3090/models/qwen3_6_35b_a3b.ninfer}"
+MODEL="${NINFER_MODEL:-$model_dir/qwen3_6_35b_a3b.ninfer}"
 
 # The native maximum, two lanes, everything on. This is the production headless profile: rk8v4 at
 # 262,144 tokens with MTP3 + draft head and vision overlay all enabled. It needs about 2.67 GiB of
@@ -106,7 +112,6 @@ esac
 HOST="${NINFER_HOST:-127.0.0.1}"
 PORT="${NINFER_PORT:-8080}"
 
-root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 server="${NINFER_SERVER:-$root/build-linux/apps/ninfer-serve}"
 [[ -x "$server" ]] || server="$root/ninfer-serve"
 

--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
@@ -53,15 +53,19 @@ root="$(cd -- "$script_dir/.." && pwd)"
 # An explicit NINFER_MODEL_DIR is taken verbatim and never probed. Falling back past a
 # directory the caller named turns their typo into a 'Missing model' error about a path they
 # never mentioned, which is worse than failing on the one they did.
+artifact='qwen3_6_35b_a3b.ninfer'
 if [[ -n "${NINFER_MODEL_DIR:-}" ]]; then
   model_dir="$NINFER_MODEL_DIR"
 else
+  # Test for the artifact, not merely for a models/ directory. An archive unpacked below a
+  # directory that happens to have its own models/ would otherwise stop at the parent and
+  # never look beside the launcher, failing while its own artifact sits right there.
   model_dir="$root/models"
-  [[ -d "$model_dir" ]] || model_dir="$script_dir/models"
+  [[ -f "$model_dir/$artifact" ]] || model_dir="$script_dir/models"
 fi
 # Override with NINFER_MODEL=... to point at a copy on the Linux filesystem, which loads faster
 # than reading 20.6 GiB across the 9p mount.
-MODEL="${NINFER_MODEL:-$model_dir/qwen3_6_35b_a3b.ninfer}"
+MODEL="${NINFER_MODEL:-$model_dir/$artifact}"
 
 # The native maximum, two lanes, everything on. This is the production headless profile: rk8v4 at
 # 262,144 tokens with MTP3 + draft head and vision overlay all enabled. It needs about 2.67 GiB of

--- a/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
+++ b/scripts/run-qwen36-35b-a3b-c1-maxctx.sh
@@ -113,7 +113,9 @@ HOST="${NINFER_HOST:-127.0.0.1}"
 PORT="${NINFER_PORT:-8080}"
 
 server="${NINFER_SERVER:-$root/build-linux/apps/ninfer-serve}"
-[[ -x "$server" ]] || server="$root/ninfer-serve"
+# Same two layouts as the artifact lookup above: build tree in a checkout, then the archive
+# root, where this launcher sits beside the binary.
+[[ -x "$server" ]] || server="$script_dir/ninfer-serve"
 
 if [[ ! -x "$server" ]]; then
   printf 'Missing ninfer-serve (looked for %s)\n' "$server" >&2

--- a/scripts/run-qwen38-c1-maxctx.sh
+++ b/scripts/run-qwen38-c1-maxctx.sh
@@ -87,7 +87,9 @@ case "$VISION" in
 esac
 
 server="${NINFER_SERVER:-$root/build-linux/apps/ninfer-serve}"
-[[ -x "$server" ]] || server="$root/ninfer-serve"
+# Same two layouts as the artifact lookup above: build tree in a checkout, then the archive
+# root, where this launcher sits beside the binary.
+[[ -x "$server" ]] || server="$script_dir/ninfer-serve"
 
 if [[ ! -x "$server" ]]; then
   printf 'Missing ninfer-serve (looked for %s)\n' "$server" >&2

--- a/scripts/run-qwen38-c1-maxctx.sh
+++ b/scripts/run-qwen38-c1-maxctx.sh
@@ -57,10 +57,18 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd -- "$script_dir/.." && pwd)"
 # Two layouts reach this script: a checkout, where the artifacts sit in the repository's own
 # models/ directory beside build-linux/, and an unpacked release archive, where the launcher
-# sits next to ninfer-serve and models/. Try the checkout first, then the archive -- the same
-# order the server lookup below uses. NINFER_MODEL_DIR and NINFER_MODEL override both.
-model_dir="${NINFER_MODEL_DIR:-$root/models}"
-[[ -d "$model_dir" ]] || model_dir="$script_dir/models"
+# sits next to ninfer-serve and models/. Probe for the checkout first, then the archive -- the
+# same order the server lookup below uses.
+#
+# An explicit NINFER_MODEL_DIR is taken verbatim and never probed. Falling back past a
+# directory the caller named turns their typo into a 'Missing model' error about a path they
+# never mentioned, which is worse than failing on the one they did.
+if [[ -n "${NINFER_MODEL_DIR:-}" ]]; then
+  model_dir="$NINFER_MODEL_DIR"
+else
+  model_dir="$root/models"
+  [[ -d "$model_dir" ]] || model_dir="$script_dir/models"
+fi
 MODEL="${NINFER_MODEL:-$model_dir/qwen3_8_27b.ninfer}"
 CONTEXT="${NINFER_CONTEXT:-212992}"
 CONCURRENCY="${NINFER_CONCURRENCY:-2}"

--- a/scripts/run-qwen38-c1-maxctx.sh
+++ b/scripts/run-qwen38-c1-maxctx.sh
@@ -63,13 +63,17 @@ root="$(cd -- "$script_dir/.." && pwd)"
 # An explicit NINFER_MODEL_DIR is taken verbatim and never probed. Falling back past a
 # directory the caller named turns their typo into a 'Missing model' error about a path they
 # never mentioned, which is worse than failing on the one they did.
+artifact='qwen3_8_27b.ninfer'
 if [[ -n "${NINFER_MODEL_DIR:-}" ]]; then
   model_dir="$NINFER_MODEL_DIR"
 else
+  # Test for the artifact, not merely for a models/ directory. An archive unpacked below a
+  # directory that happens to have its own models/ would otherwise stop at the parent and
+  # never look beside the launcher, failing while its own artifact sits right there.
   model_dir="$root/models"
-  [[ -d "$model_dir" ]] || model_dir="$script_dir/models"
+  [[ -f "$model_dir/$artifact" ]] || model_dir="$script_dir/models"
 fi
-MODEL="${NINFER_MODEL:-$model_dir/qwen3_8_27b.ninfer}"
+MODEL="${NINFER_MODEL:-$model_dir/$artifact}"
 CONTEXT="${NINFER_CONTEXT:-212992}"
 CONCURRENCY="${NINFER_CONCURRENCY:-2}"
 KV_CAPACITY="${NINFER_KV_CAPACITY:-$CONTEXT}"

--- a/scripts/run-qwen38-c1-maxctx.sh
+++ b/scripts/run-qwen38-c1-maxctx.sh
@@ -53,7 +53,15 @@
 # ------------------------------------------------------------------------------------------------
 set -euo pipefail
 
-MODEL="${NINFER_MODEL:-${NINFER_MODEL_DIR:-/mnt/c/Ninefer-3090/models}/qwen3_8_27b.ninfer}"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd -- "$script_dir/.." && pwd)"
+# Two layouts reach this script: a checkout, where the artifacts sit in the repository's own
+# models/ directory beside build-linux/, and an unpacked release archive, where the launcher
+# sits next to ninfer-serve and models/. Try the checkout first, then the archive -- the same
+# order the server lookup below uses. NINFER_MODEL_DIR and NINFER_MODEL override both.
+model_dir="${NINFER_MODEL_DIR:-$root/models}"
+[[ -d "$model_dir" ]] || model_dir="$script_dir/models"
+MODEL="${NINFER_MODEL:-$model_dir/qwen3_8_27b.ninfer}"
 CONTEXT="${NINFER_CONTEXT:-212992}"
 CONCURRENCY="${NINFER_CONCURRENCY:-2}"
 KV_CAPACITY="${NINFER_KV_CAPACITY:-$CONTEXT}"
@@ -78,7 +86,6 @@ case "$VISION" in
   *) printf 'NINFER_VISION must be on or off, got %s\n' "$VISION" >&2; exit 2 ;;
 esac
 
-root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 server="${NINFER_SERVER:-$root/build-linux/apps/ninfer-serve}"
 [[ -x "$server" ]] || server="$root/ninfer-serve"
 

--- a/scripts/sweeps/README.md
+++ b/scripts/sweeps/README.md
@@ -7,10 +7,15 @@ these is an hour of work, not because they are polished tooling.
 All of them expect a Release `build-ninja` and run from the repository root:
 
 ```powershell
-$env:NINFER_MODEL_DIR = 'D:\elsewhere\models'      # optional; default is this repo's models dir
+$env:NINFER_MODEL_DIR = 'D:\elsewhere\models'      # optional; see model-dir.ps1 for the default
 $env:NINFER_SWEEP_OUT = 'profiles\sweeps'          # default; gitignored
 powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\kv-decode-vs-depth.ps1
 ```
+
+With `NINFER_MODEL_DIR` unset, `model-dir.ps1` picks the first directory that actually holds a
+`.ninfer`: the repository's own `models\` first, then `scripts\models\`, which is where
+`scripts\download-qwen*` put artifacts by default. Set the variable to use anything else -- an
+explicit value is taken verbatim, never probed, so a typo fails on the path you named.
 
 They print a CSV summary to stdout and leave per-run `ninfer_bench` CSVs and logs under
 `$NINFER_SWEEP_OUT`. **Read the CSVs, not the console summary** — the summary is a convenience and

--- a/scripts/sweeps/README.md
+++ b/scripts/sweeps/README.md
@@ -7,7 +7,7 @@ these is an hour of work, not because they are polished tooling.
 All of them expect a Release `build-ninja` and run from the repository root:
 
 ```powershell
-$env:NINFER_MODEL_DIR = 'C:\Ninefer-3090\models'   # default; override for another box
+$env:NINFER_MODEL_DIR = 'D:\elsewhere\models'      # optional; default is this repo's models dir
 $env:NINFER_SWEEP_OUT = 'profiles\sweeps'          # default; gitignored
 powershell -NoProfile -ExecutionPolicy Bypass -File scripts\sweeps\kv-decode-vs-depth.ps1
 ```

--- a/scripts/sweeps/admin-profile.ps1
+++ b/scripts/sweeps/admin-profile.ps1
@@ -20,10 +20,14 @@
 # point is to capture what an unelevated session cannot.
 [CmdletBinding()]
 param(
-  [string]$ModelDir = $(if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }),
+  # Resolved below rather than here: $PSScriptRoot is empty while a param default is being bound,
+  # so a repo-relative default written in this block silently resolves against the drive root.
+  [string]$ModelDir = $env:NINFER_MODEL_DIR,
   [string]$Ncu      = $(if ($env:NINFER_NCU) { $env:NINFER_NCU } else { 'C:\Program Files\NVIDIA Corporation\Nsight Compute 2025.1.0\ncu.bat' }),
   [switch]$SkipPower
 )
+
+if (-not $ModelDir) { $ModelDir = [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 

--- a/scripts/sweeps/admin-profile.ps1
+++ b/scripts/sweeps/admin-profile.ps1
@@ -27,7 +27,8 @@ param(
   [switch]$SkipPower
 )
 
-if (-not $ModelDir) { $ModelDir = [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+if (-not $ModelDir) { $ModelDir = Get-NInferModelDir }
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 

--- a/scripts/sweeps/decode-roofline.ps1
+++ b/scripts/sweeps/decode-roofline.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 $d        = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $python   = if ($env:NINFER_PYTHON) { $env:NINFER_PYTHON } else { 'python' }
 
 # Reads the per-run CSVs that kv-decode-vs-depth.ps1 leaves in $NINFER_SWEEP_OUT -- run that first.

--- a/scripts/sweeps/decode-roofline.ps1
+++ b/scripts/sweeps/decode-roofline.ps1
@@ -1,7 +1,8 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 $d        = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $python   = if ($env:NINFER_PYTHON) { $env:NINFER_PYTHON } else { 'python' }
 
 # Reads the per-run CSVs that kv-decode-vs-depth.ps1 leaves in $NINFER_SWEEP_OUT -- run that first.

--- a/scripts/sweeps/decode-step-profile.ps1
+++ b/scripts/sweeps/decode-step-profile.ps1
@@ -26,7 +26,8 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/decode-step-profile.ps1
+++ b/scripts/sweeps/decode-step-profile.ps1
@@ -26,7 +26,7 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
+++ b/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
@@ -5,7 +5,7 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
+++ b/scripts/sweeps/dflash-residency-and-auto-capacity.ps1
@@ -5,7 +5,8 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/dflash2-draft-tokens-realtext.ps1
+++ b/scripts/sweeps/dflash2-draft-tokens-realtext.ps1
@@ -28,7 +28,7 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/dflash2-draft-tokens-realtext.ps1
+++ b/scripts/sweeps/dflash2-draft-tokens-realtext.ps1
@@ -28,7 +28,8 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/dflash2-draft-tokens.ps1
+++ b/scripts/sweeps/dflash2-draft-tokens.ps1
@@ -20,7 +20,7 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/dflash2-draft-tokens.ps1
+++ b/scripts/sweeps/dflash2-draft-tokens.ps1
@@ -20,7 +20,8 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/kv-decode-vs-depth.ps1
+++ b/scripts/sweeps/kv-decode-vs-depth.ps1
@@ -5,7 +5,7 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/kv-decode-vs-depth.ps1
+++ b/scripts/sweeps/kv-decode-vs-depth.ps1
@@ -5,7 +5,8 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/kv-decode-with-speculation.ps1
+++ b/scripts/sweeps/kv-decode-with-speculation.ps1
@@ -5,7 +5,7 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/kv-decode-with-speculation.ps1
+++ b/scripts/sweeps/kv-decode-with-speculation.ps1
@@ -5,7 +5,8 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/kv-perplexity.ps1
+++ b/scripts/sweeps/kv-perplexity.ps1
@@ -5,7 +5,7 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/kv-perplexity.ps1
+++ b/scripts/sweeps/kv-perplexity.ps1
@@ -5,7 +5,8 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
+++ b/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
@@ -5,7 +5,7 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
+++ b/scripts/sweeps/memory-linearity-and-dflash-residency.ps1
@@ -5,7 +5,8 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/model-dir.ps1
+++ b/scripts/sweeps/model-dir.ps1
@@ -1,0 +1,36 @@
+# Where the .ninfer artifacts are, for the sweeps in this directory. Dot-source it and call
+# Get-NInferModelDir; every sweep here does.
+#
+# A checkout can hold artifacts in two places and both are legitimate:
+#
+#   * the repository's own models\ -- what .gitignore has always ignored, and where a large local
+#     collection tends to end up because it sits beside build-ninja\ rather than inside scripts\;
+#   * scripts\models\ -- where scripts\download-qwen*.{bat,sh} put them by default, and what
+#     docs/rtx-3090-linux.md documents as the download location.
+#
+# A sweep that hardcodes either one fails for whoever followed the other instruction, so probe:
+# the first candidate that actually contains an artifact wins, repository root first. Testing for
+# *.ninfer rather than for the directory matters -- an empty models\ directory left behind by a
+# cleared download would otherwise shadow a populated one.
+#
+# NINFER_MODEL_DIR is taken verbatim and never probed. Falling back past a directory the caller
+# named turns their typo into a missing-artifact error about a path they never mentioned.
+#
+# Do not move this logic into a param() default in a calling script: $PSScriptRoot is empty while a
+# param default is being bound, so a repo-relative path written there resolves against the drive
+# root and silently yields C:\models. Measured, not assumed.
+function Get-NInferModelDir {
+    if ($env:NINFER_MODEL_DIR) { return $env:NINFER_MODEL_DIR }
+    # $PSScriptRoot inside a function is the directory of the file that *defined* it, which is this
+    # one, regardless of which sweep dot-sourced it or what the current location is.
+    $candidates = @(
+        [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\models')),
+        [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\models'))
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path -Path (Join-Path $candidate '*.ninfer')) { return $candidate }
+    }
+    # Neither holds an artifact. Return the repository's own models\ so the caller's own
+    # "model not found" throw names the conventional location instead of an empty string.
+    return $candidates[0]
+}

--- a/scripts/sweeps/moe-prefill-pipeline-depth.ps1
+++ b/scripts/sweeps/moe-prefill-pipeline-depth.ps1
@@ -34,7 +34,7 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 $bench    = '.\build-ninja\bench\ninfer_bench.exe'
 $model    = "$modelDir\qwen3_6_35b_a3b.ninfer"

--- a/scripts/sweeps/moe-prefill-pipeline-depth.ps1
+++ b/scripts/sweeps/moe-prefill-pipeline-depth.ps1
@@ -34,7 +34,8 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 $bench    = '.\build-ninja\bench\ninfer_bench.exe'
 $model    = "$modelDir\qwen3_6_35b_a3b.ninfer"

--- a/scripts/sweeps/power-and-clocks.ps1
+++ b/scripts/sweeps/power-and-clocks.ps1
@@ -19,7 +19,7 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 $bench    = '.\build-ninja\bench\ninfer_bench.exe'
 $model    = "$modelDir\qwen3_8_27b.ninfer"

--- a/scripts/sweeps/power-and-clocks.ps1
+++ b/scripts/sweeps/power-and-clocks.ps1
@@ -19,7 +19,8 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 $bench    = '.\build-ninja\bench\ninfer_bench.exe'
 $model    = "$modelDir\qwen3_8_27b.ninfer"

--- a/scripts/sweeps/speculation-matrix.ps1
+++ b/scripts/sweeps/speculation-matrix.ps1
@@ -5,7 +5,7 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/speculation-matrix.ps1
+++ b/scripts/sweeps/speculation-matrix.ps1
@@ -5,7 +5,8 @@ Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
 # Both overridable so this is not welded to one machine. The output directory is created here
 # because it does not exist in a clean checkout -- profiles/ is gitignored.
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/speculative-memory-terms.ps1
+++ b/scripts/sweeps/speculative-memory-terms.ps1
@@ -15,7 +15,7 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/speculative-memory-terms.ps1
+++ b/scripts/sweeps/speculative-memory-terms.ps1
@@ -15,7 +15,8 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 New-Item -ItemType Directory -Force -Path $out | Out-Null
 

--- a/scripts/sweeps/vision-encode-throughput.ps1
+++ b/scripts/sweeps/vision-encode-throughput.ps1
@@ -33,7 +33,8 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
+. "$PSScriptRoot\model-dir.ps1"
+$modelDir = Get-NInferModelDir
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 $cli      = '.\build-ninja\apps\ninfer.exe'
 $model    = "$modelDir\qwen3_8_27b.ninfer"

--- a/scripts/sweeps/vision-encode-throughput.ps1
+++ b/scripts/sweeps/vision-encode-throughput.ps1
@@ -33,7 +33,7 @@
 $ErrorActionPreference = 'Continue'
 Set-Location (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
 
-$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { 'C:\Ninefer-3090\models' }
+$modelDir = if ($env:NINFER_MODEL_DIR) { $env:NINFER_MODEL_DIR } else { [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models") }
 $out      = if ($env:NINFER_SWEEP_OUT) { $env:NINFER_SWEEP_OUT } else { 'profiles\sweeps' }
 $cli      = '.\build-ninja\apps\ninfer.exe'
 $model    = "$modelDir\qwen3_8_27b.ninfer"


### PR DESCRIPTION
Seventeen scripts hardcoded `C:\Ninefer-3090\models` (or `/mnt/c/Ninefer-3090/models`) as their
default model directory. That path no longer exists: the artifacts now live in the repository's own
gitignored `models/`, and the packaged v0.6.1 install that used to sit beside them was deleted with
it. Every sweep therefore fails on a path that cannot exist, having only ever worked on the machine
that wrote them.

Split out of the v0.9.1 release PR (#86) deliberately -- `PR_POLICY.md` asks for no drive-by
cleanup, and this touches seventeen files the release does not.

## The fifteen sweeps

    [IO.Path]::GetFullPath("$PSScriptRoot\..\..\models")

`GetFullPath` rather than `Resolve-Path`, so a checkout with no artifacts still reaches each
script's own `model not found` throw instead of dying inside path resolution.

## admin-profile.ps1 could not take the same change

Its `$ModelDir` is a `param()` default, and **`$PSScriptRoot` is empty while a param default is
being bound** -- the repo-relative expression resolves against the drive root and silently yields
`C:\models`. I only found this because I ran the generated param block on its own before trusting
it:

    ModelDir = C:\models        # the one-liner, inside param()
    ModelDir = C:\ninfer-fork\ninfer-3090\models    # the same expression, one line below the block

So the default is now just `$env:NINFER_MODEL_DIR`, with the fallback resolved immediately after
the param block, and a comment saying why it cannot live inside it.

## The two -maxctx launchers

These ship inside the Linux archive *and* live in the checkout, so no single default is right for
both. They now mirror what their own server lookup already does -- try the checkout
(`$root/models`, beside `build-linux/`), then the archive (`$script_dir/models`, beside
`ninfer-serve`) -- with `NINFER_MODEL_DIR` and `NINFER_MODEL` still overriding both.
`run-qwen36-35b-a3b-c1-maxctx.sh` had no `NINFER_MODEL_DIR` support at all and gains it; both drop
their now-duplicate `root=` line.

## Verification

- `scripts/check-linux-scripts.sh` passes. It also earned its keep here: my first pass wrote CRLF
  into both launchers (Python's default newline translation), the guard rejected them by byte, and
  they were rewritten LF. That is exactly the failure `.gitattributes` documents.
- Both resolutions checked in situ against the real checkout: the sweep body assignment and the
  launcher's two-candidate lookup each resolve to `C:\ninfer-fork\ninfer-3090\models` and find
  `qwen3_8_27b.ninfer`.
- `bash -n` clean on both launchers; `admin-profile.ps1` parses clean.
- No behaviour change where `NINFER_MODEL_DIR` is already set, which is how every sweep has been
  invoked since the move.