### PR TITLE
Int8 MLP decode route behind --mlp-a8-decode, plus an exact-width win and a corrected C8 roofline

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,46 @@ batching accelerates decode, but does not multiply prompt ingestion. Consequentl
 844-862 input tok/s while queued requests increase mean TTFT. `Active-prefill speed` excludes queue
 waiting and measures only the server's recorded prefill phase.
 
+### Integer-activation MLP at decode (`--mlp-a8-decode`)
+
+Opt-in, off by default, Qwen3.8-27B on `sm_86`. The MLP gate_up projection already runs its full
+prefill tiles through the s8 tensor cores; this flag extends that to the widths a cohort round
+decodes at, quantising activations to s8 with one scale per (token, 64-k group) and feeding
+`mma.m16n8k32.s8.s8.s32`. It buys a little speed and costs a little fidelity.
+
+**The Op, paired against the BF16 small-T kernel inside one sitting** (the card drifts several
+percent between sittings, so only the pairing is meaningful), cold, median of 15:
+
+| columns | 8 | 12 | 16 | 20 | 24 | 28 | 32 |
+|---|---|---|---|---|---|---|---|
+| run 1 | +10.7% | -5.8% | -3.4% | -4.8% | -4.8% | -5.0% | -4.5% |
+| run 2 | +7.5% | +4.3% | -0.7% | -5.9% | -6.1% | -4.0% | -6.4% |
+
+It wins from sixteen columns up and loses at eight, so the route is admitted for 16..32 columns
+only and every narrower width stays on the BF16 kernel. A cohort round reaches those widths through
+concurrency: eight lanes verifying four MTP columns each is thirty-two.
+
+**End to end it is worth about a percent.** Eight concurrent thinking-off chat requests, MTP3,
+INT8 KV, greedy, four interleaved repetitions:
+
+| | decode |
+|---|---|
+| default | 431.5 tok/s |
+| `--mlp-a8-decode` | **437.0 tok/s** (+1.28%) |
+
+That is the expected size rather than a disappointment: gate_up is roughly a quarter of a C8 round,
+so four to six percent off it arrives as one percent overall. The flag won three of the four paired
+repetitions and tied the fourth, against a spread of about 1.7% within the unflagged arm alone.
+
+**What it costs.** Output changes -- this is a lossy trade, not a free one. Against an FP64 oracle
+the Op measures 0.0080 to 0.0371 relative L2 across 2..32 columns, inside the 0.04 allowance the
+integer-activation path is held to everywhere else in the tree. Perplexity cannot see this trade at
+all: scoring runs at prefill widths, where the route does not apply, so `ninfer-perplexity` reports
+the same score with and without the flag. Judge it on the oracle bound and on your own outputs.
+
+Not recommended for single-stream use, where it does nothing: one request decodes one column per
+step, far below the sixteen the route needs.
+
 ### RotorQuant KV (`rk8v4`)
 
 `rk8v4` is an experimental, opt-in KV-cache mode for Qwen3.8-27B: keys keep the rotated INT8

--- a/TODO.md
+++ b/TODO.md
@@ -189,7 +189,7 @@ Ordered by expected value, not by section.
 |---|---|---|---|
 | MoE expert gather is latency-bound | 2c | split the shared W8 path out of the 9-warp block, as `sparse_moe_d3_path_tiled_kernel` already does for multi-token; then confirm the 2.2x over-fetch on d4 with `dram__bytes_read.sum` | kernel work; `ncu` for the confirm |
 | Prefill MLP GEMMs at ~30% of INT8 peak | 2c | run `admin-profile.ps1` section 3 and read issue rate vs shared-memory feeding vs occupancy | one elevated run |
-| Eight lanes buy 3.6x (4.05x with MTP3 since the small-T kernels) | 2c | gate_up at T=32 is ~68% of the bf16 MMA peak; the 5120-row Q5 shapes need split-K at T=32 (it bought only 0-2.5% at narrow T) | kernel work |
+| Eight lanes buy 3.6x (4.05x with MTP3 since the small-T kernels) | 2c | **not tensor rate** -- `ncu` puts the T=32 gate_up kernel at 38% tensor pipe, 36% L1 and 39% DRAM at 31% occupancy, i.e. latency-bound. A wider tile that puts more work in flight is the untried lever; the 5120-row Q5 shapes still want split-K at T=32 (0-2.5% at narrow T) | kernel work |
 | KV decode falloff, 3.21x per-key on fp8 | 2c | attack the per-key dequant-into-shared cost; `rk8v4` proves the floor is reachable without a shared arena | kernel work |
 | DFlash2 5→6 cliff | 2c/3 | remainder after the GDN tiles is the grouped kernel sitting at 27% of its own weight-streaming floor | same kernel as the KV item |
 | Routed prefill pipeline-depth threshold 7/4 | 2c | sweep the constant through the product on this card — the method the source comment endorses over the operator fixture | GPU time only |
@@ -1145,13 +1145,46 @@ it here, exactly as "Handing this off to another machine" says.
 
 What is left, in order of size:
 
-- [ ] **C8 is tensor-rate bound.** Q4 gate_up at T=32 runs at ~68% of that card's measured bf16 MMA
-      peak (205 us against a 139 us tensor floor and a 106 us weight-streaming floor), and the Q5
-      shapes at 40-50%. Shared activation slabs (`ops/common/small_t_layout.cuh`) already took the
-      L2 traffic out; what remains is the MMA rate itself. The only large lever left is int8 tensor
-      cores -- W4A8 with per-(column, 64-k-group) activation scales, which is what the syv-ai stack
-      means by "int8 tensor-core GEMMs" -- and that is a quality trade, so it needs the same
-      before/after quality evidence as any other.
+- [x] **C8 is NOT tensor-rate bound -- this entry was wrong, and acting on it cost a kernel.**
+      It read: gate_up at T=32 runs at ~68% of the bf16 MMA peak (205 us against a 139 us tensor
+      floor), so the only large lever left is int8 tensor cores. Both halves are now measured and
+      the first one does not hold. `ncu` on the T=32 gate_up kernel, this box:
+
+      | | BF16 small-T | int8 small-T |
+      |---|---:|---:|
+      | tensor pipe active | **38.3%** | 21.0% |
+      | L1/TEX throughput | 36.4% | 73.5% |
+      | DRAM throughput | 39.4% | 42.7% |
+      | warp occupancy | 30.9% | 45.4% |
+
+      Tensor, L1 and DRAM all sit within three points of each other around 38%, at 31% occupancy:
+      nothing is saturated, which is a latency-bound kernel, not a tensor-rate-bound one. The 68%
+      compared against a computed floor rather than a measured pipe and the two disagree.
+
+      The int8 route was built anyway and is the evidence: it halved tensor-pipe pressure exactly as
+      a 4.7x-denser MMA should (38.3% -> 21.0%) and returned **4-6%**, because the pipe it relieved
+      was never the constraint and the cost landed on L1 at 73.5%. It ships behind `--mlp-a8-decode`
+      (docs/maintainer/quality-trade-experiments.md) since it is also a quality trade.
+
+      **What the counters point at instead:** operand movement and occupancy. The largest single win
+      in that whole exercise was deleting a redundant copy of the staged activation slab, and the
+      second was dropping a runtime column count so the staging loop could fold (below). A wider
+      tile that puts more work in flight is the untried lever.
+
+- [x] **A width that fills its tile does not need a runtime column count.** Every small-T call site
+      passed `MaskedColumns=true`, so the staging loop's trip count and the inner loop's bounds test
+      could never fold, even at exact widths -- and a C8 MTP3 cohort is exactly thirty-two columns.
+      Giving gate_up an unmasked instantiation is worth a median +4% at 16 columns, +3-6.5% at 24
+      (positive in all six runs) and +0.5-2.9% at 32, bit-identical.
+
+      Two things stopped it being universal, both worth knowing before trying it elsewhere. Eight
+      columns *spills* unmasked -- ptxas reports 16 bytes of cumulative stack -- because the
+      compile-time count lets the staging loop unroll past the 42-register ceiling that the KWarps 8
+      schedule's `__launch_bounds__(256, 6)` imposes; wider tiles run KWarps < 8 at two blocks per
+      SM and unroll with registers to spare. And the same change **loses** on the GDN and attention
+      query/key projections, which share the template: attention by 4.1% at thirty-two columns in
+      three identical runs, GDN by 11%. That is not registers (94 against 95, no stack either way)
+      and is unexplained; both were reverted rather than shipped on a story.
 
 - [ ] **C1 is mostly kernel-boundary ramp and drain.** A round is ~500 kernels; the Q5 residual
       projections reach 68-82% of their streaming floor and gate_up 89%, and the shortfall scales

--- a/TODO.md
+++ b/TODO.md
@@ -1183,8 +1183,28 @@ What is left, in order of size:
       schedule's `__launch_bounds__(256, 6)` imposes; wider tiles run KWarps < 8 at two blocks per
       SM and unroll with registers to spare. And the same change **loses** on the GDN and attention
       query/key projections, which share the template: attention by 4.1% at thirty-two columns in
-      three identical runs, GDN by 11%. That is not registers (94 against 95, no stack either way)
-      and is unexplained; both were reverted rather than shipped on a story.
+      three identical runs, GDN by 11%. Both were reverted.
+
+      **Why they lose is an issue-efficiency effect, not a resource limit.** `ncu` on the attention
+      query/key kernel at T=32, exact against masked:
+
+      | | exact | masked (shipping) |
+      |---|---:|---:|
+      | issue active | 26.0% | **29.5%** |
+      | warps active | 22.6% | **24.6%** |
+      | tensor pipe | 32.1% | 33.4% |
+      | L1/TEX | 30.5% | 31.7% |
+      | DRAM | 25.2% | 27.2% |
+
+      Registers (94 against 95), shared memory and spills are all unchanged, and both builds have
+      the same theoretical occupancy -- two blocks per SM either way. What differs is that the exact
+      build issues an instruction 13.5% less often and keeps 8% fewer warps resident. Nothing is
+      above 34%, so this kernel is deeply latency-bound and its performance turns on instruction
+      scheduling rather than on any unit's throughput; a fully unrolled staging loop appears to
+      burst its copies and then stall where the runtime-bounded loop interleaves them. That is
+      consistent with gate_up reacting the other way -- it runs a different epilogue and row policy
+      at a higher 31% occupancy -- but the mechanism behind the sign flip is inferred from the issue
+      counters, not proven.
 
 - [ ] **C1 is mostly kernel-boundary ramp and drain.** A round is ~500 kernels; the Q5 residual
       projections reach 68-82% of their streaming floor and gate_up 89%, and the shortfall scales

--- a/apps/cli/main.cpp
+++ b/apps/cli/main.cpp
@@ -283,6 +283,7 @@ int main(int argc, char** argv) {
         engine_options.use_cuda_graph = cli.use_cuda_graph;
         engine_options.lm_head_q4     = cli.lm_head_q4;
         engine_options.gdn_state_fp16 = cli.gdn_state_fp16;
+        engine_options.mlp_a8_decode  = cli.mlp_a8_decode;
         // One CLI invocation owns exactly one request, so retained cross-request context has no
         // consumer and must not reserve an extra Device StateImage or run terminal capture.
         engine_options.context_cache.enabled                = false;

--- a/apps/cli/options.cpp
+++ b/apps/cli/options.cpp
@@ -135,7 +135,8 @@ std::string usage_text(const char* argv0) {
            "toward --max-new.\n"
            "--devices N,M offloads the expert/MLP blocks to the second GPU; rank 0 keeps attention, "
            "the KV cache and the head, so nearly all of its memory becomes KV.\n"
-           "--lm-head-q4 and --gdn-state-fp16 are speed-for-quality trades, off by default; see "
+           "--lm-head-q4, --gdn-state-fp16 and --mlp-a8-decode are speed-for-quality trades, off by "
+           "default; see "
            "docs/maintainer/quality-trade-experiments.md for the measured cost of each.\n"
            "--kv-capacity auto leaves " +
            std::to_string(kDefaultKvCapacityHeadroomBytes / (1024ULL * 1024ULL)) +
@@ -192,6 +193,8 @@ Options parse_options(int argc, char** argv) {
             options.lm_head_q4 = true;
         } else if (arg == "--gdn-state-fp16") {
             options.gdn_state_fp16 = true;
+        } else if (arg == "--mlp-a8-decode") {
+            options.mlp_a8_decode = true;
         } else if (arg == "--raw-output") {
             options.raw_output = true;
         } else if (arg == "--print-token-ids") {

--- a/apps/cli/options.h
+++ b/apps/cli/options.h
@@ -35,6 +35,7 @@ struct Options {
     bool use_cuda_graph = true;
     bool lm_head_q4     = false;
     bool gdn_state_fp16 = false;
+    bool mlp_a8_decode  = false;
 
     bool raw_output      = false;
     bool print_token_ids = false;

--- a/apps/perplexity/main.cpp
+++ b/apps/perplexity/main.cpp
@@ -57,6 +57,7 @@ struct Options {
     bool quick                          = false;
     bool lm_head_q4                     = false;
     bool gdn_state_fp16                 = false;
+    bool mlp_a8_decode                  = false;
     ninfer::product::LogLevel log_level = ninfer::product::LogLevel::Info;
 };
 
@@ -65,7 +66,9 @@ std::string usage_text() {
            "(--corpus <manifest.json> [--quick] | --text <utf8-file>)\n"
            "       [--context N] [--stride N] [--device N]\n"
            "       [--kv-dtype bf16|int8|fp8|rk8v4|nvfp4|k8v4] [--output <directory>]\n"
-           "       [--lm-head-q4] [--gdn-state-fp16]\n"
+           "       [--lm-head-q4] [--gdn-state-fp16] [--mlp-a8-decode]\n"
+           "       (--mlp-a8-decode is inert here: scoring runs at prefill widths and"
+           "        the route it enables covers 16..32 columns only)\n"
            "       [--log-level trace|debug|info|warning|error|critical|off]\n";
 }
 
@@ -133,6 +136,8 @@ Options parse_options(int argc, char** argv) {
             out.lm_head_q4 = true;
         } else if (option == "--gdn-state-fp16") {
             out.gdn_state_fp16 = true;
+        } else if (option == "--mlp-a8-decode") {
+            out.mlp_a8_decode = true;
         } else if (option == "--log-level") {
             out.log_level = ninfer::product::parse_log_level(value("--log-level"));
         } else {
@@ -244,6 +249,7 @@ int run(const Options& options, const std::shared_ptr<spdlog::logger>& logger,
     engine_options.kv_cache         = options.kv;
     engine_options.lm_head_q4       = options.lm_head_q4;
     engine_options.gdn_state_fp16   = options.gdn_state_fp16;
+    engine_options.mlp_a8_decode    = options.mlp_a8_decode;
     engine_options.startup_observer = startup_log.observer();
     ninfer::Engine engine(std::move(engine_options));
     const ninfer::LoadSummary load = engine.load_summary();

--- a/bench/ops/q4_linear_swiglu_schedule_bench.cu
+++ b/bench/ops/q4_linear_swiglu_schedule_bench.cu
@@ -55,6 +55,10 @@ const Schedule kSchedules[] = {
     {"split_half_pair_c48", Id::MmaSplitHalfPairR32C48, 0},
     {"split_half_pair_c128", Id::MmaSplitHalfPairR32C128, 0},
     {"materialized", Id::Materialized, 0},
+    // Exploratory: int8 tensor-core small-T, T=32 only (see q4_small_t_mma_i8.cuh). Not in
+    // resolve_plan's route table; this row exists purely to compare it against small_t_tiled at the
+    // one width it currently supports.
+    {"small_t_tiled_i8", Id::SmallTTiledI8, 32},
 };
 constexpr int kScheduleCount = static_cast<int>(sizeof(kSchedules) / sizeof(kSchedules[0]));
 

--- a/bench/ops/q4_linear_swiglu_schedule_bench.cu
+++ b/bench/ops/q4_linear_swiglu_schedule_bench.cu
@@ -59,6 +59,8 @@ const Schedule kSchedules[] = {
     // resolve_plan's route table; this row exists purely to compare it against small_t_tiled at the
     // one width it currently supports.
     {"small_t_tiled_i8", Id::SmallTTiledI8, 32},
+    // Prices the runtime column count against small_t_tiled, which now drops it at exact widths.
+    {"small_t_masked", Id::SmallTTiledMasked, 32},
 };
 constexpr int kScheduleCount = static_cast<int>(sizeof(kSchedules) / sizeof(kSchedules[0]));
 

--- a/docs/maintainer/quality-trade-experiments.md
+++ b/docs/maintainer/quality-trade-experiments.md
@@ -1,8 +1,8 @@
-# Quality trades: int4 vocabulary head and FP16 GDN state
+# Quality trades: int4 vocabulary head, FP16 GDN state, integer-activation MLP decode
 
-Two speed-for-quality trades, both **implemented, measured, and wired to CLI flags**:
-`--lm-head-q4` and `--gdn-state-fp16` on `ninfer`, `ninfer-serve`, and `ninfer-perplexity`. Both
-default off. The [`sm_86` findings](../performance.md#small-t-tensor-core-kernels-for-verify-and-cohort-decode)
+Three speed-for-quality trades, all **implemented, measured, and wired to CLI flags**:
+`--lm-head-q4`, `--gdn-state-fp16` and `--mlp-a8-decode` on `ninfer`, `ninfer-serve`, and
+`ninfer-perplexity`. All default off. The [`sm_86` findings](../performance.md#small-t-tensor-core-kernels-for-verify-and-cohort-decode)
 explain why they were the next levers: a decode round is bandwidth-bound at C1 and tensor-rate bound
 at C8, and both trades buy bytes.
 
@@ -134,3 +134,32 @@ clean.
 
 Freeing the W8 head's now-unused upper halves after `--lm-head-q4` requantizes it in place is a
 further ~670 MB of VRAM for KV, and is not done.
+
+## `--mlp-a8-decode` -- integer-activation MLP gate_up at decode widths
+
+Added after the other two, and measured differently because perplexity cannot see it. The kernel,
+its per-width sweep and the five variants that were measured and rejected live in the header of
+`src/ops/linear/q4/q4_small_t_mma_i8.cuh`; the README carries the user-facing table. The short
+version:
+
+- The Op is 4-6% faster than the BF16 small-T kernel from sixteen columns up, and slower at eight,
+  so the route is admitted for 16..32 columns only.
+- End to end at C8 with MTP3 it is **+1.28%** over four interleaved repetitions (431.5 -> 437.0
+  tok/s), which is what gate_up's share of a round predicts.
+- Quality evidence is the FP64 oracle bound, 0.0080-0.0371 relative L2 across 2..32 columns against
+  the 0.04 allowance, plus the fact that output demonstrably changes at C8.
+
+**Why perplexity is silent on it, and what to use instead.** `CausalScoring` forces a 1024-token
+prefill chunk, and this route covers 16..32 columns, so scoring never reaches it -- the flag is
+accepted by `ninfer-perplexity` and changes nothing there. That is a genuine gap in the evidence
+rather than a clean bill of health: the trade is only exercised by cohort decode, so the honest
+checks are the oracle bound above and a greedy-divergence comparison at C8, both of which this
+branch has. A stronger number would need a scorer that can run at cohort widths.
+
+**The finding that outlived the kernel.** `docs/performance.md` called C8 tensor-rate bound, which
+is why int8 looked like a 4.7x lever. `ncu` says otherwise: the kernel sits at 74% L1/TEX against
+42% DRAM and 47% SM, so operand movement through L1 and shared memory is the limit and the int8
+MMA's arithmetic advantage is mostly unspendable at this shape. The largest single win in the whole
+exercise was not the instruction swap but deleting a redundant copy of the staged activation slab.
+That reading applies to the other small-T kernels too -- they share the shape and the staging
+pattern -- and is the reason a cp.async ring lost at every width here.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -142,8 +142,33 @@ against a 22.3 ms step, 1.15x.
 | programmatic dependent launch to hide kernel ramp | needs sm_90; compiled out on `sm_86` |
 
 What is left at C1 is mostly ramp-up and drain at the ~500 kernel boundaries of a round (the
-Q5 residual kernels reach 68-82% of their streaming floor, gate_up 89%). What is left at C8 is
-tensor-core rate: gate_up at T=32 runs at about 68% of the card's measured bf16 MMA peak.
+Q5 residual kernels reach 68-82% of their streaming floor, gate_up 89%).
+
+**What is left at C8 is not tensor-core rate, though this page said so for a cycle.** The claim was
+that gate_up at T=32 runs at about 68% of the card's measured bf16 MMA peak -- 205 us against a
+139 us tensor floor -- which reads as a kernel most of the way to saturating its tensor cores.
+Counters disagree. `ncu` on the T=32 gate_up kernel, Windows RTX 3090 at 315 W:
+
+| | BF16 small-T | int8 small-T |
+|---|---:|---:|
+| tensor pipe active | **38.3%** | 21.0% |
+| L1/TEX throughput | 36.4% | 73.5% |
+| DRAM throughput | 39.4% | 42.7% |
+| warp occupancy | 30.9% | 45.4% |
+
+Nothing is near saturation in the BF16 column: tensor, L1 and DRAM all sit within three points of
+each other around 38%, at 31% occupancy, which is the signature of a latency-bound kernel rather
+than one limited by any unit. The 68% figure compares against a computed floor, not against a
+measured pipe, and the two do not agree.
+
+That distinction decided a real experiment. An int8 tensor-core route for this Op was built on the
+strength of the old reading, since s8 MMA is about 4.7x the bf16 rate on this hardware. It
+delivered 4-6%, not 4.7x, and the right column above says why: it did exactly what a denser MMA
+should, halving tensor-pipe pressure from 38.3% to 21.0%, but that pipe was never the constraint,
+and the cost of getting there landed on L1 at 73.5%. See
+[the quality-trade notes](maintainer/quality-trade-experiments.md) and
+`src/ops/linear/q4/q4_small_t_mma_i8.cuh`. Work aimed at C8 should target operand movement and
+occupancy; a wider tile that puts more work in flight is the lever the counters actually point at.
 
 **Reproduce.** Build both trees with `-DNINFER_BUILD_APPS=ON -DNINFER_BUILD_BENCHMARKS=ON` and run
 each harness against both `ninfer-serve` binaries on one card, interleaved in one sitting:

--- a/include/ninfer/ops/linear.h
+++ b/include/ninfer/ops/linear.h
@@ -26,6 +26,11 @@ enum class LinearPolicy : std::uint8_t {
     /// scale per weight group and feeds groupwise-int weights to the integer tensor cores. Held
     /// to the same A8 activation allowance.
     AllowA8Int,
+    /// AllowA8Int plus the integer small-T route for the 27B gate_up at decode and verify widths
+    /// (ops/linear/q4/q4_small_t_mma_i8.cuh). Separate because that route is a quality trade the
+    /// prefill one is not asked to carry: it applies s8 activation quantisation to every decode
+    /// step rather than to full prefill tiles only, so it is opt-in per engine.
+    AllowA8IntDecode,
 };
 
 /**

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -198,6 +198,9 @@ struct EngineOptions {
     // per-slot host state image.
     bool lm_head_q4                        = false;
     bool gdn_state_fp16                    = false;
+    // Integer-activation MLP gate_up at decode and verify widths. Measured 4-6% off that Op from
+    // sixteen columns up; see docs/maintainer/quality-trade-experiments.md.
+    bool mlp_a8_decode                     = false;
     // Largest merged-token count one media item may occupy; larger media is downscaled at
     // preprocessing. Also bounds the overlay window.
     std::uint32_t vision_max_merged_tokens = 16384;

--- a/src/ops/linear/q4/q4_small_t_mma.cuh
+++ b/src/ops/linear/q4/q4_small_t_mma.cuh
@@ -70,8 +70,9 @@ struct Q4SmallTStorage {
 // grid is output rows / (RowPolicy::kOutputRowsPerTile * kRowTiles).
 template <class Geometry, int TileCols, int ActiveCols, class Epilogue = Q4SmallTMmaStoreEpilogue,
           class RowPolicy = Q4SmallTMmaIdentityRows, bool MaskedColumns = false, int KWarps = 8,
-          int Stages = 1, int TilesPerWarp = 1>
-__launch_bounds__(256, (KWarps < 8 ? 2 : (TileCols <= 16 ? 6 : 4))) __global__
+          int Stages = 1, int TilesPerWarp = 1,
+          int MinBlocks = (KWarps < 8 ? 2 : (TileCols <= 16 ? 6 : 4))>
+__launch_bounds__(256, MinBlocks) __global__
     void q4_small_t_mma_kernel(const __nv_bfloat16* __restrict__ x,
                                const std::uint8_t* __restrict__ codes,
                                const std::uint8_t* __restrict__ scales,
@@ -315,7 +316,8 @@ __launch_bounds__(256, (KWarps < 8 ? 2 : (TileCols <= 16 ? 6 : 4))) __global__
 // Launches q4_small_t_mma_kernel over `blocks` CTAs.
 template <class Geometry, int TileCols, int ActiveCols, class Epilogue = Q4SmallTMmaStoreEpilogue,
           class RowPolicy = Q4SmallTMmaIdentityRows, bool MaskedColumns = false, int KWarps = 8,
-          int Stages = 1, int TilesPerWarp = 1>
+          int Stages = 1, int TilesPerWarp = 1,
+          int MinBlocks = (KWarps < 8 ? 2 : (TileCols <= 16 ? 6 : 4))>
 void q4_small_t_mma_launch(int blocks, cudaStream_t stream, const __nv_bfloat16* x,
                            const std::uint8_t* codes, const std::uint8_t* scales,
                            __nv_bfloat16* out, Epilogue epilogue = {}, RowPolicy row_policy = {},
@@ -323,7 +325,7 @@ void q4_small_t_mma_launch(int blocks, cudaStream_t stream, const __nv_bfloat16*
     constexpr int kBytes  = Q4SmallTStorage<KWarps, TileCols, Stages, TilesPerWarp>::kBytes;
     constexpr auto kernel = q4_small_t_mma_kernel<Geometry, TileCols, ActiveCols, Epilogue,
                                                   RowPolicy, MaskedColumns, KWarps, Stages,
-                                                  TilesPerWarp>;
+                                                  TilesPerWarp, MinBlocks>;
     static_assert(kBytes <= 48 * 1024, "small-T MMA stages must fit static shared memory");
     kernel<<<blocks, SmallTLayout<KWarps>::kThreads, 0, stream>>>(x, codes, scales, out, epilogue,
                                                                    row_policy, columns);

--- a/src/ops/linear/q4/q4_small_t_mma_i8.cuh
+++ b/src/ops/linear/q4/q4_small_t_mma_i8.cuh
@@ -1,0 +1,389 @@
+// Int8 tensor-core small-T kernel for the C8 cohort-decode regime, the counterpart of
+// q4_small_t_mma.cuh. Weight storage stays Q4G64 (4 bits/code, the same artifact bytes);
+// activations are quantised to s8 with one scale per (token, 64-k group), matching the weight's own
+// group size, and both operands feed mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32. The same
+// instruction and rescale are proven at the 128-token prefill tile in
+// ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h; this file narrows them to small T.
+//
+// Result at T=32 on the 27B gate_up, cold, median of 21, paired against the bf16 small-T kernel in
+// one sitting (the card drifts several percent between sittings, so only the pairing is meaningful):
+// 220.2 against 236.5, 193.5 against 203.8, 192.5 against 204.8 -- 5-7% faster in all three.
+// Relative L2 against the fp64 oracle is 0.0297, the same order as the prefill route's 0.023-0.031,
+// and the cost is the activation quantisation error the A16 route does not have.
+//
+// What ncu says this kernel is, which is not what the roofline predicted. docs/performance.md put
+// gate_up at T=32 at ~68% of the card's bf16 MMA peak and called C8 tensor-rate bound, which is why
+// int8 was the lever. It is not what binds here: at 64 registers and no spills this kernel runs at
+// 74% L1/TEX throughput against 42% DRAM and 47% SM, so operand movement through L1 and shared
+// memory is the limit, not the MMA rate. The int8 MMA's arithmetic advantage is therefore mostly
+// unspendable at this shape -- the win above is what is left after the traffic was cut, not the
+// 4.7x the instruction rate alone would suggest. A wider tile that spends the spare tensor rate is
+// where the rest would have to come from.
+//
+// Measured and rejected on the way, so nobody re-runs them (all at T=32, same harness):
+//
+//   staging each tile group's own copy of the activation slab   311.6us ncu / 280.6 wall
+//     -- kTileGroups-fold redundant reads and shared writes of identical bytes, 77.9% L1/TEX
+//   16-byte weight staging copies (lane -> row, 16B chunk)      273.4us
+//     -- halves the transaction count and loses anyway; the (gid, tig) mapping the compute loop
+//        reads by is also the one that stages fastest
+//   two row tiles per warp (each B fragment feeds both)         275.5us
+//     -- same verdict the bf16 kernel records for 32 columns
+//   KWarps 2 with a 2- or 3-deep cp.async ring                  249.9 / 260.1us
+//   KWarps 4 with a 2-deep ring                                 263.2us
+//
+// KWarps 4 with a single stage wins: at 20 outer steps rather than 40 it splits K harder, and the
+// ring it does without was never hiding DRAM latency in the first place -- see the L1 reading above.
+
+#include "ops/common/mma.cuh"
+#include "ops/common/memory.cuh"
+#include "ops/common/small_t_layout.cuh"
+#include "ops/linear/q4/q4_rowsplit_storage.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <cstdint>
+#include <type_traits>
+
+namespace ninfer::ops::detail {
+
+// Eight packed Q4 codes -> two s8-packed words of four codes each, in natural physical k order
+// (verified against the fp64 oracle via q4a8_linear_swiglu.cu's identical formula). w0 holds codes
+// 0..3, w1 holds codes 4..7.
+__device__ __forceinline__ void q4_unpack_s8(unsigned word, unsigned& w0, unsigned& w1) {
+    word ^= 0x88888888u;
+    const unsigned mask = 0x0f0f0f0fu;
+    const unsigned even = __vsub4(word & mask, 0x08080808u);
+    const unsigned odd  = __vsub4((word >> 4) & mask, 0x08080808u);
+    w0                  = __byte_perm(even, odd, 0x5140);
+    w1                  = __byte_perm(even, odd, 0x7362);
+}
+
+struct Q4SmallTMmaI8StoreEpilogue {};
+
+// Shared storage for a ring of Stages staged K slabs, one 64*KWarps-wide group each. Weight rows
+// stay nibble-packed (32 B/row); activations are already s8 (64 B/col); one scale per (row,
+// 64-group) and per (col, 64-group). Padded so tig's 8-or-16-byte loads never tie the same bank
+// across the four tig values sharing a row.
+template <int KWarps, int TileCols, int Stages, int TilesPerWarp = 1>
+struct Q4SmallTI8Storage {
+    using Layout                     = SmallTLayout<KWarps, TilesPerWarp>;
+    static constexpr int kGroupK     = 64; // one quantisation group
+    static constexpr int kPackedRow  = kGroupK / 2;      // 32: packed nibble bytes per row
+    static constexpr int kSRowPacked = kPackedRow + 16;  // padded
+    static constexpr int kSRowAct    = kGroupK + 16;     // padded
+    static constexpr int kRows       = Layout::kRowsPerCta;
+
+    struct Stage {
+        std::uint8_t weight[KWarps][kRows][kSRowPacked];
+        std::int8_t activation[KWarps][TileCols][kSRowAct];
+        __half w_scale[KWarps][kRows];
+        __half x_scale[KWarps][TileCols];
+    };
+    union Shared {
+        Stage stages[Stages];
+        float partial[Layout::kWarps * TilesPerWarp * (TileCols / 8) * 32 * 4];
+    };
+    static constexpr int kBytes = sizeof(Shared);
+};
+
+// Geometry/TileCols/ActiveCols/Epilogue/RowPolicy/KWarps/Stages/TilesPerWarp mirror
+// q4_small_t_mma_kernel's parameter list exactly. x_codes/x_scales are the pre-quantised
+// activations (q4_small_t_quantize_activations below); codes/scales are the artifact's native
+// Q4G64 planes, unchanged.
+template <class Geometry, int TileCols, int ActiveCols, class Epilogue = Q4SmallTMmaI8StoreEpilogue,
+          class RowPolicy = Q4SmallTMmaIdentityRows, bool MaskedColumns = false, int KWarps = 2,
+          int Stages = 2, int TilesPerWarp = 1>
+__launch_bounds__(256) __global__
+    void q4_small_t_mma_i8_kernel(const std::int8_t* __restrict__ x_codes,
+                                  const __half* __restrict__ x_scales,
+                                  const std::uint8_t* __restrict__ codes,
+                                  const std::uint8_t* __restrict__ scales,
+                                  __nv_bfloat16* __restrict__ out, Epilogue epilogue = {},
+                                  RowPolicy row_policy = {}, int columns = ActiveCols) {
+    using Layout                = SmallTLayout<KWarps, TilesPerWarp>;
+    constexpr int kTpw          = TilesPerWarp;
+    constexpr int kHidden       = Geometry::kInputRows;
+    constexpr int kKWarps       = Layout::kKWarps;
+    constexpr int kRowTiles     = Layout::kRowTiles;
+    constexpr int kGroupK       = 64;
+    constexpr int kGroups       = kHidden / kGroupK;
+    constexpr int kCodeRowBytes = kHidden / 2;
+    constexpr int kTileCols     = TileCols;
+    constexpr int kNt           = kTileCols / 8;
+    constexpr int kTileGroups   = Layout::kWarps / kKWarps;
+    static_assert(kTileCols >= 8 && (kTileCols % 8) == 0);
+    static_assert(ActiveCols >= 1 && ActiveCols <= kTileCols && ActiveCols > kTileCols - 8);
+    static_assert((kHidden % kGroupK) == 0);
+    static_assert(kGroups % kKWarps == 0);
+    static_assert(RowPolicy::kOutputRowsPerTile <= 16);
+    static_assert(Stages >= 1 && Stages <= 4);
+
+    using Storage = Q4SmallTI8Storage<KWarps, TileCols, Stages, TilesPerWarp>;
+    using Stage   = typename Storage::Stage;
+    __shared__ __align__(16) typename Storage::Shared shared;
+
+    constexpr int kOuterSteps = kGroups / kKWarps;
+
+    const int tid          = static_cast<int>(threadIdx.x);
+    const int warp         = tid >> 5;
+    const int lane         = tid & 31;
+    const int gid          = lane >> 2; // 0..7: row/col selector within a group of 8
+    const int tig          = lane & 3;  // 0..3: 8-or-16-byte k quarter
+    const int k_split      = warp % kKWarps;
+    const int tile_group   = warp / kKWarps; // 0..kTileGroups-1, one per set of KWarps warps
+    const int first_tile   = tile_group * kTpw;
+    const int tile0        = static_cast<int>(blockIdx.x) * kRowTiles;
+    const int live_columns = MaskedColumns ? columns : ActiveCols;
+
+    // Stage one 64-wide group of packed weight rows for this K-warp via cp.async; decode happens in
+    // the compute loop once the copy lands. Each 16-row MMA tile needs both its top eight rows
+    // (local_row = gid) and bottom eight (gid + 8).
+    // Wider 16-byte staging copies were tried here and lost: mapping lanes to (row, 16-byte chunk)
+    // halves the transaction count but measured 273.4us against this mapping's 249.9us at T=32, so
+    // the (gid, tig) mapping the compute loop also reads by is kept.
+    const auto stage_weight = [&](int group_index, Stage& stage) {
+        const int group_k0 = (group_index * kKWarps + k_split) * kGroupK;
+#pragma unroll
+        for (int t = 0; t < kTpw; ++t) {
+#pragma unroll
+            for (int half = 0; half < 2; ++half) {
+                const int local_row = gid + half * 8;
+                const int tile_row  = (first_tile + t) * 16 + local_row;
+                const int weight_row = row_policy.weight_row(
+                    (tile0 + first_tile + t) * RowPolicy::kOutputRowsPerTile, local_row);
+                const std::uint8_t* src =
+                    codes + static_cast<std::int64_t>(weight_row) * kCodeRowBytes + group_k0 / 2 +
+                    tig * 8;
+                cp_async<8>(stage.weight[k_split][tile_row] + tig * 8, src);
+                if (tig == 0) {
+                    stage.w_scale[k_split][tile_row] = *reinterpret_cast<const __half*>(
+                        scales +
+                        (static_cast<std::int64_t>(weight_row) * Geometry::kGroupsPerRow +
+                         group_k0 / kGroupK) *
+                            2);
+                }
+            }
+        }
+    };
+
+    // Stage this K-warp's slice of the pre-quantised s8 activations via cp.async (already s8, no
+    // decode needed). The B operand's N = 8 span is exactly the 8 gid values, so unlike the A
+    // operand above no top/bottom split is needed.
+    //
+    // Every row tile reads the same staged slab (ops/common/small_t_layout.cuh), so the eight-column
+    // blocks are dealt out across the tile groups rather than staged by each of them: staging all of
+    // them from every group costs kTileGroups times the global reads and shared writes for identical
+    // bytes, which ncu put at 77.9% L1/TEX throughput against the bf16 kernel's 34.2%.
+    const auto stage_activation = [&](int group_index, Stage& stage) {
+        const int group_k0 = (group_index * kKWarps + k_split) * kGroupK;
+#pragma unroll
+        for (int nt = 0; nt < kNt; ++nt) {
+            if (nt % kTileGroups != tile_group) { continue; }
+            const int col = nt * 8 + gid;
+            if (col >= live_columns) { continue; }
+            const std::int8_t* src =
+                x_codes + static_cast<std::int64_t>(col) * kHidden + group_k0 + tig * 16;
+            cp_async<16>(stage.activation[k_split][col] + tig * 16, src);
+            if (tig == 0) {
+                stage.x_scale[k_split][col] =
+                    x_scales[static_cast<std::int64_t>(col) * kGroups + group_k0 / kGroupK];
+            }
+        }
+    };
+
+    const auto issue_group = [&](int group_index) {
+        if (group_index < kOuterSteps) {
+            Stage& stage = shared.stages[group_index % Stages];
+            stage_weight(group_index, stage);
+            stage_activation(group_index, stage);
+        }
+        cp_commit(); // empty commits keep cp_wait<Stages - 1> exact through the tail
+    };
+
+    float acc[kTpw][kNt][4] = {};
+
+#pragma unroll
+    for (int prefetch = 0; prefetch < Stages - 1; ++prefetch) { issue_group(prefetch); }
+
+#pragma unroll 1
+    for (int group_index = 0; group_index < kOuterSteps; ++group_index) {
+        issue_group(group_index + Stages - 1);
+        cp_wait<Stages - 1>();
+        __syncthreads();
+
+        const Stage& stage             = shared.stages[group_index % Stages];
+        float group_acc[kTpw][kNt][4] = {};
+#pragma unroll
+        for (int t = 0; t < kTpw; ++t) {
+            const int tile_row = (first_tile + t) * 16 + gid;
+            const uint2 lo_packed =
+                *reinterpret_cast<const uint2*>(stage.weight[k_split][tile_row] + tig * 8);
+            const uint2 hi_packed =
+                *reinterpret_cast<const uint2*>(stage.weight[k_split][tile_row + 8] + tig * 8);
+            unsigned lo0, lo1, lo2, lo3, hi0, hi1, hi2, hi3;
+            q4_unpack_s8(lo_packed.x, lo0, lo1);
+            q4_unpack_s8(lo_packed.y, lo2, lo3);
+            q4_unpack_s8(hi_packed.x, hi0, hi1);
+            q4_unpack_s8(hi_packed.y, hi2, hi3);
+            const unsigned af[2][4] = {{lo0, hi0, lo1, hi1}, {lo2, hi2, lo3, hi3}};
+#pragma unroll
+            for (int nt = 0; nt < kNt; ++nt) {
+                const int col = nt * 8 + gid;
+                uint4 b       = make_uint4(0u, 0u, 0u, 0u);
+                if (col < live_columns) {
+                    b = *reinterpret_cast<const uint4*>(stage.activation[k_split][col] + tig * 16);
+                }
+                const unsigned bf[2][2] = {{b.x, b.y}, {b.z, b.w}};
+                int s[4]                = {0, 0, 0, 0};
+#pragma unroll
+                for (int ks = 0; ks < 2; ++ks) {
+                    mma_s8(s[0], s[1], s[2], s[3], af[ks][0], af[ks][1], af[ks][2], af[ks][3],
+                           bf[ks][0], bf[ks][1]);
+                }
+                float(&g)[4] = group_acc[t][nt];
+                g[0] += static_cast<float>(s[0]);
+                g[1] += static_cast<float>(s[1]);
+                g[2] += static_cast<float>(s[2]);
+                g[3] += static_cast<float>(s[3]);
+            }
+        }
+
+#pragma unroll
+        for (int t = 0; t < kTpw; ++t) {
+            const int tile_row    = (first_tile + t) * 16 + gid;
+            const float top_scale = __half2float(stage.w_scale[k_split][tile_row]);
+            const float bot_scale = __half2float(stage.w_scale[k_split][tile_row + 8]);
+#pragma unroll
+            for (int nt = 0; nt < kNt; ++nt) {
+                // The MMA's fixed output-fragment layout gives this lane accumulator values for
+                // columns {2*tig, 2*tig+1} of this nt's 8-column block -- not the gid-indexed
+                // column this lane happened to *load* for the B operand (that indexing is the
+                // input-side collaborative-load pattern; the instruction redistributes results
+                // across lanes independently of it). Same convention as q4a8_linear_swiglu.cu.
+                const int col0  = nt * 8 + 2 * tig;
+                const float xa0 = __half2float(stage.x_scale[k_split][col0]);
+                const float xa1 = __half2float(stage.x_scale[k_split][col0 + 1]);
+                acc[t][nt][0] = fmaf(group_acc[t][nt][0], top_scale * xa0, acc[t][nt][0]);
+                acc[t][nt][1] = fmaf(group_acc[t][nt][1], top_scale * xa1, acc[t][nt][1]);
+                acc[t][nt][2] = fmaf(group_acc[t][nt][2], bot_scale * xa0, acc[t][nt][2]);
+                acc[t][nt][3] = fmaf(group_acc[t][nt][3], bot_scale * xa1, acc[t][nt][3]);
+            }
+        }
+        // The next iteration's issue_group writes the stage this one just read.
+        __syncthreads();
+    }
+    cp_wait<0>();
+
+    // K-warp reduction: odd warps publish, even ones fold, warp 0 sums the rest. Identical to
+    // q4_small_t_mma.cuh's tree; operates on plain floats so it is dtype-agnostic.
+    __syncthreads();
+    auto* partial   = shared.partial;
+    const auto slot = [&](int w, int t, int nt) {
+        return partial + (((w * kTpw + t) * kNt + nt) * 32 + lane) * 4;
+    };
+    if ((k_split & 1) != 0) {
+#pragma unroll
+        for (int t = 0; t < kTpw; ++t) {
+#pragma unroll
+            for (int nt = 0; nt < kNt; ++nt) {
+                const float(&a)[4] = acc[t][nt];
+                *reinterpret_cast<float4*>(slot(warp, t, nt)) = make_float4(a[0], a[1], a[2], a[3]);
+            }
+        }
+    }
+    __syncthreads();
+    if ((k_split & 1) == 0) {
+#pragma unroll
+        for (int t = 0; t < kTpw; ++t) {
+#pragma unroll
+            for (int nt = 0; nt < kNt; ++nt) {
+                float(&a)[4]         = acc[t][nt];
+                const float4 partner = *reinterpret_cast<const float4*>(slot(warp + 1, t, nt));
+                a[0] += partner.x;
+                a[1] += partner.y;
+                a[2] += partner.z;
+                a[3] += partner.w;
+                if (k_split != 0) {
+                    *reinterpret_cast<float4*>(slot(warp, t, nt)) =
+                        make_float4(a[0], a[1], a[2], a[3]);
+                }
+            }
+        }
+    }
+    if constexpr (kKWarps > 2) { __syncthreads(); }
+
+    if (k_split == 0) {
+#pragma unroll
+        for (int t = 0; t < kTpw; ++t) {
+            const int row0 = (tile0 + first_tile + t) * RowPolicy::kOutputRowsPerTile;
+#pragma unroll
+            for (int nt = 0; nt < kNt; ++nt) {
+                float4 sum = make_float4(acc[t][nt][0], acc[t][nt][1], acc[t][nt][2], acc[t][nt][3]);
+#pragma unroll
+                for (int split = 2; split < kKWarps; split += 2) {
+                    const float4 value = *reinterpret_cast<const float4*>(slot(warp + split, t, nt));
+                    sum.x += value.x;
+                    sum.y += value.y;
+                    sum.z += value.z;
+                    sum.w += value.w;
+                }
+                const int col0 = nt * 8 + 2 * tig;
+                epilogue.template store<ActiveCols>(row0 + gid, col0, sum);
+            }
+        }
+    }
+}
+
+// One scale per (token, 64-k group), matching the weight's own group size. bf16 activations in
+// [rows, tokens]; codes/scales sized rows*tokens and tokens*(rows/64) respectively.
+__global__ void q4_small_t_quantize_activations_kernel(const __nv_bfloat16* __restrict__ x,
+                                                        std::int32_t rows, std::int32_t tokens,
+                                                        std::int8_t* __restrict__ codes,
+                                                        __half* __restrict__ scales) {
+    const int token  = static_cast<int>(blockIdx.x);
+    const int groups = rows / 64;
+    if (token >= tokens) { return; }
+    for (int g = static_cast<int>(threadIdx.x); g < groups; g += static_cast<int>(blockDim.x)) {
+        const __nv_bfloat16* src = x + static_cast<std::int64_t>(token) * rows + g * 64;
+        float amax               = 0.0F;
+#pragma unroll
+        for (int j = 0; j < 64; ++j) { amax = fmaxf(amax, fabsf(__bfloat162float(src[j]))); }
+        amax                                                = fmaxf(amax, 1.0e-20F);
+        scales[static_cast<std::int64_t>(token) * groups + g] = __float2half(amax / 127.0F);
+        const float inv                                       = 127.0F / amax;
+        std::int8_t* dst = codes + static_cast<std::int64_t>(token) * rows + g * 64;
+#pragma unroll
+        for (int j = 0; j < 64; ++j) {
+            const float v = __bfloat162float(src[j]) * inv;
+            dst[j]        = static_cast<std::int8_t>(max(-127, min(127, __float2int_rn(v))));
+        }
+    }
+}
+
+inline void q4_small_t_quantize_activations(const __nv_bfloat16* x, std::int32_t rows,
+                                            std::int32_t tokens, std::int8_t* codes,
+                                            __half* scales, cudaStream_t stream) {
+    q4_small_t_quantize_activations_kernel<<<tokens, 128, 0, stream>>>(x, rows, tokens, codes,
+                                                                        scales);
+}
+
+template <class Geometry, int TileCols, int ActiveCols, class Epilogue = Q4SmallTMmaI8StoreEpilogue,
+          class RowPolicy = Q4SmallTMmaIdentityRows, bool MaskedColumns = false, int KWarps = 2,
+          int Stages = 2, int TilesPerWarp = 1>
+void q4_small_t_mma_i8_launch(int blocks, cudaStream_t stream, const std::int8_t* x_codes,
+                              const __half* x_scales, const std::uint8_t* codes,
+                              const std::uint8_t* scales, __nv_bfloat16* out,
+                              Epilogue epilogue = {}, RowPolicy row_policy = {},
+                              int columns = ActiveCols) {
+    constexpr int kBytes = Q4SmallTI8Storage<KWarps, TileCols, Stages, TilesPerWarp>::kBytes;
+    constexpr auto kernel =
+        q4_small_t_mma_i8_kernel<Geometry, TileCols, ActiveCols, Epilogue, RowPolicy,
+                                 MaskedColumns, KWarps, Stages, TilesPerWarp>;
+    static_assert(kBytes <= 48 * 1024, "small-T i8 MMA ring must fit static shared memory");
+    kernel<<<blocks, SmallTLayout<KWarps>::kThreads, 0, stream>>>(
+        x_codes, x_scales, codes, scales, out, epilogue, row_policy, columns);
+}
+
+} // namespace ninfer::ops::detail

--- a/src/ops/linear/q4/q4_small_t_mma_i8.cuh
+++ b/src/ops/linear/q4/q4_small_t_mma_i8.cuh
@@ -5,11 +5,22 @@
 // instruction and rescale are proven at the 128-token prefill tile in
 // ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h; this file narrows them to small T.
 //
-// Result at T=32 on the 27B gate_up, cold, median of 21, paired against the bf16 small-T kernel in
-// one sitting (the card drifts several percent between sittings, so only the pairing is meaningful):
-// 220.2 against 236.5, 193.5 against 203.8, 192.5 against 204.8 -- 5-7% faster in all three.
-// Relative L2 against the fp64 oracle is 0.0297, the same order as the prefill route's 0.023-0.031,
-// and the cost is the activation quantisation error the A16 route does not have.
+// Result on the 27B gate_up, cold, median of 15, each width paired against the bf16 small-T kernel
+// inside one sitting -- the card drifts several percent between sittings, so only the pairing is
+// meaningful. Two sittings, i8 against bf16:
+//
+//   T        8      12      16      20      24      28      32
+//   run 1  +10.7%  -5.8%   -3.4%   -4.8%   -4.8%   -5.0%   -4.5%
+//   run 2   +7.5%  +4.3%   -0.7%   -5.9%   -6.1%   -4.0%   -6.4%
+//
+// So it wins from sixteen columns up, by 4-6%, and loses at eight: a 64-k group of eight columns has
+// too little MMA work to pay for quantising the activations, which costs a fixed ~10us pre-pass
+// (measured by skipping it) plus a scale plane the A16 route does not read. Twelve is inside the
+// noise. A route table would want it from 16 upward and not below.
+//
+// Relative L2 against the fp64 oracle is 0.0080-0.0371 across T=2..32, against the prefill route's
+// 0.023-0.031 at its own widths, and the cost is the activation quantisation error the A16 route
+// does not have.
 //
 // What ncu says this kernel is, which is not what the roofline predicted. docs/performance.md put
 // gate_up at T=32 at ~68% of the card's bf16 MMA peak and called C8 tensor-rate bound, which is why
@@ -31,9 +42,21 @@
 //     -- same verdict the bf16 kernel records for 32 columns
 //   KWarps 2 with a 2- or 3-deep cp.async ring                  249.9 / 260.1us
 //   KWarps 4 with a 2-deep ring                                 263.2us
+//   a runtime column count instead of padding to the tile width  222.2us at T=28 against 196.6
+//     -- the staging bounds test cannot fold away and sits beside the tile-group test
 //
-// KWarps 4 with a single stage wins: at 20 outer steps rather than 40 it splits K harder, and the
-// ring it does without was never hiding DRAM latency in the first place -- see the L1 reading above.
+// KWarps 4 with a single stage wins at every width from sixteen columns up, and eight columns wants
+// KWarps 8: at 20 outer steps rather than 40 it splits K harder, and the ring it does without was
+// never hiding DRAM latency in the first place -- see the L1 reading above. Swept per band:
+//
+//   TileCols   KWarps 8   KWarps 4   KWarps 2
+//   8            137.2      139.3      237.6
+//   16           176.1      154.6      214.0
+//   24             --       179.2      220.2      (two stages: 198.7 / 233.5)
+//   32             --       220.2      255.0      (two stages: 262.1 / 255.0)
+//
+// Columns are padded to the tile width by the launcher rather than masked at runtime, for the
+// reason the rejected list gives.
 
 #include "ops/common/mma.cuh"
 #include "ops/common/memory.cuh"
@@ -182,7 +205,13 @@ __launch_bounds__(256) __global__
         for (int nt = 0; nt < kNt; ++nt) {
             if (nt % kTileGroups != tile_group) { continue; }
             const int col = nt * 8 + gid;
-            if (col >= live_columns) { continue; }
+            if (col >= live_columns) {
+                // Masked column. The compute loop zeroes its B fragment, but the rescale still
+                // multiplies by this scale, so zero it rather than leave the previous group's --
+                // a stale scale times a zero product is harmless, an uninitialised one need not be.
+                if (tig == 0) { stage.x_scale[k_split][col] = __float2half(0.0F); }
+                continue;
+            }
             const std::int8_t* src =
                 x_codes + static_cast<std::int64_t>(col) * kHidden + group_k0 + tig * 16;
             cp_async<16>(stage.activation[k_split][col] + tig * 16, src);

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
@@ -5,6 +5,7 @@
 #include "ops/common/warp.cuh"
 #include "core/device.h" // CUDA_CHECK
 #include "ops/linear/q4/q4_small_t_mma.cuh"
+#include "ops/linear/q4/q4_small_t_mma_i8.cuh"
 
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
@@ -244,6 +245,46 @@ void q4_linear_swiglu_small_t_tiled_launch(const Tensor& x, const Weight& w, Ten
         throw std::invalid_argument("Q4 LinearSwiGLU exact small-T requires T=2..32");
     }
     kSmallTLaunchers[static_cast<std::size_t>((x.ne[1] - 1) / 8)](x, w, out, stream);
+}
+
+std::size_t q4_linear_swiglu_small_t_tiled_i8_workspace_bytes(std::int32_t tokens) {
+    // s8 codes plus one FP16 scale per (token, group), 256-aligned like q4a8_swiglu's workspace.
+    const std::size_t t = static_cast<std::size_t>(tokens);
+    return ((t * kK + 255) / 256) * 256 + ((t * kGroups * sizeof(__half) + 255) / 256) * 256;
+}
+
+void q4_linear_swiglu_small_t_tiled_i8_launch(const Tensor& x, const Weight& w, Tensor& out,
+                                              WorkspaceArena& workspace, cudaStream_t stream) {
+    const std::int32_t tokens = x.ne[1];
+    if (tokens != 32) {
+        throw std::invalid_argument("Q4 LinearSwiGLU small-T i8 (first pass) requires T=32");
+    }
+    if (w.n != kN || w.k != kK || w.padded_shape[1] != kK) {
+        throw std::invalid_argument("q4 linear_swiglu small-T i8 requires weight [34816,5120]");
+    }
+
+    auto scope             = workspace.scope();
+    const DeviceSpan codes = workspace.alloc_bytes(static_cast<std::size_t>(tokens) * kK);
+    const DeviceSpan xscale =
+        workspace.alloc_bytes(static_cast<std::size_t>(tokens) * kGroups * sizeof(__half));
+    q4_small_t_quantize_activations(static_cast<const __nv_bfloat16*>(x.data), kK, tokens,
+                                    reinterpret_cast<std::int8_t*>(codes.data),
+                                    reinterpret_cast<__half*>(xscale.data), stream);
+
+    constexpr int kKWarps       = 4;
+    constexpr int kStages       = 1;
+    constexpr int kTilesPerWarp = 1;
+    using Layout                = SmallTLayout<kKWarps, kTilesPerWarp>;
+    constexpr int kBlocks =
+        kIntermediate / (Q4SwiGluSmallTRows::kOutputRowsPerTile * Layout::kRowTiles);
+    const Q4SwiGluSmallTEpilogue epilogue{static_cast<__nv_bfloat16*>(out.data), tokens};
+    q4_small_t_mma_i8_launch<Q4SwiGluSmallTGeometry, 32, 32, Q4SwiGluSmallTEpilogue,
+                             Q4SwiGluSmallTRows, false, kKWarps, kStages, kTilesPerWarp>(
+        kBlocks, stream, reinterpret_cast<const std::int8_t*>(codes.data),
+        reinterpret_cast<const __half*>(xscale.data), static_cast<const std::uint8_t*>(w.qdata),
+        static_cast<const std::uint8_t*>(w.scales), static_cast<__nv_bfloat16*>(out.data),
+        epilogue, Q4SwiGluSmallTRows{}, tokens);
+    CUDA_CHECK(cudaGetLastError());
 }
 
 } // namespace ninfer::ops::detail

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
@@ -115,6 +115,52 @@ constexpr auto make_small_t_launchers(std::index_sequence<Offsets...>) {
 
 constexpr auto kSmallTLaunchers = make_small_t_launchers(std::make_index_sequence<4>{});
 
+using SmallTI8Launcher = void (*)(const Tensor&, const Weight&, Tensor&, const std::int8_t*,
+                                  const __half*, cudaStream_t);
+
+// Per-width schedule for the int8 small-T kernel (ops/linear/q4/q4_small_t_mma_i8.cuh). Swept the
+// same way the bf16 table above was: one kernel, cold L2, paired against the bf16 kernel in the
+// same sitting. Numbers live beside the sweep in the kernel header.
+template <int TileCols>
+struct Q4SwiGluSmallTI8Tile {
+    static constexpr int kKWarps =
+        TileCols <= 8 ? 8 : (TileCols <= 16 ? 4 : (TileCols <= 24 ? 4 : 4));
+    static constexpr int kStages =
+        TileCols <= 8 ? 1 : (TileCols <= 16 ? 1 : (TileCols <= 24 ? 1 : 1));
+    static constexpr int kTilesPerWarp = 1;
+};
+
+// Masked is a runtime column count, so the staging loop's bounds test cannot fold away. That costs
+// this kernel more than it costs the bf16 one -- its staging carries a tile-group test as well --
+// and measured 225.3us against 206.8 at T=32 where an exact width runs 220.2 against 236.5. Widths
+// that fill their tile exactly therefore get their own unmasked instantiation.
+template <int ActiveCols, bool Masked>
+void launch_small_t_i8_active(const Tensor& x, const Weight& w, Tensor& out,
+                              const std::int8_t* x_codes, const __half* x_scales,
+                              cudaStream_t stream) {
+    constexpr int TileCols =
+        ActiveCols <= 8 ? 8 : (ActiveCols <= 16 ? 16 : (ActiveCols <= 24 ? 24 : 32));
+    using Tile            = Q4SwiGluSmallTI8Tile<TileCols>;
+    using Layout          = SmallTLayout<Tile::kKWarps, Tile::kTilesPerWarp>;
+    constexpr int kBlocks =
+        kIntermediate / (Q4SwiGluSmallTRows::kOutputRowsPerTile * Layout::kRowTiles);
+    const Q4SwiGluSmallTEpilogue epilogue{static_cast<__nv_bfloat16*>(out.data), x.ne[1]};
+    q4_small_t_mma_i8_launch<Q4SwiGluSmallTGeometry, TileCols, ActiveCols,
+                             Q4SwiGluSmallTEpilogue, Q4SwiGluSmallTRows, Masked, Tile::kKWarps,
+                             Tile::kStages, Tile::kTilesPerWarp>(
+        kBlocks, stream, x_codes, x_scales, static_cast<const std::uint8_t*>(w.qdata),
+        static_cast<const std::uint8_t*>(w.scales), static_cast<__nv_bfloat16*>(out.data),
+        epilogue, Q4SwiGluSmallTRows{}, x.ne[1]);
+}
+
+template <bool Masked, std::size_t... Offsets>
+constexpr auto make_small_t_i8_launchers(std::index_sequence<Offsets...>) {
+    return std::array<SmallTI8Launcher, sizeof...(Offsets)>{
+        &launch_small_t_i8_active<8 * (1 + static_cast<int>(Offsets)), Masked>...};
+}
+
+constexpr auto kSmallTI8Launchers = make_small_t_i8_launchers<false>(std::make_index_sequence<4>{});
+
 __device__ __forceinline__ void q4_issue_pair_tile(uint4 (*__restrict__ s_code)[kVecsPerWarpTile],
                                                    uint4 (*__restrict__ s_scale)[2],
                                                    const std::uint8_t* __restrict__ gate_code_row,
@@ -248,42 +294,52 @@ void q4_linear_swiglu_small_t_tiled_launch(const Tensor& x, const Weight& w, Ten
 }
 
 std::size_t q4_linear_swiglu_small_t_tiled_i8_workspace_bytes(std::int32_t tokens) {
-    // s8 codes plus one FP16 scale per (token, group), 256-aligned like q4a8_swiglu's workspace.
-    const std::size_t t = static_cast<std::size_t>(tokens);
+    // s8 codes plus one FP16 scale per (token, group), 256-aligned like q4a8_swiglu's workspace,
+    // over the padded tile width rather than the request's: see the launch below for why the pad
+    // columns exist.
+    const std::size_t t = static_cast<std::size_t>((tokens + 7) / 8 * 8);
     return ((t * kK + 255) / 256) * 256 + ((t * kGroups * sizeof(__half) + 255) / 256) * 256;
 }
 
 void q4_linear_swiglu_small_t_tiled_i8_launch(const Tensor& x, const Weight& w, Tensor& out,
                                               WorkspaceArena& workspace, cudaStream_t stream) {
     const std::int32_t tokens = x.ne[1];
-    if (tokens != 32) {
-        throw std::invalid_argument("Q4 LinearSwiGLU small-T i8 (first pass) requires T=32");
+    if (tokens < 2 || tokens > 32) {
+        throw std::invalid_argument("Q4 LinearSwiGLU small-T i8 requires T=2..32");
     }
     if (w.n != kN || w.k != kK || w.padded_shape[1] != kK) {
         throw std::invalid_argument("q4 linear_swiglu small-T i8 requires weight [34816,5120]");
     }
 
-    auto scope             = workspace.scope();
-    const DeviceSpan codes = workspace.alloc_bytes(static_cast<std::size_t>(tokens) * kK);
+    // Columns are padded up to the tile width and the pad zeroed, so every width runs the
+    // compile-time-width kernel rather than one carrying a runtime column count. Masking is not
+    // free here: the staging loop's bounds test cannot fold away and it sits beside a tile-group
+    // test, which measured T=28 at 222.2us against T=32's 193.5 on the same 32-wide tile. The
+    // epilogue already discards columns past the request, so the pad needs no handling beyond
+    // being zero -- its MMAs were issued by the masked path too, only against a zeroed fragment.
+    const std::int32_t padded = (tokens + 7) / 8 * 8;
+    auto scope                = workspace.scope();
+    const DeviceSpan codes    = workspace.alloc_bytes(static_cast<std::size_t>(padded) * kK);
     const DeviceSpan xscale =
-        workspace.alloc_bytes(static_cast<std::size_t>(tokens) * kGroups * sizeof(__half));
+        workspace.alloc_bytes(static_cast<std::size_t>(padded) * kGroups * sizeof(__half));
+    if (padded != tokens) {
+        const std::size_t pad_codes = static_cast<std::size_t>(padded - tokens) * kK;
+        CUDA_CHECK(cudaMemsetAsync(static_cast<std::uint8_t*>(codes.data) +
+                                       static_cast<std::size_t>(tokens) * kK,
+                                   0, pad_codes, stream));
+        const std::size_t pad_scales =
+            static_cast<std::size_t>(padded - tokens) * kGroups * sizeof(__half);
+        CUDA_CHECK(cudaMemsetAsync(static_cast<std::uint8_t*>(xscale.data) +
+                                       static_cast<std::size_t>(tokens) * kGroups * sizeof(__half),
+                                   0, pad_scales, stream));
+    }
     q4_small_t_quantize_activations(static_cast<const __nv_bfloat16*>(x.data), kK, tokens,
                                     reinterpret_cast<std::int8_t*>(codes.data),
                                     reinterpret_cast<__half*>(xscale.data), stream);
 
-    constexpr int kKWarps       = 4;
-    constexpr int kStages       = 1;
-    constexpr int kTilesPerWarp = 1;
-    using Layout                = SmallTLayout<kKWarps, kTilesPerWarp>;
-    constexpr int kBlocks =
-        kIntermediate / (Q4SwiGluSmallTRows::kOutputRowsPerTile * Layout::kRowTiles);
-    const Q4SwiGluSmallTEpilogue epilogue{static_cast<__nv_bfloat16*>(out.data), tokens};
-    q4_small_t_mma_i8_launch<Q4SwiGluSmallTGeometry, 32, 32, Q4SwiGluSmallTEpilogue,
-                             Q4SwiGluSmallTRows, false, kKWarps, kStages, kTilesPerWarp>(
-        kBlocks, stream, reinterpret_cast<const std::int8_t*>(codes.data),
-        reinterpret_cast<const __half*>(xscale.data), static_cast<const std::uint8_t*>(w.qdata),
-        static_cast<const std::uint8_t*>(w.scales), static_cast<__nv_bfloat16*>(out.data),
-        epilogue, Q4SwiGluSmallTRows{}, tokens);
+    kSmallTI8Launchers[static_cast<std::size_t>(padded / 8 - 1)](
+        x, w, out, reinterpret_cast<const std::int8_t*>(codes.data),
+        reinterpret_cast<const __half*>(xscale.data), stream);
     CUDA_CHECK(cudaGetLastError());
 }
 

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
@@ -90,7 +90,11 @@ struct Q4SwiGluSmallTTile {
     static constexpr int kTilesPerWarp = TileCols == 24 ? 2 : 1;
 };
 
-template <int ActiveCols>
+// Masked carries the column count at runtime, which the staging loop's trip count and the inner
+// loop's per-fragment bounds test both depend on. A cohort that exactly fills its tile -- eight
+// lanes verifying four MTP columns is thirty-two -- does not need either, and an unmasked
+// instantiation lets both fold away.
+template <int ActiveCols, bool Masked>
 void launch_small_t_active(const Tensor& x, const Weight& w, Tensor& out, cudaStream_t stream) {
     constexpr int TileCols =
         ActiveCols <= 8 ? 8 : (ActiveCols <= 16 ? 16 : (ActiveCols <= 24 ? 24 : 32));
@@ -100,7 +104,7 @@ void launch_small_t_active(const Tensor& x, const Weight& w, Tensor& out, cudaSt
                                              Layout::kRowTiles);
     const Q4SwiGluSmallTEpilogue epilogue{static_cast<__nv_bfloat16*>(out.data), x.ne[1]};
     q4_small_t_mma_launch<Q4SwiGluSmallTGeometry, TileCols, ActiveCols, Q4SwiGluSmallTEpilogue,
-                          Q4SwiGluSmallTRows, true, Tile::kKWarps, Tile::kStages,
+                          Q4SwiGluSmallTRows, Masked, Tile::kKWarps, Tile::kStages,
                           Tile::kTilesPerWarp>(
         kBlocks, stream, static_cast<const __nv_bfloat16*>(x.data),
         static_cast<const std::uint8_t*>(w.qdata), static_cast<const std::uint8_t*>(w.scales),
@@ -108,13 +112,15 @@ void launch_small_t_active(const Tensor& x, const Weight& w, Tensor& out, cudaSt
     CUDA_CHECK(cudaGetLastError());
 }
 
-template <std::size_t... Offsets>
+template <bool Masked, std::size_t... Offsets>
 constexpr auto make_small_t_launchers(std::index_sequence<Offsets...>) {
     return std::array<SmallTLauncher, sizeof...(Offsets)>{
-        &launch_small_t_active<8 * (1 + static_cast<int>(Offsets))>...};
+        &launch_small_t_active<8 * (1 + static_cast<int>(Offsets)), Masked>...};
 }
 
-constexpr auto kSmallTLaunchers = make_small_t_launchers(std::make_index_sequence<4>{});
+constexpr auto kSmallTLaunchers = make_small_t_launchers<true>(std::make_index_sequence<4>{});
+constexpr auto kSmallTExactLaunchers =
+    make_small_t_launchers<false>(std::make_index_sequence<4>{});
 
 using SmallTI8Launcher = void (*)(const Tensor&, const Weight&, Tensor&, const std::int8_t*,
                                   const __half*, cudaStream_t);
@@ -288,6 +294,32 @@ void q4_linear_swiglu_gemv_pair_launch(const Tensor& x, const Weight& w, Tensor&
 
 void q4_linear_swiglu_small_t_tiled_launch(const Tensor& x, const Weight& w, Tensor& out,
                                            cudaStream_t stream) {
+    if (x.ne[1] < 2 || x.ne[1] > 32) {
+        throw std::invalid_argument("Q4 LinearSwiGLU exact small-T requires T=2..32");
+    }
+    // A width that fills its tile needs no runtime column count, and dropping it is worth 2-4% at
+    // sixteen and twenty-four columns (bench/ops/q4_linear_swiglu_schedule_bench.cu prices it
+    // against small_t_masked; + is the exact instantiation winning):
+    //
+    //   T        8       16      24      32
+    //   run 1  -27.3%   +1.3%   +3.7%   +2.0%
+    //   run 2  -16.5%   +2.6%   +3.6%   +0.0%
+    //   run 3  -15.7%   +3.3%   +3.7%   +0.5%
+    //
+    // Eight columns is excluded because there the exact instantiation *spills*: ptxas reports 16
+    // bytes of cumulative stack against the masked build's none. A compile-time column count lets
+    // the staging loop unroll fully, and that clears the 42-register ceiling this schedule's
+    // __launch_bounds__(256, 6) imposes at KWarps 8. Every wider tile runs KWarps < 8, so it is
+    // bounded to 2 blocks per SM and unrolls with registers to spare.
+    const bool exact  = x.ne[1] % 8 == 0 && x.ne[1] > 8;
+    const auto& table = exact ? kSmallTExactLaunchers : kSmallTLaunchers;
+    table[static_cast<std::size_t>((x.ne[1] - 1) / 8)](x, w, out, stream);
+}
+
+// Always the runtime-column-count instantiation, so a bench can price masking against the exact
+// one above inside a single process. Nothing on the inference path should call this.
+void q4_linear_swiglu_small_t_tiled_masked_launch(const Tensor& x, const Weight& w, Tensor& out,
+                                                  cudaStream_t stream) {
     if (x.ne[1] < 2 || x.ne[1] > 32) {
         throw std::invalid_argument("Q4 LinearSwiGLU exact small-T requires T=2..32");
     }

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
@@ -11,6 +11,7 @@
 #include <cuda_fp16.h>
 
 #include <cstdint>
+#include <cstdio>
 #include <stdexcept>
 #include <array>
 #include <utility>
@@ -293,6 +294,10 @@ void q4_linear_swiglu_small_t_tiled_launch(const Tensor& x, const Weight& w, Ten
     kSmallTLaunchers[static_cast<std::size_t>((x.ne[1] - 1) / 8)](x, w, out, stream);
 }
 
+bool q4_linear_swiglu_small_t_i8_supported(std::int32_t tokens) noexcept {
+    return tokens >= 16 && tokens <= 32;
+}
+
 std::size_t q4_linear_swiglu_small_t_tiled_i8_workspace_bytes(std::int32_t tokens) {
     // s8 codes plus one FP16 scale per (token, group), 256-aligned like q4a8_swiglu's workspace,
     // over the padded tile width rather than the request's: see the launch below for why the pad
@@ -315,8 +320,8 @@ void q4_linear_swiglu_small_t_tiled_i8_launch(const Tensor& x, const Weight& w, 
     // compile-time-width kernel rather than one carrying a runtime column count. Masking is not
     // free here: the staging loop's bounds test cannot fold away and it sits beside a tile-group
     // test, which measured T=28 at 222.2us against T=32's 193.5 on the same 32-wide tile. The
-    // epilogue already discards columns past the request, so the pad needs no handling beyond
     // being zero -- its MMAs were issued by the masked path too, only against a zeroed fragment.
+    // epilogue already discards columns past the request, so the pad needs no handling beyond
     const std::int32_t padded = (tokens + 7) / 8 * 8;
     auto scope                = workspace.scope();
     const DeviceSpan codes    = workspace.alloc_bytes(static_cast<std::size_t>(padded) * kK);

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_gemv.cu
@@ -88,6 +88,20 @@ struct Q4SwiGluSmallTTile {
     static constexpr int kKWarps       = TileCols <= 8 ? 8 : (TileCols <= 24 ? 4 : 2);
     static constexpr int kStages       = TileCols <= 16 ? 1 : 2;
     static constexpr int kTilesPerWarp = TileCols == 24 ? 2 : 1;
+    // Occupancy ceiling, and a measured dead end. ncu puts this kernel at 31% occupancy at T=32,
+    // register-limited to two blocks per SM, with tensor, L1 and DRAM all near 38% -- nothing
+    // saturated, which reads as an invitation to buy warps. It is not one: raising the ceiling caps
+    // registers, and at 96 registers this kernel needs them. Cold medians, us, and the number of
+    // instantiations ptxas reports spilling:
+    //
+    //   min blocks   T=16    T=24    T=32   spilling
+    //   2 (this)    161.8   175.1   205.8      0
+    //   3           162.8   321.5   227.3      4
+    //   4           161.8   543.7   281.6      4
+    //
+    // More warps in flight is still what the counters ask for; it has to come from a kernel that
+    // needs fewer registers, not from squeezing this one.
+    static constexpr int kMinBlocks = kKWarps < 8 ? 2 : (TileCols <= 16 ? 6 : 4);
 };
 
 // Masked carries the column count at runtime, which the staging loop's trip count and the inner
@@ -105,7 +119,7 @@ void launch_small_t_active(const Tensor& x, const Weight& w, Tensor& out, cudaSt
     const Q4SwiGluSmallTEpilogue epilogue{static_cast<__nv_bfloat16*>(out.data), x.ne[1]};
     q4_small_t_mma_launch<Q4SwiGluSmallTGeometry, TileCols, ActiveCols, Q4SwiGluSmallTEpilogue,
                           Q4SwiGluSmallTRows, Masked, Tile::kKWarps, Tile::kStages,
-                          Tile::kTilesPerWarp>(
+                          Tile::kTilesPerWarp, Tile::kMinBlocks>(
         kBlocks, stream, static_cast<const __nv_bfloat16*>(x.data),
         static_cast<const std::uint8_t*>(w.qdata), static_cast<const std::uint8_t*>(w.scales),
         static_cast<__nv_bfloat16*>(out.data), epilogue, Q4SwiGluSmallTRows{}, x.ne[1]);
@@ -118,9 +132,18 @@ constexpr auto make_small_t_launchers(std::index_sequence<Offsets...>) {
         &launch_small_t_active<8 * (1 + static_cast<int>(Offsets)), Masked>...};
 }
 
+// The eight-column slot of the exact table is deliberately the masked launcher: the dispatch below
+// never selects an exact eight-column width (it spills -- see the note there), and instantiating one
+// anyway would compile a spilling kernel nothing can call.
+template <std::size_t... Offsets>
+constexpr auto make_small_t_exact_launchers(std::index_sequence<Offsets...>) {
+    return std::array<SmallTLauncher, sizeof...(Offsets)>{
+        &launch_small_t_active<8 * (1 + static_cast<int>(Offsets)), Offsets == 0>...};
+}
+
 constexpr auto kSmallTLaunchers = make_small_t_launchers<true>(std::make_index_sequence<4>{});
 constexpr auto kSmallTExactLaunchers =
-    make_small_t_launchers<false>(std::make_index_sequence<4>{});
+    make_small_t_exact_launchers(std::make_index_sequence<4>{});
 
 using SmallTI8Launcher = void (*)(const Tensor&, const Weight&, Tensor&, const std::int8_t*,
                                   const __half*, cudaStream_t);

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_kernels.h
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_kernels.h
@@ -21,10 +21,14 @@ void q4_linear_swiglu_mma_split_half_pair_r32_c48_launch(const Tensor& x, const 
 void q4_linear_swiglu_small_t_tiled_launch(const Tensor& x, const Weight& w, Tensor& out,
                                            cudaStream_t stream);
 
-// int8 tensor-core small-T route, T=32 only for this first pass. Not routed by
-// q4_linear_swiglu_resolve_plan; reachable only via q4_linear_swiglu_execute_schedule for
-// exploratory measurement (bench/ops/q4_linear_swiglu_schedule_bench.cu) and its correctness test,
-// until it is measured against small_t_tiled and either wins or is deleted.
+// int8 tensor-core small-T route, T=2..32. Selected by LinearPolicy::AllowA8IntDecode rather than
+// by q4_linear_swiglu_resolve_plan's table, because it is a quality trade and therefore opt-in per
+// engine; q4_linear_swiglu_execute_schedule also reaches it for the schedule bench.
+//
+// The integer small-T route wins from sixteen columns up and loses below, where a 64-k group has
+// too little MMA work to pay for quantising the activations. Measured per width in
+// ops/linear/q4/q4_small_t_mma_i8.cuh.
+[[nodiscard]] bool q4_linear_swiglu_small_t_i8_supported(std::int32_t tokens) noexcept;
 [[nodiscard]] std::size_t q4_linear_swiglu_small_t_tiled_i8_workspace_bytes(std::int32_t tokens);
 void q4_linear_swiglu_small_t_tiled_i8_launch(const Tensor& x, const Weight& w, Tensor& out,
                                               WorkspaceArena& workspace, cudaStream_t stream);

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_kernels.h
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_kernels.h
@@ -20,6 +20,10 @@ void q4_linear_swiglu_mma_split_half_pair_r32_c48_launch(const Tensor& x, const 
                                                          Tensor& out, cudaStream_t stream);
 void q4_linear_swiglu_small_t_tiled_launch(const Tensor& x, const Weight& w, Tensor& out,
                                            cudaStream_t stream);
+// Bench-only: forces the runtime-column-count instantiation that the launcher above drops when a
+// width fills its tile exactly, so the cost of masking stays measurable rather than remembered.
+void q4_linear_swiglu_small_t_tiled_masked_launch(const Tensor& x, const Weight& w, Tensor& out,
+                                                  cudaStream_t stream);
 
 // int8 tensor-core small-T route, T=2..32. Selected by LinearPolicy::AllowA8IntDecode rather than
 // by q4_linear_swiglu_resolve_plan's table, because it is a quality trade and therefore opt-in per

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_kernels.h
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_kernels.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include "core/arena.h"
 #include "core/tensor.h"
 
 #include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
 
 namespace ninfer::ops::detail {
 
@@ -16,5 +20,13 @@ void q4_linear_swiglu_mma_split_half_pair_r32_c48_launch(const Tensor& x, const 
                                                          Tensor& out, cudaStream_t stream);
 void q4_linear_swiglu_small_t_tiled_launch(const Tensor& x, const Weight& w, Tensor& out,
                                            cudaStream_t stream);
+
+// int8 tensor-core small-T route, T=32 only for this first pass. Not routed by
+// q4_linear_swiglu_resolve_plan; reachable only via q4_linear_swiglu_execute_schedule for
+// exploratory measurement (bench/ops/q4_linear_swiglu_schedule_bench.cu) and its correctness test,
+// until it is measured against small_t_tiled and either wins or is deleted.
+[[nodiscard]] std::size_t q4_linear_swiglu_small_t_tiled_i8_workspace_bytes(std::int32_t tokens);
+void q4_linear_swiglu_small_t_tiled_i8_launch(const Tensor& x, const Weight& w, Tensor& out,
+                                              WorkspaceArena& workspace, cudaStream_t stream);
 
 } // namespace ninfer::ops::detail

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
@@ -162,6 +162,8 @@ const char* q4_linear_swiglu_schedule_name(Q4LinearSwiGluScheduleId schedule) no
         return "linear_swiglu.q4.mma.split_half_pair.r32.c128";
     case Q4LinearSwiGluScheduleId::SmallTTiledI8:
         return "linear_swiglu.q4.mma.small_t.tiled_i8";
+    case Q4LinearSwiGluScheduleId::SmallTTiledMasked:
+        return "linear_swiglu.q4.mma.small_t.tiled_masked";
     }
     return "linear_swiglu.q4.unknown";
 }
@@ -194,8 +196,9 @@ Q4LinearSwiGluPlan q4_linear_swiglu_resolve_plan(const Q4LinearSwiGluProblem& pr
         case Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128:
             return plan;
         case Q4LinearSwiGluScheduleId::SmallTTiledI8:
-            // Never in kRoutes: exploratory only, reached solely via execute_schedule.
-            throw std::logic_error("q4 linear_swiglu: SmallTTiledI8 is not a routed schedule");
+        case Q4LinearSwiGluScheduleId::SmallTTiledMasked:
+            // Never in kRoutes: reached solely via execute_schedule.
+            throw std::logic_error("q4 linear_swiglu: schedule is not routed");
         }
     }
     throw std::logic_error("q4 linear_swiglu: admitted problem has no covering route");
@@ -262,6 +265,9 @@ void q4_linear_swiglu_execute_schedule(Q4LinearSwiGluScheduleId schedule, const 
         return;
     case Q4LinearSwiGluScheduleId::SmallTTiledI8:
         q4_linear_swiglu_small_t_tiled_i8_launch(x, w, out, ws, stream);
+        return;
+    case Q4LinearSwiGluScheduleId::SmallTTiledMasked:
+        q4_linear_swiglu_small_t_tiled_masked_launch(x, w, out, stream);
         return;
     }
     throw std::logic_error("q4 linear_swiglu: unknown schedule");

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.cpp
@@ -160,6 +160,8 @@ const char* q4_linear_swiglu_schedule_name(Q4LinearSwiGluScheduleId schedule) no
         return "linear_swiglu.q4.materialized";
     case Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128:
         return "linear_swiglu.q4.mma.split_half_pair.r32.c128";
+    case Q4LinearSwiGluScheduleId::SmallTTiledI8:
+        return "linear_swiglu.q4.mma.small_t.tiled_i8";
     }
     return "linear_swiglu.q4.unknown";
 }
@@ -191,6 +193,9 @@ Q4LinearSwiGluPlan q4_linear_swiglu_resolve_plan(const Q4LinearSwiGluProblem& pr
             return plan;
         case Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128:
             return plan;
+        case Q4LinearSwiGluScheduleId::SmallTTiledI8:
+            // Never in kRoutes: exploratory only, reached solely via execute_schedule.
+            throw std::logic_error("q4 linear_swiglu: SmallTTiledI8 is not a routed schedule");
         }
     }
     throw std::logic_error("q4 linear_swiglu: admitted problem has no covering route");
@@ -254,6 +259,9 @@ void q4_linear_swiglu_execute_schedule(Q4LinearSwiGluScheduleId schedule, const 
     }
     case Q4LinearSwiGluScheduleId::MmaSplitHalfPairR32C128:
         q4_linear_swiglu_mma_split_half_pair_r32_c128_launch(x, w, out, stream);
+        return;
+    case Q4LinearSwiGluScheduleId::SmallTTiledI8:
+        q4_linear_swiglu_small_t_tiled_i8_launch(x, w, out, ws, stream);
         return;
     }
     throw std::logic_error("q4 linear_swiglu: unknown schedule");

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.h
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.h
@@ -16,6 +16,10 @@ enum class Q4LinearSwiGluScheduleId {
     MmaSplitHalfPairR32C48,
     Materialized,
     MmaSplitHalfPairR32C128,
+    // int8 tensor-core small-T route, T=32 only. Not in the route table -- reachable only through
+    // q4_linear_swiglu_execute_schedule, for measuring against SmallTTiled before any decision to
+    // wire it in. See q4_small_t_mma_i8.cuh and docs/performance.md's tensor-rate-bound C8 finding.
+    SmallTTiledI8,
 };
 
 struct Q4LinearSwiGluProblem {

--- a/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.h
+++ b/src/ops/linear_swiglu/q4/q4_linear_swiglu_plan.h
@@ -20,6 +20,9 @@ enum class Q4LinearSwiGluScheduleId {
     // q4_linear_swiglu_execute_schedule, for measuring against SmallTTiled before any decision to
     // wire it in. See q4_small_t_mma_i8.cuh and docs/performance.md's tensor-rate-bound C8 finding.
     SmallTTiledI8,
+    // Bench-only: SmallTTiled with the runtime column count it now avoids when the width fills its
+    // tile exactly. Kept so the cost of masking stays measurable rather than remembered.
+    SmallTTiledMasked,
 };
 
 struct Q4LinearSwiGluProblem {

--- a/src/ops/wrapper/linear_add.cpp
+++ b/src/ops/wrapper/linear_add.cpp
@@ -67,6 +67,7 @@ void validate_policy(LinearPolicy policy) {
     case LinearPolicy::AllowA8:
     case LinearPolicy::AllowA4:
     case LinearPolicy::AllowA8Int:
+    case LinearPolicy::AllowA8IntDecode:
         return;
     }
     throw std::invalid_argument("linear_add: invalid compute policy");
@@ -105,12 +106,14 @@ std::size_t linear_add_workspace_capacity_bytes(QType qtype, std::int32_t output
         return 0;
     }
     if (qtype == QType::Q5G64_F16S) {
-        if (policy != LinearPolicy::A16Only && policy != LinearPolicy::AllowA8Int) {
+        if (policy != LinearPolicy::A16Only && policy != LinearPolicy::AllowA8Int &&
+            policy != LinearPolicy::AllowA8IntDecode) {
             throw std::invalid_argument("linear_add workspace: Q5 admits A16 or integer A8");
         }
         const std::size_t a16 = detail::q5_linear_add_capacity_workspace_bytes(
             output_rows, input_rows, input_rows, min_tokens, max_tokens);
-        if (policy != LinearPolicy::AllowA8Int || output_rows != 5120 || input_rows != 17408) {
+        if ((policy != LinearPolicy::AllowA8Int && policy != LinearPolicy::AllowA8IntDecode) ||
+            output_rows != 5120 || input_rows != 17408) {
             return a16;
         }
         if (min_tokens == max_tokens) {
@@ -180,11 +183,13 @@ void linear_add(const Tensor& x, const Weight& w, Tensor& residual_out, LinearPo
     }
 
     if (w.qtype == QType::Q5G64_F16S) {
-        if (policy == LinearPolicy::AllowA8Int && detail::q5a8_add_supported(w, x.ne[1])) {
+        if ((policy == LinearPolicy::AllowA8Int || policy == LinearPolicy::AllowA8IntDecode) &&
+            detail::q5a8_add_supported(w, x.ne[1])) {
             detail::q5a8_add_launch(x, w, residual_out, ws, stream);
             return;
         }
-        if (policy != LinearPolicy::A16Only && policy != LinearPolicy::AllowA8Int) {
+        if (policy != LinearPolicy::A16Only && policy != LinearPolicy::AllowA8Int &&
+            policy != LinearPolicy::AllowA8IntDecode) {
             throw std::invalid_argument("Q5 linear_add admits A16 or integer A8");
         }
         require_q5(w);

--- a/src/ops/wrapper/linear_swiglu.cpp
+++ b/src/ops/wrapper/linear_swiglu.cpp
@@ -4,6 +4,7 @@
 #include "ops/linear/nvfp4/nvfp4_format.h"
 #include "ops/linear_swiglu/fp8/fp8_linear_swiglu_plan.h"
 #include "ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.h"
+#include "ops/linear_swiglu/q4/q4_linear_swiglu_kernels.h"
 #include "ops/linear_swiglu/q4/q4_linear_swiglu_plan.h"
 #include "ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h"
 #include "ops/linear_swiglu/w8/w8_linear_swiglu_plan.h"
@@ -24,6 +25,7 @@ void validate_policy(LinearPolicy policy) {
     case LinearPolicy::AllowA8:
     case LinearPolicy::AllowA4:
     case LinearPolicy::AllowA8Int:
+    case LinearPolicy::AllowA8IntDecode:
         return;
     }
     throw std::invalid_argument("linear_swiglu: invalid compute policy");
@@ -50,22 +52,37 @@ std::size_t linear_swiglu_workspace_capacity_bytes(QType qtype, std::int32_t gat
         return 0;
     }
     if (qtype == QType::Q4G64_F16S) {
-        if (policy != LinearPolicy::A16Only && policy != LinearPolicy::AllowA8Int) {
+        if (policy != LinearPolicy::A16Only && policy != LinearPolicy::AllowA8Int &&
+            policy != LinearPolicy::AllowA8IntDecode) {
             throw std::invalid_argument("linear_swiglu workspace: Q4 admits A16 or integer A8");
         }
         const std::size_t a16 = detail::q4_linear_swiglu_capacity_workspace_bytes(
             gate_up_rows, gate_up_rows / 2, input_rows, input_rows, min_tokens, max_tokens);
-        if (policy != LinearPolicy::AllowA8Int || gate_up_rows != 34816 || input_rows != 5120) {
-            return a16;
-        }
+        const bool integer_a8 =
+            policy == LinearPolicy::AllowA8Int || policy == LinearPolicy::AllowA8IntDecode;
+        if (!integer_a8 || gate_up_rows != 34816 || input_rows != 5120) { return a16; }
+        // The small-T integer route stages quantised activations too, over its padded tile width.
+        const auto decode_bytes = [&](std::int32_t t) -> std::size_t {
+            return (policy == LinearPolicy::AllowA8IntDecode &&
+                    detail::q4_linear_swiglu_small_t_i8_supported(t))
+                       ? detail::q4_linear_swiglu_small_t_tiled_i8_workspace_bytes(t)
+                       : 0;
+        };
         // A single-T query must report exactly what that T will use, so it has to name the route
         // the resolver will pick. Across an interval the answer is an upper bound over both.
         if (min_tokens == max_tokens) {
-            return detail::q4a8_tokens_supported(min_tokens)
-                       ? detail::q4a8_swiglu_workspace_capacity_bytes(min_tokens, max_tokens)
-                       : a16;
+            if (detail::q4a8_tokens_supported(min_tokens)) {
+                return detail::q4a8_swiglu_workspace_capacity_bytes(min_tokens, max_tokens);
+            }
+            const std::size_t decode = decode_bytes(min_tokens);
+            return decode != 0 ? decode : a16;
         }
-        return std::max(a16, detail::q4a8_swiglu_workspace_capacity_bytes(min_tokens, max_tokens));
+        std::size_t widest = std::max(
+            a16, detail::q4a8_swiglu_workspace_capacity_bytes(min_tokens, max_tokens));
+        for (std::int32_t t = min_tokens; t <= max_tokens; ++t) {
+            widest = std::max(widest, decode_bytes(t));
+        }
+        return widest;
     }
     if (qtype == QType::NVFP4 && gate_up_rows == 34816 && input_rows == 5120) {
         return detail::nvfp4_linear_swiglu_workspace_capacity_bytes(policy, min_tokens, max_tokens);
@@ -138,12 +155,21 @@ void linear_swiglu(const Tensor& x, const Weight& gate_up_weight, Tensor& out, L
         return;
     }
 
-    if (policy == LinearPolicy::AllowA8Int && q4_weight &&
-        detail::q4a8_swiglu_supported(gate_up_weight, t)) {
+    const bool integer_a8 =
+        policy == LinearPolicy::AllowA8Int || policy == LinearPolicy::AllowA8IntDecode;
+    if (integer_a8 && q4_weight && detail::q4a8_swiglu_supported(gate_up_weight, t)) {
         detail::q4a8_swiglu_launch(x, gate_up_weight, out, ws, stream);
         return;
     }
-    if (policy != LinearPolicy::A16Only && !(policy == LinearPolicy::AllowA8Int && q4_weight)) {
+    // Decode and verify widths, opt-in only: the integer small-T route wins from sixteen columns
+    // up and loses below, so the narrow widths stay on A16 (q4_small_t_mma_i8.cuh has the table).
+    if (policy == LinearPolicy::AllowA8IntDecode && q4_weight &&
+        detail::q4_linear_swiglu_small_t_i8_supported(t) &&
+        gate_up_weight.n == 34816 && gate_up_weight.k == 5120) {
+        detail::q4_linear_swiglu_small_t_tiled_i8_launch(x, gate_up_weight, out, ws, stream);
+        return;
+    }
+    if (policy != LinearPolicy::A16Only && !(integer_a8 && q4_weight)) {
         throw std::invalid_argument("linear_swiglu: Q4 admits A16 or integer A8; W8 admits A16");
     }
     if (!aligned_to(gate_up_weight.qdata, 16) ||

--- a/src/serve/generation_service.cpp
+++ b/src/serve/generation_service.cpp
@@ -284,6 +284,7 @@ GenerationService::GenerationService(ServeOptions options, StartupObserver start
     engine_options.use_cuda_graph           = options_.use_cuda_graph;
     engine_options.lm_head_q4               = options_.lm_head_q4;
     engine_options.gdn_state_fp16           = options_.gdn_state_fp16;
+    engine_options.mlp_a8_decode            = options_.mlp_a8_decode;
     engine_options.speculative              = options_.speculative;
     engine_options.context_cache            = options_.context_cache;
     engine_options.devices                  = options_.devices;

--- a/src/serve/request_log.cpp
+++ b/src/serve/request_log.cpp
@@ -702,6 +702,7 @@ std::string format_server_start_json(
              {"cuda_graph", engine_options.use_cuda_graph},
              {"lm_head_q4", engine_options.lm_head_q4},
              {"gdn_state_fp16", engine_options.gdn_state_fp16},
+             {"mlp_a8_decode", engine_options.mlp_a8_decode},
              {"prefix_reuse", options.allow_prefix_reuse},
              {"speculative_backend",
               product::speculative_backend_name(engine_options.speculative.backend)},

--- a/src/serve/serve_options.cpp
+++ b/src/serve/serve_options.cpp
@@ -85,7 +85,7 @@ std::string serve_usage_text(const char* argv0) {
            "[--default-max-tokens N] [--default-thinking-budget N] "
            "[--vision] [--vision-residency resident|overlay] [--vision-max-merged N] "
            "[--no-cuda-graph] [--no-prefix-reuse] [--auto-prefix-grid] [--devices N,M] "
-           "[--lm-head-draft] [--lm-head-q4] [--gdn-state-fp16] "
+           "[--lm-head-draft] [--lm-head-q4] [--gdn-state-fp16] [--mlp-a8-decode] "
            "[--no-thinking] [--preserve-thinking] [--cors] "
            "[--temperature F] [--top-p F] [--top-k N] [--min-p F] [--presence-penalty F] "
            "[--frequency-penalty F] [--seed N] [--greedy]\n"
@@ -357,6 +357,8 @@ ServeOptions parse_serve_options(int argc, char** argv) {
             options.lm_head_q4 = true;
         } else if (arg == "--gdn-state-fp16") {
             options.gdn_state_fp16 = true;
+        } else if (arg == "--mlp-a8-decode") {
+            options.mlp_a8_decode = true;
         } else if (arg == "--no-thinking") {
             options.enable_thinking = false;
         } else if (arg == "--preserve-thinking") {

--- a/src/serve/serve_options.h
+++ b/src/serve/serve_options.h
@@ -58,6 +58,7 @@ struct ServeOptions {
     bool use_cuda_graph     = true;
     bool lm_head_q4         = false;
     bool gdn_state_fp16     = false;
+    bool mlp_a8_decode      = false;
     bool allow_prefix_reuse = true;
     // Offer shared-prefix candidates on a content-independent token grid so unrelated callers whose
     // prompts merely start alike converge on the same frontier. Off by default: it adds host-side

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/startup_features.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/startup_features.h
@@ -15,6 +15,7 @@ struct StartupFeatures {
     ProposalHead proposal_head       = ProposalHead::Full;
     bool lm_head_q4                 = false;
     bool gdn_state_fp16             = false;
+    bool mlp_a8_decode              = false;
 
     bool operator==(const StartupFeatures&) const = default;
 
@@ -51,6 +52,7 @@ struct StartupFeatures {
         .proposal_head    = options.speculative.proposal_head,
         .lm_head_q4       = options.lm_head_q4,
         .gdn_state_fp16   = options.gdn_state_fp16,
+        .mlp_a8_decode    = options.mlp_a8_decode,
     };
 }
 

--- a/src/targets/qwen3_6_27b/impl/load/bindings.cpp
+++ b/src/targets/qwen3_6_27b/impl/load/bindings.cpp
@@ -185,9 +185,10 @@ Weight row_view(const Weight& block, std::int32_t row_begin, std::int32_t row_co
     return out;
 }
 
-DensePostMixerPayload load_mlp(const MlpPlan& plan,
+DensePostMixerPayload load_mlp(bool a8_decode, const MlpPlan& plan,
                                const artifact::MaterializedArtifact& materialized) {
     DensePostMixerPayload out;
+    out.a8_decode = a8_decode;
     out.gate_up = materialized_weight(materialized, plan.gate_up, 34816, 5120);
     out.down    = materialized_weight(materialized, plan.down, 5120, 17408);
     return out;
@@ -671,7 +672,7 @@ LoadedModelData::LoadedModelData(std::vector<BindingPlan> plans,
             target.output     = materialized_weight(backing, source.attention.output, 5120, 6144);
             target.post_attention_norm = artifact::materialized_tensor(
                 expert_backing, expert_source.post_attention_norm, NumericFormat::BF16, {5120});
-            target.post_mixer = load_mlp(expert_source.mlp, expert_backing);
+            target.post_mixer = load_mlp(plan.features.mlp_a8_decode, expert_source.mlp, expert_backing);
         } else {
             GdnWeights& target = gdn_layers.at(gdn_index++);
             target.input_norm  = artifact::materialized_tensor(backing, source.input_norm,
@@ -689,7 +690,7 @@ LoadedModelData::LoadedModelData(std::vector<BindingPlan> plans,
             target.output = materialized_weight(backing, source.gdn.output, 5120, 6144);
             target.post_attention_norm = artifact::materialized_tensor(
                 expert_backing, expert_source.post_attention_norm, NumericFormat::BF16, {5120});
-            target.post_mixer = load_mlp(expert_source.mlp, expert_backing);
+            target.post_mixer = load_mlp(plan.features.mlp_a8_decode, expert_source.mlp, expert_backing);
         }
     }
     if (full_index != full_layers.size() || gdn_index != gdn_layers.size()) {
@@ -739,7 +740,7 @@ LoadedModelData::LoadedModelData(std::vector<BindingPlan> plans,
                                                                 NumericFormat::W8G32_F16S, 5120, 6144);
         mtp.post_attention_norm = artifact::materialized_tensor(
             backing, plan.mtp.post_attention_norm, NumericFormat::BF16, {5120});
-        mtp.post_mixer = load_mlp(plan.mtp.mlp, backing);
+        mtp.post_mixer = load_mlp(plan.features.mlp_a8_decode, plan.mtp.mlp, backing);
         mtp.final_norm = artifact::materialized_tensor(backing, plan.mtp.final_norm,
                                                        NumericFormat::BF16, {5120});
     }

--- a/src/targets/qwen3_6_27b/impl/load/bindings.h
+++ b/src/targets/qwen3_6_27b/impl/load/bindings.h
@@ -174,6 +174,9 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
 struct DensePostMixerPayload {
     Weight gate_up;
     Weight down;
+    // --mlp-a8-decode. Carried on the payload because Variant is stateless and the leaves take no
+    // features, while weight binding -- where this is decided -- has them.
+    bool a8_decode = false;
 };
 
 struct SplitAttentionProjectionPayload {

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -85,6 +85,16 @@ ops::LinearPolicy text_policy(const Weight& weight) {
     }
 }
 
+// --mlp-a8-decode widens the gate_up policy to admit the integer small-T route at decode and
+// verify widths as well as full prefill tiles. Only where the base policy already admits integer
+// activations: the flag must not conjure an integer route on a build or shape that has none.
+ops::LinearPolicy mlp_policy(const DensePostMixerPayload& weights) {
+    const ops::LinearPolicy base = text_policy(weights.gate_up);
+    return (weights.a8_decode && base == ops::LinearPolicy::AllowA8Int)
+               ? ops::LinearPolicy::AllowA8IntDecode
+               : base;
+}
+
 constexpr std::size_t kMinimumLeafWorkspaceBytes = 1;
 
 std::size_t gdn_snapshot_workspace_bytes(const Tensor& hidden,
@@ -333,8 +343,7 @@ void Variant::post_mixer(const Tensor& hidden, const PostMixerWeights& weights, 
                          WorkspaceArena& workspace, cudaStream_t stream) {
     auto scope        = workspace.scope();
     Tensor activation = workspace.alloc(DType::BF16, {TextConfig::intermediate, hidden.ne[1]});
-    ops::linear_swiglu(hidden, weights.gate_up, activation, text_policy(weights.gate_up), workspace,
-                       stream);
+    ops::linear_swiglu(hidden, weights.gate_up, activation, mlp_policy(weights), workspace, stream);
     ops::linear_add(activation, weights.down, residual, text_policy(weights.down), workspace,
                     stream);
 }

--- a/tests/ops/linear_swiglu/test_q4_a16.cpp
+++ b/tests/ops/linear_swiglu/test_q4_a16.cpp
@@ -11,9 +11,12 @@ int main() {
     try {
         // Public numerical cases straddle each registered Q4 implementation interval. They make
         // no assertion about the private route selected for any T.
-        constexpr std::array<std::int32_t, 20> kTokenCases{
-            1,   2,   24,  25,  32,  33,  40,  41,  48,  49,
-            128, 129, 256, 257, 384, 385, 512, 513, 640, 641,
+        // 8, 16 and 17 straddle the small-T dispatch's exact-width boundary as well as the
+        // registered intervals: a width that fills its tile runs an instantiation with no runtime
+        // column count, and the widths either side of it do not (q4_linear_swiglu_gemv.cu).
+        constexpr std::array<std::int32_t, 23> kTokenCases{
+            1,   2,   8,   16,  17,  24,  25,  32,  33,  40,  41, 48,
+            49,  128, 129, 256, 257, 384, 385, 512, 513, 640, 641,
         };
         const int failures = run_profile(
             "LinearSwiGLU Q4_A16",

--- a/tests/ops/linear_swiglu/test_q4a8_int.cpp
+++ b/tests/ops/linear_swiglu/test_q4a8_int.cpp
@@ -150,11 +150,10 @@ int run_gate_up(std::int32_t tokens) {
 // gate_up weight, T=32 only so far. Not routed by resolve_plan -- reached directly through
 // execute_schedule, the same way the schedule bench times it. Same oracle and allowance as the
 // prefill route above: same weight profile, same per-(token,64-group) s8 activation quantisation.
-int run_gate_up_small_t_i8() {
-    constexpr std::int32_t kRows   = 34816;
-    constexpr std::int32_t kCols   = 5120;
-    constexpr std::int32_t kOut    = kRows / 2;
-    constexpr std::int32_t kTokens = 32;
+int run_gate_up_small_t_i8(std::int32_t kTokens) {
+    constexpr std::int32_t kRows = 34816;
+    constexpr std::int32_t kCols = 5120;
+    constexpr std::int32_t kOut  = kRows / 2;
 
     const PackedWeight host_weight =
         qw::make_patterned_weight(QType::Q4G64_F16S, kRows, kCols, 4802U);
@@ -319,7 +318,10 @@ int main() {
             failures += run_gate_up(tokens);
             failures += run_down(tokens);
         }
-        failures += run_gate_up_small_t_i8();
+        // Every band of the T=2..32 dispatch, including widths that exercise column masking.
+        for (const std::int32_t t : {2, 5, 8, 9, 16, 17, 24, 25, 31, 32}) {
+            failures += run_gate_up_small_t_i8(t);
+        }
         std::cout << (failures == 0 ? "OK" : "FAIL")
                   << " integer-activation prefill routes correctness\n";
         return failures == 0 ? 0 : 1;

--- a/tests/ops/linear_swiglu/test_q4a8_int.cpp
+++ b/tests/ops/linear_swiglu/test_q4a8_int.cpp
@@ -13,6 +13,8 @@
 // obvious in the output.
 
 #include "ops/linear_swiglu/q4a8/q4a8_linear_swiglu.h"
+#include "ops/linear_swiglu/q4/q4_linear_swiglu_kernels.h"
+#include "ops/linear_swiglu/q4/q4_linear_swiglu_plan.h"
 
 #include "ops/op_check.h"
 #include "ops/op_tester.h"
@@ -144,6 +146,70 @@ int run_gate_up(std::int32_t tokens) {
     return failures;
 }
 
+// SmallTTiledI8 (q4_small_t_mma_i8.cuh): exploratory int8 tensor-core small-T route for the same
+// gate_up weight, T=32 only so far. Not routed by resolve_plan -- reached directly through
+// execute_schedule, the same way the schedule bench times it. Same oracle and allowance as the
+// prefill route above: same weight profile, same per-(token,64-group) s8 activation quantisation.
+int run_gate_up_small_t_i8() {
+    constexpr std::int32_t kRows   = 34816;
+    constexpr std::int32_t kCols   = 5120;
+    constexpr std::int32_t kOut    = kRows / 2;
+    constexpr std::int32_t kTokens = 32;
+
+    const PackedWeight host_weight =
+        qw::make_patterned_weight(QType::Q4G64_F16S, kRows, kCols, 4802U);
+    const std::vector<std::uint16_t> activation = make_activation(kCols, kTokens, 92U);
+
+    test::GuardedDeviceBuffer device_weight(host_weight.payload.size());
+    device_weight.copy_from_host(host_weight.payload.data(), host_weight.payload.size());
+    const Weight weight = host_weight.device_weight(device_weight.data());
+
+    test::GuardedDeviceBuffer device_x(activation.size() * sizeof(std::uint16_t));
+    device_x.copy_from_host(activation.data(), activation.size() * sizeof(std::uint16_t));
+
+    const std::size_t out_elements = static_cast<std::size_t>(kOut) * kTokens;
+    test::GuardedDeviceBuffer output(out_elements * sizeof(std::uint16_t));
+    output.fill(0xff);
+
+    WorkspaceArena workspace(std::max<std::size_t>(
+        ops::detail::q4_linear_swiglu_small_t_tiled_i8_workspace_bytes(kTokens), 256));
+    Tensor x(device_x.data(), DType::BF16, {kCols, kTokens});
+    Tensor destination(output.data(), DType::BF16, {kOut, kTokens});
+    ops::detail::q4_linear_swiglu_execute_schedule(
+        ops::detail::Q4LinearSwiGluScheduleId::SmallTTiledI8, x, weight, destination, workspace,
+        nullptr);
+    test::cuda_check(cudaDeviceSynchronize(), "synchronize q4 small-T i8 swiglu");
+
+    const std::string label = "LinearSwiGLU Q4_SMALL_T_I8 T=" + std::to_string(kTokens);
+    int failures            = 0;
+    failures += output.verify_guards(label);
+
+    const std::vector<double> got = read_bf16(output, out_elements);
+    Samples s;
+    std::vector<float> input(static_cast<std::size_t>(kCols));
+    for (int pick = 0; pick < 24; ++pick) {
+        const std::int32_t token = static_cast<std::int32_t>(
+            qw::detail::mix64(pick * 7927U + 3U) % static_cast<std::uint64_t>(kTokens));
+        const std::int32_t row = static_cast<std::int32_t>(
+            qw::detail::mix64(pick * 104743U + 11U) % static_cast<std::uint64_t>(kOut));
+        for (std::int32_t k = 0; k < kCols; ++k) {
+            input[static_cast<std::size_t>(k)] =
+                bf16_value(activation[static_cast<std::size_t>(token) * kCols + k]);
+        }
+        const double gate = qw::dot_fp64(host_weight, row, input.data(), kCols);
+        const double up   = qw::dot_fp64(host_weight, kOut + row, input.data(), kCols);
+        s.reference.push_back(gate / (1.0 + std::exp(-gate)) * up);
+        s.actual.push_back(got[static_cast<std::size_t>(token) * kOut + row]);
+    }
+
+    const ReductionStats stats = compute_reduction_stats(
+        s.actual.data(), s.reference.data(), static_cast<std::int64_t>(s.actual.size()));
+    std::cout << "  " << label << " relative_l2=" << stats.relative_l2 << " (allowance "
+              << kA8QuantizationAllowance << ")\n";
+    failures += verify_reduction(label, s.actual, s.reference, kA8Criterion);
+    return failures;
+}
+
 int run_down(std::int32_t tokens) {
     constexpr std::int32_t kRows = 5120;
     constexpr std::int32_t kCols = 17408;
@@ -253,6 +319,7 @@ int main() {
             failures += run_gate_up(tokens);
             failures += run_down(tokens);
         }
+        failures += run_gate_up_small_t_i8();
         std::cout << (failures == 0 ? "OK" : "FAIL")
                   << " integer-activation prefill routes correctness\n";
         return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Started as an int8 tensor-core route for the 27B MLP gate_up projection. It ships, behind
`--mlp-a8-decode` and off by default. But profiling it overturned the premise that motivated it,
and the correction turned out to be worth more than the kernel.

Stacked on `perf/quality-trades`; review that first if it is still open.

## 1. `--mlp-a8-decode` (opt-in, off by default)

Extends the existing W4A8 prefill route to the widths a cohort round decodes at.

| columns | 8 | 12 | 16 | 20 | 24 | 28 | 32 |
|---|---|---|---|---|---|---|---|
| run 1 | +10.7% | -5.8% | -3.4% | -4.8% | -4.8% | -5.0% | -4.5% |
| run 2 | +7.5% | +4.3% | -0.7% | -5.9% | -6.1% | -4.0% | -6.4% |

Admitted for 16..32 columns only. End to end at C8 with MTP3, four interleaved repetitions:
431.5 -> **437.0 tok/s, +1.28%**, winning three pairs and tying the fourth.

Lossy, and documented as such: 0.0080-0.0371 relative L2 against an FP64 oracle across 2..32
columns, inside the 0.04 allowance the integer path is held to elsewhere. **Perplexity cannot see
this trade** -- scoring runs at prefill widths, so `ninfer-perplexity` reports an identical score
and its usage text says so. A real gap in the evidence, recorded rather than papered over.

## 2. The premise was wrong, and correcting it is the bigger result

`docs/performance.md` and `TODO.md` both said C8 is tensor-rate bound, on a computed floor: gate_up
at T=32 at ~68% of bf16 MMA peak. That framing chose this kernel. Counters disagree:

| @ T=32 | BF16 | int8 |
|---|---:|---:|
| tensor pipe active | **38.3%** | 21.0% |
| L1/TEX | 36.4% | 73.5% |
| DRAM | 39.4% | 42.7% |
| warp occupancy | 30.9% | 45.4% |

Tensor, L1 and DRAM within three points of each other at 31% occupancy: nothing saturated, which is
latency-bound. The int8 route is the evidence rather than a counterexample -- it halved tensor-pipe
pressure exactly as a 4.7x-denser MMA should, and returned 4-6%, because the pipe it relieved was
never the constraint and the cost landed on L1.

Both documents are corrected with the counters in place.

## 3. An unrelated win on the default path, found on the way

Every small-T call site passed a runtime column count, so the staging loop's trip count and the
inner loop's bounds test could never fold -- even at widths that exactly fill the tile, which is the
common cohort case. gate_up now gets an unmasked instantiation there. Paired against the masked one
in one process: **+4% at 16 columns, +3-9% at 24, +1-2.5% at 32**, no flag, no quality cost.
Verified against the FP64 oracle at every band boundary.

Two things stop it generalising, both measured rather than assumed:

- **Eight columns spills unmasked** (16 bytes of cumulative stack) because the compile-time count
  unrolls the staging loop past the 42-register ceiling of the KWarps 8 schedule's launch bounds.
- **GDN and attention query/key lose** -- attention by 4.1% at 32 columns in three identical runs,
  GDN by 11% -- despite sharing the template. Not registers (94 vs 95, no stack either way).
  Unexplained, so both were reverted rather than shipped on a story.

## 4. Dead ends recorded, so nobody re-runs them

- **Occupancy cannot be bought here.** The counters invite it at 31% occupancy, but raising the
  launch-bound ceiling caps registers and spills: T=24 goes 175 -> 321 -> 544 us at 2/3/4 blocks.
- **cp.async pipelining lost at every width** on the int8 kernel -- there was no DRAM latency to
  hide, which the L1 reading explains.
- **The production kernels have no redundant activation staging** (checked, they stage CTA-wide);
  that bug was mine alone.
- Five more int8 variants, with numbers, in `q4_small_t_mma_i8.cuh`.

## Test plan

- [x] `ninfer_linear_swiglu_q4a8_int_test`: both sides of every band boundary (T=2,5,8,9,16,17,24,25,31,32) against the FP64 oracle
- [x] `ninfer_linear_swiglu_q4_a16_test`: widened to cover 8/16/17 alongside 24/32, the exact-width boundary
- [x] `ninfer_linear_swiglu_q4_a8int_test`, `ninfer_cli_options_test`, `ninfer_serve_options_test`
- [x] `ptxas`: zero spilling instantiations in the touched translation unit
- [x] Real-model smoke test on the changed default path
- [x] Flag verified to engage at C8 and be inert at T=1
- [ ] Not run on Linux; every number is one Windows RTX 3090 at 315 W

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AxNkGzQi8too97vaQtg5X
