### PR TITLE
merge: catch up with neroued/master (materialization search rework), adapted for MSVC

### DIFF
--- a/docs/maintainer/resource-scheduling-and-context-cache.md
+++ b/docs/maintainer/resource-scheduling-and-context-cache.md
@@ -698,17 +698,13 @@ Selected source 的合法 `ConsumedToActive` 是 ownership transfer，不计作 
 
 ### 8.4 排序提示不是证明
 
-Program 为未 assessment 的 target 返回 physical residual、预计剩余步数、transfer work 和稳定 ordinal。
-ResourceManager 将其与 selected hits、retention weight、shared credit 和 hit epoch 合并成确定性 priority。
-这些值只决定先探索谁：
+Program 为未 assessment 的 target 返回 physical residual、预计剩余步数、transfer/recovery work 和
+稳定 ordinal。ResourceManager 将这些事实与 portfolio policy、logical publication 条件合并成 priority。
+构造目标同时包含物理容量和逻辑可采用性；物理缺口为零不能代替 publication slot 检查。
 
-- 不能标记 target feasible；
-- 不能排除 candidate 或 target；
-- 不能证明 incumbent 最优；
-- 不能参与 physical readiness。
-
-只有完整 exact assessment 与 logical-adoption check 可以产生可采用方案。日志不再发布
-`model_optimal`、remaining lower bound 或 bound gap。
+这些值只决定探索顺序及 optional 额度边界是否值得继续搜索：不能标记 target feasible，不能证明
+incumbent 最优，不能参与 physical readiness。组合动作可能取消拷贝，预测成本不是可用于剪枝的
+数学下界。只有完整 exact assessment 与 logical-adoption check 可以产生可采用方案。
 
 ### 8.5 无压力路径
 
@@ -739,33 +735,34 @@ lane 或 open transaction 阻塞，结果为 temporarily blocked。
 
 ### 8.7 有界 heuristic search
 
-Materialization 与 shared capture 使用两个 typed entrypoint。Materialization 的 incumbent 是已验证 identity
-或 root maximal；shared capture 的 incumbent 是 Skip，只有 exact `NetGain>0` 才替换。
+Materialization 与 shared capture 使用两个 typed entrypoint。Materialization 的 incumbent 是已验证
+identity 或 root maximal；shared capture 的 incumbent 是 Skip，只有 exact `NetGain>0` 才替换。
 
 一次 planning problem 中：
 
-1. ResourceManager mint `PlanningCandidateId`、`PlanningOwnerId` 并保留到 catalog capability 的唯一映射；
-2. Program 为每个 candidate 建立只包含 eligible victims 的 domain，source 结构性缺席；
-3. target 是 Program-owned opaque handle；runner 不构造 State/KV action；
-4. guidance 只排列 frontier；
-5. Program exact evaluator 从完整联合 post-state 结算 unique State/KV identity、alias、placement、Move/Fork、
-   COW、Host geometry 和 stage peak；
-6. ResourceManager 按 owner ID 判断 logical adoption 与 future value；
-7. budget 耗尽时返回最佳已验证 incumbent。
+1. ResourceManager mint candidate/owner IDs，保留到 catalog capability 的唯一映射；Program 为每个
+   candidate 建立 selected source 结构性缺席的 eligible victim domain。
+2. Program 持有 opaque targets 与分片构造状态；Runtime 按预计完整 J 和缺口改善排列合法选项，
+   兼顾价值与尽快形成可行方案，不构造 State/KV action。
+3. 优先评估完整候选，失败后根据精确物理与逻辑反馈继续修复。Host geometry 等不能由总字节量
+   证明的条件需要更早的 exact feedback。局部构造以外保留普通 alternatives。
+4. 完整联合 post-state 结算 unique objects、alias、Move/Fork、COW、Host geometry 与 stage peak。
+   只有物理可行且 logical adoption 成功的结果参与最终 J 与稳定 tie-break 比较。
+5. 任意 optional 时间、工作或容量预算耗尽，返回最佳已验证 incumbent。
 
-普通 expansion、guided closure、root maximal 与 seal 使用同一 candidate-specific domain 和同一 exact
-evaluator。不存在另一套 source/victim eligibility 规则，也不存在 synthetic capture
-`AdmissionCandidate` 跨越 common planner 边界。
+构造、修复、普通 expansion、maximal target 与 seal 共用 candidate-specific domain 和 exact evaluator。
+游标、target arena 与借用摘要只在同一 planning session/revision 内有效；批次停止或丢弃不能产生
+真实资源 mutation。结束搜索后不跨 decode/prefill 恢复旧状态。
 
-Search management 使用 ordinal-indexed `BoundedTargetLedger`。Program target choices 存放在
-planning-session-owned flat arena；每个 target 只保存 offset/count，canonical lookup 使用 flat hash。Prepare
-expansion 在 arena 尾部建立 scratch，commit 只保留新 canonical targets，discard 回卷到原 mark。Session
-开始时按固定 target/owner 上限取得容器容量；capacity exhaustion 返回已有 incumbent，不能改变 correctness。
+Engine 提供 admission boundary 共享的 optional 时间额度，head/backfill inspections 不能各自重置。
+预算考虑其他 runnable 请求及本 boundary 已花费的时间。Planner 先用短窗口搜索，再根据尚可获得
+的预计改善和完成成本决定是否续额；不完整预测只有受限探索机会，已实现收益不能反复用于续额。
+Target、工作量和 session storage 仍独立有界。
 
-Target budget 同时约束 canonical targets 与 exact assessments。Materialization 另在不可分的 Program
-operation 之间检查 wall/value budget；identity assessments 和 root maximal correctness assessment 不计
-optional budget。Shared capture 以固定 target budget 约束工作量，incumbent 始终为 Skip。任何 budget 只影响
-cache quality，不改变 mandatory request readiness。
+Identity 与 root maximal correctness assessment 不因 optional 额度耗尽而取消。时间在 Program
+operation 之间检查，估计误差可造成单步越界；最终 seal 仍必须完成。因此预算只影响 cache quality，
+不改变 mandatory readiness，也不承诺整个 planning 调用可在任意时刻中断。
+Shared capture 维持独立的固定 target budget 与 Skip incumbent。
 
 ### 8.8 目标函数与确定性
 
@@ -791,7 +788,8 @@ machine cost model 统一定价并比较。成本模型不会进入 Program API�
 6. candidate 与 target 的稳定 ordinal。
 
 停止原因只描述实际边界：`no_pressure`、`queue_exhausted`、`target_budget`、
-`expansion_capacity`、`time_budget` 或 `value_of_next_expansion`。它们不声明当前 target graph 或真实
+`expansion_capacity`、`time_budget`、`work_budget` 或 `insufficient_expected_gain`。
+`time_budget` 也包括预计下一不可分操作无法放入余量的情况。它们不声明当前 target graph 或真实
 TTFT 的全局最优性。
 
 ### 8.9 Readiness

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -868,13 +868,6 @@ preserved for consumer validation, and a stable text-fallback reason. Fallback r
 `malformed_structure`, `duplicate_parameter`, `invalid_tool_name`, `undeclared_tool`, and
 `trailing_content`. These counters contain no tool arguments or generated text.
 
-`request_done.materialization` is the immutable decision committed for that request. It reports predicted immediate,
-future-loss and total nanoseconds; evaluated targets and projection work; planning/search nanoseconds; stop reason;
-the budget-exhausted flag; selected degradation units; and whether the selected target was the maximal root fallback.
-Stop reasons are `no_pressure`, `queue_exhausted`, `target_budget`, `expansion_capacity`, `time_budget`, and
-`value_of_next_expansion`. Search is bounded and heuristic; these diagnostics do not claim model or global optimality.
-Aborted planning attempts are not published.
-
 `request_done.timings_seconds` contains `prepare`, `ttft`, `vision`, `prefill`, `decode`, and `total`
 as full-precision JSON numbers. Its `speculative` object contains `backend`, `draft_window`, `rounds`,
 `drafted_tokens`, `accepted_tokens`, `fallback_steps`, and `accepted_per_position`. Rates can be

--- a/include/ninfer/types.h
+++ b/include/ninfer/types.h
@@ -704,7 +704,8 @@ enum class MaterializationStopReason : std::uint8_t {
     TargetBudget,
     ExpansionCapacity,
     TimeBudget,
-    ValueOfNextExpansion,
+    InsufficientExpectedGain,
+    WorkBudget,
 };
 
 [[nodiscard]] inline constexpr const char*
@@ -720,10 +721,40 @@ materialization_stop_reason_name(MaterializationStopReason reason) noexcept {
         return "expansion_capacity";
     case MaterializationStopReason::TimeBudget:
         return "time_budget";
-    case MaterializationStopReason::ValueOfNextExpansion:
-        return "value_of_next_expansion";
+    case MaterializationStopReason::InsufficientExpectedGain:
+        return "insufficient_expected_gain";
+    case MaterializationStopReason::WorkBudget:
+        return "work_budget";
     }
     return "no_pressure";
+}
+
+enum class MaterializationSearchPhase : std::uint8_t {
+    None,
+    Setup,
+    Construction,
+    Assessment,
+    Expansion,
+    Refinement,
+};
+
+[[nodiscard]] inline constexpr const char*
+materialization_search_phase_name(MaterializationSearchPhase phase) noexcept {
+    switch (phase) {
+    case MaterializationSearchPhase::None:
+        return "none";
+    case MaterializationSearchPhase::Setup:
+        return "setup";
+    case MaterializationSearchPhase::Construction:
+        return "construction";
+    case MaterializationSearchPhase::Assessment:
+        return "assessment";
+    case MaterializationSearchPhase::Expansion:
+        return "expansion";
+    case MaterializationSearchPhase::Refinement:
+        return "refinement";
+    }
+    return "none";
 }
 
 struct MaterializationDiagnostics {
@@ -738,6 +769,17 @@ struct MaterializationDiagnostics {
     bool budget_exhausted                    = false;
     std::uint32_t selected_degradation_units = 0;
     bool selected_maximal_fallback           = false;
+
+    std::uint64_t initial_predicted_total_ns = 0;
+    std::optional<std::uint64_t> first_improvement_ns;
+    std::uint32_t incumbent_improvements         = 0;
+    std::uint64_t search_work                    = 0;
+    std::uint64_t search_granted_ns              = 0;
+    std::uint32_t search_renewals                = 0;
+    bool search_discovery_used                   = false;
+    std::uint64_t search_overshoot_ns            = 0;
+    MaterializationSearchPhase search_stop_phase = MaterializationSearchPhase::None;
+    bool search_boundary_limited                 = false;
 
     [[nodiscard]] friend constexpr bool
     operator==(const MaterializationDiagnostics&,

--- a/src/ops/linear_topk/q4_m64.cu
+++ b/src/ops/linear_topk/q4_m64.cu
@@ -7,6 +7,7 @@
 #include "ops/linear_topk/linear_topk_workspace.h"
 
 #include <cub/warp/warp_merge_sort.cuh>
+#include <cuda_bf16.h>
 
 #include <cstdint>
 #include <stdexcept>

--- a/src/runtime/contract/types.h
+++ b/src/runtime/contract/types.h
@@ -542,6 +542,19 @@ struct PressurePhysicalGuidance {
     std::uint32_t unsatisfied_constraints   = 0;
     std::uint32_t estimated_remaining_steps = 0;
     std::uint64_t normalized_residual_q20   = 0;
+    // Aggregate byte relief cannot resolve an extent/ordered-stage geometry question.
+    bool requires_exact_feedback = false;
+};
+
+struct PressureOwnerRecoveryGuidance {
+    PlanningOwnerId owner;
+    CoalescedTransferWork additional_restore;
+};
+
+struct PressureConstructionOptionId {
+    std::uint32_t cursor_generation = 0;
+    std::uint32_t scan_generation   = 0;
+    std::uint32_t index             = 0;
 };
 
 // The spans are borrowed from a PressurePlanningSession scratch generation and remain valid only
@@ -554,6 +567,18 @@ struct PressureTargetGuidance {
     std::uint32_t stable_target_ordinal = 0;
     std::uint32_t degradation_units     = 0;
     std::uint32_t dropped_checkpoints   = 0;
+    PrivateSourceMode source_mode       = PrivateSourceMode::ConsumeToActive;
+    std::span<const PressureCheckpointOutcome> checkpoint_changes;
+    std::span<const PressureOwnerRecoveryGuidance> recovery_estimates;
+    bool recovery_estimate_complete = false;
+};
+
+// One resumable scan operation: one owner's successor generation or one option summary.
+// Guidance spans expire at the next session call; the ID remains valid until choose/reset.
+struct PressureConstructionStep {
+    std::optional<PressureTargetGuidance> guidance;
+    PressureConstructionOptionId option;
+    bool exhausted = false;
 };
 
 // The spans are borrowed from a PressurePlanningSession scratch generation and remain valid only

--- a/src/runtime/engine/engine_core.h
+++ b/src/runtime/engine/engine_core.h
@@ -1432,9 +1432,15 @@ private:
         }
     }
 
-    [[nodiscard]] ResourceInspection inspect_admission(const std::shared_ptr<Request>& request) {
+    [[nodiscard]] ResourceInspection inspect_admission(const std::shared_ptr<Request>& request,
+                                                       PlanningAllowance allowance) {
+        allowance.cancellation = &request->cancelled;
+        allowance.control_deadline_ns =
+            static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                           request->deadline.time_since_epoch())
+                                           .count());
         return resources_.inspect(*instance_.program, request->prompt, *request->base_plan,
-                                  request->publication_order);
+                                  request->publication_order, allowance);
     }
 
     [[nodiscard]] AdmissionProgress remove_pending_error(const std::shared_ptr<Request>& request,
@@ -1646,6 +1652,12 @@ private:
     }
 
     AdmissionProgress try_admit_one() {
+        const auto other_runnable = static_cast<std::uint32_t>(
+            std::count_if(slots_.begin(), slots_.end(), [](const auto& request) {
+                return request && !request->capture_pending &&
+                       (request->is_decode_ready() || request->is_prefilling());
+            }));
+        const PlanningAllowance allowance = PlanningAllowance::boundary(other_runnable);
         DetailScope detail(*this, &RuntimeHostWorkStats::admission_policy_ns,
                            &RuntimeHostWorkStats::admission_policy_invocations,
                            nvtx::Name::AdmissionPolicy);
@@ -1684,7 +1696,7 @@ private:
                 control_progress = true;
                 continue;
             }
-            auto head_inspection = inspect_admission(head);
+            auto head_inspection = inspect_admission(head, allowance);
             if (head_inspection.readiness == Readiness::PermanentlyInfeasible) {
                 (void)remove_pending_error(
                     head, std::make_exception_ptr(RequestError(
@@ -1758,7 +1770,7 @@ private:
                     control_progress = true;
                     continue;
                 }
-                auto candidate_inspection = inspect_admission(candidate);
+                auto candidate_inspection = inspect_admission(candidate, allowance);
                 if (candidate_inspection.readiness == Readiness::PermanentlyInfeasible) {
                     (void)remove_pending_error(
                         candidate, std::make_exception_ptr(RequestError(

--- a/src/runtime/engine/materialization_budget.h
+++ b/src/runtime/engine/materialization_budget.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "ninfer/types.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <limits>
+
+namespace ninfer::runtime {
+
+template <class Clock = std::chrono::steady_clock>
+[[nodiscard]] std::uint64_t planning_now_ns() noexcept {
+    return static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now().time_since_epoch())
+            .count());
+}
+
+// One Engine admission boundary, including all head/backfill inspections. Correctness work and
+// sealing cannot be cancelled by this allowance, but their elapsed time reduces optional headroom.
+struct PlanningAllowance {
+    std::uint64_t started_ns              = planning_now_ns();
+    std::uint64_t limit_ns                = 50'000'000;
+    std::uint32_t affected_requests       = 1;
+    const std::atomic<bool>* cancellation = nullptr;
+    std::uint64_t control_deadline_ns     = std::numeric_limits<std::uint64_t>::max();
+
+    [[nodiscard]] static PlanningAllowance
+    boundary(std::uint32_t other_runnable, std::uint64_t now = planning_now_ns()) noexcept {
+        return {.started_ns        = now,
+                .limit_ns          = other_runnable == 0 ? 50'000'000ULL : 10'000'000ULL,
+                .affected_requests = 1U + other_runnable};
+    }
+
+    [[nodiscard]] std::uint64_t remaining(std::uint64_t now) const noexcept {
+        if ((cancellation && cancellation->load(std::memory_order_relaxed)) ||
+            now >= control_deadline_ns) {
+            return 0;
+        }
+        const auto elapsed = now > started_ns ? now - started_ns : 0;
+        return std::min(elapsed < limit_ns ? limit_ns - elapsed : 0, control_deadline_ns - now);
+    }
+};
+
+// Integer timestamps make wall-budget decisions reproducible without sleeping in policy tests.
+// Estimates control optional work only; they never certify feasibility or a search bound.
+class MaterializationSearchBudget {
+public:
+    MaterializationSearchBudget(PlanningAllowance allowance, std::uint64_t started,
+                                std::uint64_t initial_cost) noexcept
+        : allowance_(allowance), started_(started),
+          granted_(std::min(
+              {std::uint64_t{5'000'000}, economic(initial_cost), allowance.remaining(started)})) {}
+
+    [[nodiscard]] bool allow(std::uint64_t now, std::uint64_t next_operation_ns,
+                             std::uint64_t completion_ns, std::uint64_t gain_ns,
+                             bool complete_prediction, std::uint64_t progress,
+                             bool discovery_eligible = true) noexcept {
+        boundary_limited_             = false;
+        const std::uint64_t elapsed   = now > started_ ? now - started_ : 0;
+        const std::uint64_t remaining = allowance_.remaining(now);
+        next_operation_ns             = std::max<std::uint64_t>(1, next_operation_ns);
+        completion_ns                 = std::max(next_operation_ns, completion_ns);
+        if (next_operation_ns > remaining) {
+            boundary_limited_ = true;
+            reason_           = MaterializationStopReason::TimeBudget;
+            return false;
+        }
+        if (elapsed < granted_ && next_operation_ns <= granted_ - elapsed) { return true; }
+        if (completion_ns > remaining || completion_ns > economic(gain_ns)) {
+            reason_ = MaterializationStopReason::InsufficientExpectedGain;
+            return false;
+        }
+        // Unknown forecasts get one bounded discovery episode, not a fresh grant for every node.
+        if (!complete_prediction && (!discovery_eligible || discovery_used_)) {
+            reason_ = MaterializationStopReason::InsufficientExpectedGain;
+            return false;
+        }
+        if (renewals_ != 0 && progress <= renewal_progress_) {
+            reason_ = MaterializationStopReason::InsufficientExpectedGain;
+            return false;
+        }
+        const auto hard = elapsed + remaining; // bounded by the allowance's representable duration
+        const auto growth = std::max(granted_, next_operation_ns);
+        auto added        = std::min(growth, hard > granted_ ? hard - granted_ : 0);
+        if (!complete_prediction) { added = std::min<std::uint64_t>(added, 5'000'000); }
+        if (added == 0 || elapsed + next_operation_ns > granted_ + added) {
+            reason_ = MaterializationStopReason::TimeBudget;
+            return false;
+        }
+        granted_ += added;
+        ++renewals_;
+        renewal_progress_ = progress;
+        discovery_used_   = discovery_used_ || !complete_prediction;
+        return true;
+    }
+
+    [[nodiscard]] std::uint64_t granted_ns() const noexcept { return granted_; }
+
+    [[nodiscard]] std::uint32_t renewals() const noexcept { return renewals_; }
+
+    [[nodiscard]] bool boundary_limited() const noexcept { return boundary_limited_; }
+
+    [[nodiscard]] bool discovery_used() const noexcept { return discovery_used_; }
+
+    [[nodiscard]] MaterializationStopReason stop_reason() const noexcept { return reason_; }
+
+    [[nodiscard]] std::uint64_t overshoot(std::uint64_t now) const noexcept {
+        const auto elapsed = now > started_ ? now - started_ : 0;
+        return elapsed > granted_ ? elapsed - granted_ : 0;
+    }
+
+private:
+    [[nodiscard]] std::uint64_t economic(std::uint64_t gain) const noexcept {
+        if (gain == std::numeric_limits<std::uint64_t>::max()) { return 0; }
+        return gain / 20U / std::max(1U, allowance_.affected_requests);
+    }
+
+    bool boundary_limited_ = false;
+    PlanningAllowance allowance_;
+    std::uint64_t started_            = 0;
+    std::uint64_t granted_            = 0;
+    std::uint64_t renewal_progress_   = 0;
+    std::uint32_t renewals_           = 0;
+    bool discovery_used_              = false;
+    MaterializationStopReason reason_ = MaterializationStopReason::TimeBudget;
+};
+
+} // namespace ninfer::runtime

--- a/src/runtime/engine/materialization_planner.h
+++ b/src/runtime/engine/materialization_planner.h
@@ -2,6 +2,7 @@
 
 #include "runtime/engine/context_cost.h"
 #include "runtime/engine/context_portfolio_value.h"
+#include "runtime/engine/materialization_budget.h"
 #include "runtime/engine/resource_search.h"
 
 #include <algorithm>
@@ -37,7 +38,7 @@ struct MaterializationOwnerPolicy {
     bool explicit_shared_credit            = false;
 };
 
-template <class Package>
+template <class Package, class SearchClock = std::chrono::steady_clock>
 class MaterializationPlanner {
 public:
     using Program                = typename Package::Program;
@@ -48,7 +49,7 @@ public:
     using SharedPrefixHandle     = typename Package::SharedPrefixHandle;
     using PressureTargetHandle   = typename Package::PressureTargetHandle;
     using AssessedPressureTarget = typename Package::AssessedPressureTarget;
-    using Clock                  = std::chrono::steady_clock;
+    using Clock                  = SearchClock;
 
     struct CandidateInput {
         AdmissionCandidate* candidate = nullptr;
@@ -83,10 +84,7 @@ public:
     MaterializationPlanner() : target_ledger_(kTargetBudget + 17U) {
         queue_.reserve(kTargetBudget);
         pending_.reserve(kTargetBudget);
-        guided_.reserve(kTargetBudget);
         identity_costs_.reserve(16);
-        candidate_guided_steps_.reserve(16);
-        candidate_seed_complete_.reserve(16);
         impact_scratch_.reserve(32);
         portfolio_owner_scratch_.reserve(32);
         portfolio_checkpoint_scratch_.reserve(64);
@@ -98,7 +96,7 @@ public:
          const ContextMachineCostModel& machine_cost, std::span<const CandidateInput> candidates,
          std::uint32_t root_candidate_index, PressureInputsFn&& pressure_inputs,
          LogicalGoalFn&& logical_goal, FinalScheduleFn&& final_schedule,
-         Clock::time_point planning_started) {
+         Clock::time_point planning_started, PlanningAllowance allowance = {}) {
         if (candidates.empty() || root_candidate_index >= candidates.size()) {
             throw std::invalid_argument("materialization planning problem has no root candidate");
         }
@@ -113,16 +111,14 @@ public:
         }
         queue_.clear();
         pending_.clear();
-        guided_.clear();
         const std::size_t frontier_capacity = candidates.size() + 1U + kTargetBudget;
         queue_.reserve(frontier_capacity);
         pending_.reserve(frontier_capacity);
-        guided_.reserve(frontier_capacity);
         identity_costs_.clear();
-        candidate_guided_steps_.assign(candidates.size(), 0);
-        candidate_seed_complete_.assign(candidates.size(), false);
         target_ledger_.reset(candidates.size() + 1U + kTargetBudget);
 
+        // The mandatory root-maximal fallback does not count as an ordinary feasible seed.
+        std::vector<bool> candidate_seeded(candidates.size(), false);
         std::optional<Incumbent> identity_best;
         std::vector<IdentityRoot> roots;
         roots.reserve(candidates.size());
@@ -147,7 +143,7 @@ public:
                     .cost             = cost,
                 };
             }
-            if (goal) { candidate_seed_complete_[index] = true; }
+            candidate_seeded[index] = goal.has_value();
             const bool needs_pressure =
                 !goal.has_value() &&
                 (identity.physical_status == MaterializationPhysicalStatus::Feasible ||
@@ -167,7 +163,10 @@ public:
             const bool needs_optional_search =
                 std::any_of(roots.begin(), roots.end(),
                             [](const IdentityRoot& root) { return root.expandable; });
-            if (!needs_optional_search) {
+            const bool no_allowance =
+                allowance.remaining(planning_now_ns<Clock>()) == 0 ||
+                identity_best->cost.total_ns / 20U / std::max(1U, allowance.affected_requests) == 0;
+            if (!needs_optional_search || no_allowance) {
                 const CandidateInput& selected = candidates[identity_best->candidate_index];
                 const auto price_split         = [&](std::span<const std::uint32_t> frontiers) {
                     const std::uint64_t baseline =
@@ -186,8 +185,16 @@ public:
                 if (!sealed) { return std::nullopt; }
                 MaterializationDiagnostics diagnostics = complete_diagnostics(
                     identity_best->cost, static_cast<std::uint32_t>(candidates.size()),
-                    projection_work, planning_started, MaterializationStopReason::NoPressure,
+                    projection_work, planning_started,
+                    needs_optional_search ? MaterializationStopReason::TimeBudget
+                                          : MaterializationStopReason::NoPressure,
                     false);
+                diagnostics.budget_exhausted  = needs_optional_search;
+                diagnostics.search_stop_phase = needs_optional_search
+                                                    ? MaterializationSearchPhase::Setup
+                                                    : MaterializationSearchPhase::None;
+                diagnostics.search_boundary_limited =
+                    needs_optional_search && allowance.remaining(planning_now_ns<Clock>()) == 0;
                 Result result;
                 result.plan             = std::move(*sealed);
                 result.candidate        = candidates[identity_best->candidate_index].id;
@@ -198,6 +205,7 @@ public:
             }
         }
 
+        typename Clock::time_point search_started = Clock::now();
         std::vector<const AdmissionCandidate*> candidate_handles;
         std::vector<PlanningCandidateId> candidate_ids;
         candidate_handles.reserve(candidates.size());
@@ -253,15 +261,47 @@ public:
             mark_target(assessment.stable_target_ordinal, kTargetDiscovered | kTargetAssessed);
         }
 
-        const Clock::time_point search_started = Clock::now();
-        const std::uint64_t search_budget_ns =
-            std::min<std::uint64_t>(5'000'000ULL, incumbent.cost.total_ns / 20U);
-        const std::uint64_t guided_watchdog_ns = search_budget_ns;
-        std::uint64_t maximum_step_ns          = 0;
-        std::uint32_t optional_targets         = 0;
-        std::uint32_t guided_assessments       = 0;
-        MaterializationStopReason stop_reason  = MaterializationStopReason::QueueExhausted;
-        bool budget_exhausted                  = false;
+        if (!identity_best) { search_started = Clock::now(); }
+        const auto search_origin_ns = static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(search_started.time_since_epoch())
+                .count());
+        MaterializationSearchBudget search_budget(allowance, search_origin_ns,
+                                                  incumbent.cost.total_ns);
+        const auto initial_cost_ns = incumbent.cost.total_ns;
+        std::optional<std::uint64_t> first_improvement_ns;
+        std::uint32_t incumbent_improvements = 0;
+        std::uint64_t option_step_ns = 1'000, assessment_step_ns = 20'000,
+                      expansion_step_ns = 20'000;
+        std::uint64_t search_work       = 0;
+        const auto work_limit           = static_cast<std::uint64_t>(kTargetBudget) *
+                                (16U + 16ULL * pressure.owner_policy.size());
+        std::uint32_t optional_targets        = 0;
+        MaterializationStopReason stop_reason = MaterializationStopReason::QueueExhausted;
+        bool budget_exhausted                 = false;
+        auto search_phase                     = MaterializationSearchPhase::Setup;
+        const auto allow_work = [&](std::uint64_t operation, std::uint64_t completion,
+                                    std::uint64_t gain, bool complete,
+                                    bool discovery_eligible = true) {
+            if (search_work >= work_limit) {
+                stop_reason      = MaterializationStopReason::WorkBudget;
+                budget_exhausted = true;
+                return false;
+            }
+            if (!search_budget.allow(planning_now_ns<Clock>(), operation, completion, gain,
+                                     complete, search_work, discovery_eligible)) {
+                stop_reason      = search_budget.stop_reason();
+                budget_exhausted = stop_reason == MaterializationStopReason::TimeBudget;
+                return false;
+            }
+            stop_reason      = MaterializationStopReason::QueueExhausted;
+            budget_exhausted = false;
+            return true;
+        };
+        const auto observe_step = [&](std::uint64_t& estimate, Clock::time_point started) {
+            const auto sample = elapsed_ns(started, Clock::now());
+            estimate          = std::max<std::uint64_t>(1, estimate / 2 + sample / 2);
+        };
+
 
         for (const IdentityRoot& root : roots) {
             if (!root.expandable) { continue; }
@@ -279,18 +319,6 @@ public:
             entry.stable_target_ordinal = root.candidate_index;
             mark_target(entry.stable_target_ordinal, kTargetDiscovered | kTargetAssessed);
             queue_push(entry);
-            const PressureTargetGuidance guidance = session.guidance(entry.target);
-            if (guidance.candidate != candidates[root.candidate_index].id) {
-                throw std::logic_error("pressure guidance changed admission candidate");
-            }
-            guided_insert(GuidedEntry{
-                .target          = entry.target,
-                .candidate_index = root.candidate_index,
-                .lower_bound_ns  = root.lower_bound_ns,
-                .guidance        = fold_guidance(candidates[root.candidate_index], guidance,
-                                                 pressure.owner_policy, machine_cost),
-                .already_assessed_expandable = true,
-            });
         }
 
         const auto make_queue_entry = [](PressureTargetHandle target, std::uint32_t candidate_index,
@@ -336,14 +364,20 @@ public:
                 goal = logical_goal(assessment.candidate, assessment.source_mode,
                                     assessment.owner_outcomes);
             }
-            if (goal && !assessment.root_maximal) {
-                candidate_seed_complete_[expected_candidate] = true;
+            if (goal) {
+                mark_target(assessment.stable_target_ordinal, kTargetFeasible);
+                candidate_seeded[expected_candidate] = true;
             }
             if (goal && cost.less(incumbent.cost)) {
+                if (cost.total_ns < initial_cost_ns && !first_improvement_ns) {
+                    first_improvement_ns = elapsed_ns(search_started, Clock::now());
+                }
+                ++incumbent_improvements;
                 incumbent = make_incumbent(target, expected_candidate, assessment,
                                            std::move(assessed), cost, *goal);
             }
             if (!assessment.expandable) { return std::nullopt; }
+            mark_target(assessment.stable_target_ordinal, kTargetExpandable);
             QueueEntry entry = make_queue_entry(target, expected_candidate, assessment, cost);
             queue_push(entry);
             return entry;
@@ -352,14 +386,18 @@ public:
         const auto expand_target = [&](const QueueEntry& parent) {
             if (target_marked(parent.stable_target_ordinal, kTargetExpanded)) { return true; }
             if (optional_targets >= kTargetBudget) { return false; }
-            auto prepared = session.prepare_expansion(parent.target);
+            auto prepared = session.prepare_expansion(parent.target, 8);
             if (prepared.new_canonical_count() > kTargetBudget - optional_targets) {
                 session.discard_expansion(std::move(prepared));
                 return false;
             }
             const auto children = session.commit_expansion(std::move(prepared));
             optional_targets += children.new_canonical_count;
-            mark_target(parent.stable_target_ordinal, kTargetExpanded);
+            if (children.complete) {
+                mark_target(parent.stable_target_ordinal, kTargetExpanded);
+            } else {
+                queue_push(parent);
+            }
             for (const PressureTargetHandle child : children.children) {
                 const PressureTargetGuidance guidance = session.guidance(child);
                 if (guidance.candidate != candidates[parent.candidate_index].id) {
@@ -370,8 +408,12 @@ public:
                 mark_target(guidance.stable_target_ordinal, kTargetDiscovered);
                 const std::uint64_t lower_bound_ns = std::max(
                     identity_costs_[candidate_index].lower_bound_ns, parent.lower_bound_ns);
-                const GuidanceCost cost = fold_guidance(candidates[candidate_index], guidance,
-                                                        pressure.owner_policy, machine_cost);
+                GuidanceCost cost =
+                    fold_guidance(candidates[candidate_index], guidance, pressure.owner_policy,
+                                  pressure.checkpoint_policy, machine_cost);
+                cost.logical_ready = logical_goal(candidates[candidate_index].id,
+                                                  guidance.source_mode, guidance.owner_outcomes)
+                                         .has_value();
                 PendingEntry pending{
                     .target          = child,
                     .candidate_index = candidate_index,
@@ -379,137 +421,220 @@ public:
                     .guidance        = cost,
                 };
                 pending_push(pending);
-                if (!candidate_seed_complete_[candidate_index]) {
-                    guided_insert(GuidedEntry{
-                        .target          = child,
-                        .candidate_index = candidate_index,
-                        .lower_bound_ns  = lower_bound_ns,
-                        .guidance        = cost,
-                    });
-                }
             }
             return true;
         };
 
-        const auto candidate_needs_seed = [&](std::uint32_t candidate_index) {
-            return candidate_index < roots.size() && roots[candidate_index].expandable &&
-                   !candidate_seed_complete_[candidate_index];
+        using Cursor = decltype(session.begin_construction(incumbent.target));
+
+        struct ConstructionPath {
+            std::optional<Cursor> cursor;
+            std::uint32_t candidate_index = 0;
+            bool feasibility_first        = false;
+            bool repair                   = false;
+            bool restore                  = false;
+            GuidanceCost parent;
+            std::optional<GuidanceCost> best;
+            PressureConstructionOptionId best_option;
+            std::vector<std::uint32_t> visited;
         };
-        const auto has_open_seed = [&] {
-            return std::any_of(roots.begin(), roots.end(), [&](const IdentityRoot& root) {
-                return candidate_needs_seed(root.candidate_index);
-            });
+
+        std::array<ConstructionPath, 4> paths;
+        std::vector<std::uint32_t> order;
+        for (const auto& root : roots) {
+            if (root.expandable) { order.push_back(root.candidate_index); }
+        }
+        std::stable_sort(order.begin(), order.end(), [&](auto a, auto b) {
+            return identity_costs_[a].lower_bound_ns < identity_costs_[b].lower_bound_ns;
+        });
+        const auto rank_guidance = [&](std::uint32_t index, const PressureTargetGuidance& guide) {
+            auto cost = fold_guidance(candidates[index], guide, pressure.owner_policy,
+                                      pressure.checkpoint_policy, machine_cost);
+            cost.logical_ready =
+                logical_goal(candidates[index].id, guide.source_mode, guide.owner_outcomes)
+                    .has_value();
+            if (!cost.logical_ready) {
+                ++cost.unsatisfied_constraints;
+                cost.normalized_residual_q20 += 1ULL << 20U;
+                cost.estimated_remaining_steps = std::max(1U, cost.estimated_remaining_steps);
+            }
+            return cost;
         };
+        const auto start_path = [&](ConstructionPath& path, std::uint32_t candidate,
+                                    PressureTargetHandle target, bool feasibility, bool restore) {
+            path.cursor.reset();
+            path.candidate_index   = candidate;
+            path.feasibility_first = feasibility;
+            path.restore           = restore;
+            path.best.reset();
+            path.visited.clear();
+            path.visited.reserve(kTargetBudget);
+            path.parent = rank_guidance(candidate, session.guidance(target));
+            path.repair = path.parent.requires_exact_feedback;
+            path.visited.push_back(path.parent.stable_target_ordinal);
+            path.cursor.emplace(session.begin_construction(target, restore));
+        };
+        std::size_t next_path  = 0;
+        bool search_stopped    = false;
+        bool rescue_done       = false;
+        bool refinement_seeded = false;
+        const auto have_paths  = [&] {
+            return std::any_of(paths.begin(), paths.end(),
+                                [](const auto& path) { return bool(path.cursor); });
+        };
+        while (!search_stopped &&
+               (next_path < 2U * order.size() || have_paths() || !refinement_seeded)) {
+            if (next_path == 2U * order.size() && !have_paths()) {
+                if (!rescue_done) {
+                    rescue_done = true;
+                    const auto promising =
+                        std::find_if(order.begin(), order.end(), [&](auto candidate) {
+                            return !candidate_seeded[candidate] &&
+                                   identity_costs_[candidate].lower_bound_ns <
+                                       incumbent.cost.total_ns;
+                        });
+                    if (promising != order.end() && optional_targets < kTargetBudget) {
+                        const auto candidate = *promising;
+                        const auto gain =
+                            incumbent.cost.total_ns - identity_costs_[candidate].lower_bound_ns;
+                        search_phase = MaterializationSearchPhase::Assessment;
+                        if (allow_work(assessment_step_ns, assessment_step_ns, gain, false)) {
+                            const auto rescue = session.maximal_target(candidates[candidate].id);
+                            const auto guide  = session.guidance(rescue);
+                            if (!target_marked(guide.stable_target_ordinal, kTargetAssessed)) {
+                                if (!target_marked(guide.stable_target_ordinal,
+                                                   kTargetDiscovered)) {
+                                    ++optional_targets;
+                                }
+                                const auto started = Clock::now();
+                                (void)assess_target(rescue, candidate, guide.stable_target_ordinal);
+                                observe_step(assessment_step_ns, started);
+                                ++search_work;
+                            }
+                        }
+                    }
+                }
+                refinement_seeded = true;
+                if (incumbent.degradation_units != 0) {
+                    start_path(paths[0], incumbent.candidate_index, incumbent.target, false, true);
+                }
+                if (!have_paths()) { break; }
+            }
+            for (auto& path : paths) {
+                if (!path.cursor && next_path < 2U * order.size()) {
+                    const auto candidate = order[next_path / 2];
+                    start_path(path, candidate, session.identity_target(candidates[candidate].id),
+                               (next_path % 2) != 0, false);
+                    ++next_path;
+                }
+                if (!path.cursor) { continue; }
+                for (unsigned slice = 0; slice < 8 && path.cursor; ++slice) {
+                    const auto& forecast  = path.best ? *path.best : path.parent;
+                    const auto optimistic = identity_costs_[path.candidate_index].lower_bound_ns;
+                    const bool complete =
+                        forecast.unsatisfied_constraints == 0 && forecast.recovery_complete;
+                    const auto estimate = complete ? forecast.estimated_total_ns : optimistic;
+                    const auto gain =
+                        incumbent.cost.total_ns > estimate ? incumbent.cost.total_ns - estimate : 0;
+                    const auto steps =
+                        std::min<std::uint64_t>(64, 1ULL + forecast.estimated_remaining_steps);
+                    const auto completion =
+                        assessment_step_ns +
+                        option_step_ns * steps *
+                            std::max<std::size_t>(1, pressure.owner_policy.size());
+                    search_phase = path.restore ? MaterializationSearchPhase::Refinement
+                                                : MaterializationSearchPhase::Construction;
+                    if (!allow_work(option_step_ns, completion, gain, complete,
+                                    !candidate_seeded[path.candidate_index])) {
+                        search_stopped = search_work >= work_limit ||
+                                         allowance.remaining(planning_now_ns<Clock>()) == 0;
+                        path.cursor.reset();
+                        break;
+                    }
+                    const auto step_started = Clock::now();
+                    const auto step         = session.next_construction_option(*path.cursor);
+                    observe_step(option_step_ns, step_started);
+                    ++search_work;
+                    if (step.guidance) {
+                        auto cost = rank_guidance(path.candidate_index, *step.guidance);
+                        if (construction_option_better(path.parent, path.best, cost,
+                                                       path.feasibility_first, path.restore)) {
+                            path.best        = cost;
+                            path.best_option = step.option;
+                        }
+                    }
+                    if (!step.exhausted) { continue; }
+                    if (!path.best || optional_targets >= kTargetBudget) {
+                        path.cursor.reset();
+                        break;
+                    }
+                    session.choose_construction(*path.cursor, path.best_option);
+                    const auto target = session.construction_target(*path.cursor);
+                    if (!target) {
+                        stop_reason      = MaterializationStopReason::ExpansionCapacity;
+                        budget_exhausted = search_stopped = true;
+                        break;
+                    }
+                    auto chosen = rank_guidance(path.candidate_index, session.guidance(*target));
+                    if (std::find(path.visited.begin(), path.visited.end(),
+                                  chosen.stable_target_ordinal) != path.visited.end()) {
+                        path.cursor.reset();
+                        break;
+                    }
+                    path.visited.push_back(chosen.stable_target_ordinal);
+                    if (!target_marked(chosen.stable_target_ordinal, kTargetDiscovered)) {
+                        mark_target(chosen.stable_target_ordinal, kTargetDiscovered);
+                        ++optional_targets;
+                        pending_push({.target          = *target,
+                                      .candidate_index = path.candidate_index,
+                                      .lower_bound_ns  = optimistic,
+                                      .guidance        = chosen});
+                    }
+                    path.parent = chosen;
+                    path.best.reset();
+                    if (chosen.unsatisfied_constraints != 0 && !path.repair && !path.restore) {
+                        continue;
+                    }
+                    if (!target_marked(chosen.stable_target_ordinal, kTargetAssessed)) {
+                        const auto target_gain =
+                            incumbent.cost.total_ns > chosen.estimated_total_ns
+                                ? incumbent.cost.total_ns - chosen.estimated_total_ns
+                                : 0;
+                        search_phase = MaterializationSearchPhase::Assessment;
+                        if (!allow_work(assessment_step_ns, assessment_step_ns,
+                                        chosen.recovery_complete ? target_gain : gain,
+                                        chosen.recovery_complete &&
+                                            chosen.unsatisfied_constraints == 0,
+                                        !candidate_seeded[path.candidate_index])) {
+                            search_stopped = search_work >= work_limit ||
+                                             allowance.remaining(planning_now_ns<Clock>()) == 0;
+                            path.cursor.reset();
+                            break;
+                        }
+                        const auto started = Clock::now();
+                        (void)assess_target(*target, path.candidate_index,
+                                            chosen.stable_target_ordinal);
+                        observe_step(assessment_step_ns, started);
+                        ++search_work;
+                    }
+                    const bool feasible =
+                        target_marked(chosen.stable_target_ordinal, kTargetFeasible);
+                    path.cursor.reset();
+                    if (!feasible && !path.restore &&
+                        target_marked(chosen.stable_target_ordinal, kTargetExpandable)) {
+                        // The Program resumes from its exact residual/geometry evidence.
+                        path.cursor.emplace(session.begin_construction(*target));
+                        path.repair = true;
+                    }
+                }
+                if (search_stopped) { break; }
+            }
+        }
+        for (auto& path : paths) { path.cursor.reset(); }
 
-        std::vector<const MaterializationOwnerPolicy*> preferred_owners;
-        preferred_owners.reserve(pressure.owner_policy.size());
-        for (const MaterializationOwnerPolicy& policy : pressure.owner_policy) {
-            preferred_owners.push_back(&policy);
-        }
-        std::sort(preferred_owners.begin(), preferred_owners.end(),
-                  [](const auto* left, const auto* right) {
-                      return std::tuple{
-                                 left->selected_hit_count,
-                                 left->explicit_shared_credit ? 1U : 0U,
-                                 left->private_retention_weight,
-                                 left->last_hit_epoch,
-                                 left->owner.value,
-                             } < std::tuple{
-                                     right->selected_hit_count,
-                                     right->explicit_shared_credit ? 1U : 0U,
-                                     right->private_retention_weight,
-                                     right->last_hit_epoch,
-                                     right->owner.value,
-                                 };
-                  });
-        std::vector<PlanningOwnerId> preferred_owner_ids;
-        preferred_owner_ids.reserve(preferred_owners.size());
-        for (const MaterializationOwnerPolicy* policy : preferred_owners) {
-            preferred_owner_ids.push_back(policy->owner);
-        }
-
-        std::vector<IdentityRoot> closure_order;
-        closure_order.reserve(roots.size());
-        for (const IdentityRoot& root : roots) {
-            if (candidate_needs_seed(root.candidate_index)) { closure_order.push_back(root); }
-        }
-        std::sort(closure_order.begin(), closure_order.end(),
-                  [](const IdentityRoot& left, const IdentityRoot& right) {
-                      return std::tuple{left.lower_bound_ns, left.candidate_index} <
-                             std::tuple{right.lower_bound_ns, right.candidate_index};
-                  });
-        for (const IdentityRoot& root : closure_order) {
-            if (!candidate_needs_seed(root.candidate_index) ||
-                elapsed_ns(search_started, Clock::now()) >= guided_watchdog_ns ||
-                optional_targets >= kTargetBudget) {
-                continue;
-            }
-            const Clock::time_point step_started              = Clock::now();
-            const std::optional<PressureTargetHandle> closure = session.guided_closure_target(
-                candidates[root.candidate_index].id, preferred_owner_ids);
-            maximum_step_ns = std::max(maximum_step_ns, elapsed_ns(step_started, Clock::now()));
-            if (!closure) { continue; }
-            const PressureTargetGuidance closure_guidance = session.guidance(*closure);
-            if (closure_guidance.candidate != candidates[root.candidate_index].id) {
-                throw std::logic_error("guided closure changed admission candidate");
-            }
-            if (target_marked(closure_guidance.stable_target_ordinal, kTargetAssessed)) {
-                continue;
-            }
-            if (!target_marked(closure_guidance.stable_target_ordinal, kTargetDiscovered)) {
-                mark_target(closure_guidance.stable_target_ordinal, kTargetDiscovered);
-                ++optional_targets;
-            }
-            const Clock::time_point assessment_started = Clock::now();
-            (void)assess_target(*closure, root.candidate_index,
-                                closure_guidance.stable_target_ordinal);
-            ++guided_assessments;
-            maximum_step_ns =
-                std::max(maximum_step_ns, elapsed_ns(assessment_started, Clock::now()));
-        }
-
-        // Build one ordinary feasible seed per expandable candidate. Estimated machine cost orders
-        // independent beams but never excludes a candidate or certifies an incumbent.
-        while (has_open_seed() && !guided_.empty() &&
-               guided_assessments < kGuidedAssessmentBudget) {
-            if (elapsed_ns(search_started, Clock::now()) >= guided_watchdog_ns) { break; }
-            const GuidedEntry next = guided_pop();
-            if (!candidate_needs_seed(next.candidate_index) ||
-                target_marked(next.guidance.stable_target_ordinal, kTargetExpanded)) {
-                continue;
-            }
-            std::optional<QueueEntry> exact;
-            if (next.already_assessed_expandable) {
-                exact = QueueEntry{
-                    .target          = next.target,
-                    .candidate_index = next.candidate_index,
-                    .lower_bound_ns  = next.lower_bound_ns,
-                    .remaining_prefill =
-                        identity_costs_[next.candidate_index].remaining_text_prefill,
-                    .remaining_vision_prefill =
-                        identity_costs_[next.candidate_index].remaining_vision_prefill,
-                    .reused_prompt_tokens =
-                        identity_costs_[next.candidate_index].reused_prompt_tokens,
-                    .current_session_binding =
-                        identity_costs_[next.candidate_index].current_session_binding,
-                    .candidate_ordinal = identity_costs_[next.candidate_index].candidate_ordinal,
-                    .stable_target_ordinal = next.guidance.stable_target_ordinal,
-                };
-            } else if (!target_marked(next.guidance.stable_target_ordinal, kTargetAssessed)) {
-                const Clock::time_point step_started = Clock::now();
-                exact = assess_target(next.target, next.candidate_index,
-                                      next.guidance.stable_target_ordinal);
-                ++guided_assessments;
-                maximum_step_ns = std::max(maximum_step_ns, elapsed_ns(step_started, Clock::now()));
-            }
-            if (!exact || !candidate_needs_seed(next.candidate_index)) { continue; }
-            if (elapsed_ns(search_started, Clock::now()) >= guided_watchdog_ns) { break; }
-            const Clock::time_point step_started = Clock::now();
-            if (!expand_target(*exact)) { break; }
-            maximum_step_ns = std::max(maximum_step_ns, elapsed_ns(step_started, Clock::now()));
-        }
-
+        // Ordinary alternatives remain available: construction heuristics are not pruning proofs.
         for (;;) {
+            if (search_stopped) { break; }
             while (!queue_.empty() &&
                    target_marked(queue_.front().stable_target_ordinal, kTargetExpanded)) {
                 (void)queue_pop();
@@ -519,54 +644,56 @@ public:
                 target_marked(pending_.front().guidance.stable_target_ordinal, kTargetAssessed)) {
                 (void)pending_pop();
             }
-            if (queue_.empty() && pending_.empty()) {
-                stop_reason = MaterializationStopReason::QueueExhausted;
-                break;
-            }
-            const std::uint64_t queue_bound   = queue_.empty()
-                                                    ? std::numeric_limits<std::uint64_t>::max()
-                                                    : queue_.front().lower_bound_ns;
-            const std::uint64_t pending_bound = pending_.empty()
-                                                    ? std::numeric_limits<std::uint64_t>::max()
-                                                    : pending_.front().lower_bound_ns;
-            const std::uint64_t next_bound    = std::min(queue_bound, pending_bound);
-            const std::uint64_t elapsed       = elapsed_ns(search_started, Clock::now());
-            if (elapsed >= search_budget_ns) {
-                stop_reason      = MaterializationStopReason::TimeBudget;
-                budget_exhausted = true;
-                break;
-            }
-            const std::uint64_t possible_improvement =
-                incumbent.cost.total_ns > next_bound ? incumbent.cost.total_ns - next_bound : 0;
-            if (possible_improvement != 0 && maximum_step_ns != 0 &&
-                maximum_step_ns >= possible_improvement) {
-                stop_reason = MaterializationStopReason::ValueOfNextExpansion;
-                break;
-            }
-
+            if (queue_.empty() && pending_.empty()) { break; }
             const bool assess_pending =
-                !pending_.empty() && (queue_.empty() || pending_bound <= queue_bound);
-            const Clock::time_point step_started = Clock::now();
-            if (assess_pending) {
-                const PendingEntry next = pending_pop();
-                if (!target_marked(next.guidance.stable_target_ordinal, kTargetAssessed)) {
-                    (void)assess_target(next.target, next.candidate_index,
-                                        next.guidance.stable_target_ordinal);
+                !pending_.empty() && (queue_.empty() || pending_.front().lower_bound_ns <=
+                                                            queue_.front().lower_bound_ns);
+            const auto estimate = assess_pending ? pending_.front().guidance.estimated_total_ns
+                                                 : queue_.front().lower_bound_ns;
+            const auto gain =
+                incumbent.cost.total_ns > estimate ? incumbent.cost.total_ns - estimate : 0;
+            const auto predicted_step = assess_pending ? assessment_step_ns : expansion_step_ns;
+            search_phase              = assess_pending ? MaterializationSearchPhase::Assessment
+                                                       : MaterializationSearchPhase::Expansion;
+            if (!allow_work(predicted_step,
+                            predicted_step + (assess_pending ? 0 : assessment_step_ns), gain,
+                            assess_pending && pending_.front().guidance.recovery_complete &&
+                                pending_.front().guidance.unsatisfied_constraints == 0 &&
+                                pending_.front().guidance.logical_ready,
+                            !candidate_seeded[assess_pending ? pending_.front().candidate_index
+                                                             : queue_.front().candidate_index])) {
+                if (search_work >= work_limit ||
+                    allowance.remaining(planning_now_ns<Clock>()) == 0) {
+                    break;
                 }
+                // A forecast that cannot justify another window must not starve a different source.
+                if (assess_pending) {
+                    (void)pending_pop();
+                } else {
+                    (void)queue_pop();
+                }
+                continue;
+            }
+            const auto started = Clock::now();
+            if (assess_pending) {
+                const auto next = pending_pop();
+                (void)assess_target(next.target, next.candidate_index,
+                                    next.guidance.stable_target_ordinal);
+                observe_step(assessment_step_ns, started);
             } else {
                 if (optional_targets >= kTargetBudget) {
                     stop_reason      = MaterializationStopReason::TargetBudget;
                     budget_exhausted = true;
                     break;
                 }
-                const QueueEntry parent = queue_pop();
-                if (!expand_target(parent)) {
+                if (!expand_target(queue_pop())) {
                     stop_reason      = MaterializationStopReason::ExpansionCapacity;
                     budget_exhausted = true;
                     break;
                 }
+                observe_step(expansion_step_ns, started);
             }
-            maximum_step_ns = std::max(maximum_step_ns, elapsed_ns(step_started, Clock::now()));
+            ++search_work;
         }
 
         const std::uint64_t search_elapsed_ns = elapsed_ns(search_started, Clock::now());
@@ -598,6 +725,18 @@ public:
             incumbent.cost, targets_evaluated, projection_work, planning_started, search_elapsed_ns,
             stop_reason, budget_exhausted, incumbent.degradation_units, incumbent.root_maximal);
 
+        diagnostics.initial_predicted_total_ns = initial_cost_ns;
+        diagnostics.first_improvement_ns       = first_improvement_ns;
+        diagnostics.incumbent_improvements     = incumbent_improvements;
+        diagnostics.search_work                = search_work;
+        diagnostics.search_granted_ns          = search_budget.granted_ns();
+        diagnostics.search_renewals            = search_budget.renewals();
+        diagnostics.search_discovery_used      = search_budget.discovery_used();
+        diagnostics.search_stop_phase          = search_phase;
+        diagnostics.search_boundary_limited    = search_budget.boundary_limited();
+        diagnostics.search_overshoot_ns        = search_elapsed_ns > search_budget.granted_ns()
+                                                     ? search_elapsed_ns - search_budget.granted_ns()
+                                                     : 0;
         Result result;
         result.plan                = std::move(*sealed);
         result.candidate           = candidates[incumbent.candidate_index].id;
@@ -614,19 +753,18 @@ public:
     plan(Program& program, const PreparedPrompt& prompt,
          const ContextMachineCostModel& machine_cost, std::span<const CandidateInput> candidates,
          std::uint32_t root_candidate_index, PressureInputsFn&& pressure_inputs,
-         LogicalGoalFn&& logical_goal, Clock::time_point planning_started) {
+         LogicalGoalFn&& logical_goal, Clock::time_point planning_started,
+         PlanningAllowance allowance = {}) {
         const auto no_optional_schedule = [](PlanningCandidateId, const RequestPlanSummary&,
                                              const auto&) { return std::vector<std::uint32_t>{}; };
         return plan(program, prompt, machine_cost, candidates, root_candidate_index,
                     std::forward<PressureInputsFn>(pressure_inputs),
                     std::forward<LogicalGoalFn>(logical_goal), no_optional_schedule,
-                    planning_started);
+                    planning_started, allowance);
     }
 
 private:
-    static constexpr std::uint32_t kTargetBudget           = 4096;
-    static constexpr std::uint32_t kGuidedBeamWidth        = 16;
-    static constexpr std::uint32_t kGuidedAssessmentBudget = 32;
+    static constexpr std::uint32_t kTargetBudget = 4096;
 
     struct FoldedCost {
         std::uint64_t now_ns                    = 0;
@@ -707,6 +845,10 @@ private:
     };
 
     struct GuidanceCost {
+        std::uint64_t estimated_total_ns        = 0;
+        bool recovery_complete                  = false;
+        bool requires_exact_feedback            = false;
+        bool logical_ready                      = false;
         std::uint32_t estimated_remaining_steps = 0;
         std::uint32_t unsatisfied_constraints   = 0;
         std::uint64_t normalized_residual_q20   = 0;
@@ -729,6 +871,7 @@ private:
 
         [[nodiscard]] auto key() const noexcept {
             return std::tuple{
+                estimated_total_ns,
                 affected_selected_hits,
                 explicit_shared_losses,
                 owner_evictions,
@@ -752,19 +895,47 @@ private:
         }
     };
 
+    [[nodiscard]] static bool construction_option_better(const GuidanceCost& parent,
+                                                         const std::optional<GuidanceCost>& best,
+                                                         const GuidanceCost& cost,
+                                                         bool feasibility_first,
+                                                         bool restore) noexcept {
+        if (!best) { return true; }
+        const auto& prior         = *best;
+        const bool complete       = cost.unsatisfied_constraints == 0;
+        const bool prior_complete = prior.unsatisfied_constraints == 0;
+        if (restore || (complete && prior_complete)) { return cost.key() < prior.key(); }
+        if (feasibility_first) {
+            if (complete != prior_complete) { return complete; }
+            return std::tuple{cost.estimated_remaining_steps, cost.normalized_residual_q20,
+                              cost.key()} < std::tuple{prior.estimated_remaining_steps,
+                                                       prior.normalized_residual_q20, prior.key()};
+        }
+        const auto relief = [&](const GuidanceCost& item) {
+            return parent.normalized_residual_q20 > item.normalized_residual_q20
+                       ? parent.normalized_residual_q20 - item.normalized_residual_q20
+                       : 0;
+        };
+        const auto a = relief(cost), b = relief(prior);
+        if ((a != 0) != (b != 0)) { return a != 0; }
+        if (a && b) {
+            const auto delta = [&](const GuidanceCost& item) {
+                return item.estimated_total_ns > parent.estimated_total_ns
+                           ? item.estimated_total_ns - parent.estimated_total_ns
+                           : 0;
+            };
+            const __uint128_t left  = static_cast<__uint128_t>(delta(cost)) * b;
+            const __uint128_t right = static_cast<__uint128_t>(delta(prior)) * a;
+            if (left != right) { return left < right; }
+        }
+        return cost.key() < prior.key();
+    }
+
     struct PendingEntry {
         PressureTargetHandle target{};
         std::uint32_t candidate_index = 0;
         std::uint64_t lower_bound_ns  = 0;
         GuidanceCost guidance;
-    };
-
-    struct GuidedEntry {
-        PressureTargetHandle target{};
-        std::uint32_t candidate_index = 0;
-        std::uint64_t lower_bound_ns  = 0;
-        GuidanceCost guidance;
-        bool already_assessed_expandable = false;
     };
 
     struct CombinedImpact {
@@ -828,13 +999,15 @@ private:
     [[nodiscard]] GuidanceCost
     fold_guidance(const CandidateInput& candidate, const PressureTargetGuidance& guidance,
                   std::span<const MaterializationOwnerPolicy> owner_policies,
-                  const ContextMachineCostModel& machine_cost) const {
+                  std::span<const MaterializationCheckpointPolicy> checkpoint_policies,
+                  const ContextMachineCostModel& machine_cost) {
         const PricedMaterializationMachineWork priced =
             price_materialization_machine_work(machine_cost, guidance.estimated_machine_work);
         GuidanceCost cost;
         cost.estimated_remaining_steps = guidance.physical.estimated_remaining_steps;
         cost.unsatisfied_constraints   = guidance.physical.unsatisfied_constraints;
         cost.normalized_residual_q20   = guidance.physical.normalized_residual_q20;
+        cost.requires_exact_feedback   = guidance.physical.requires_exact_feedback;
         cost.checkpoint_drops          = guidance.dropped_checkpoints;
         cost.degradation_units         = guidance.degradation_units;
         cost.estimated_immediate_ns    = priced.immediate_ns;
@@ -865,6 +1038,58 @@ private:
             planning_saturating_add(cost.retention_weight, policy->private_retention_weight);
             if (policy->explicit_shared_credit) { ++cost.explicit_shared_losses; }
         }
+        portfolio_owner_scratch_.clear();
+        for (const auto& policy : owner_policies) {
+            portfolio_owner_scratch_.push_back(
+                {.owner                    = policy.owner,
+                 .private_retention_weight = policy.private_retention_weight,
+                 .explicit_shared_credit   = policy.explicit_shared_credit});
+        }
+        portfolio_checkpoint_scratch_.clear();
+        for (const auto& checkpoint : checkpoint_policies) {
+            const auto outcome =
+                std::find_if(guidance.owner_outcomes.begin(), guidance.owner_outcomes.end(),
+                             [&](const auto& item) { return item.owner == checkpoint.owner; });
+            const auto change =
+                std::find_if(guidance.checkpoint_changes.begin(), guidance.checkpoint_changes.end(),
+                             [&](const auto& item) {
+                                 return item.owner == checkpoint.owner &&
+                                        item.checkpoint == checkpoint.checkpoint;
+                             });
+            std::uint64_t recovery = checkpoint.baseline_recovery_ns;
+            if ((outcome != guidance.owner_outcomes.end() &&
+                 outcome->disposition == VictimDisposition::Evicted) ||
+                (change != guidance.checkpoint_changes.end() && !change->survives)) {
+                recovery = checkpoint.rebuild_ns;
+            } else {
+                const auto estimate = std::find_if(
+                    guidance.recovery_estimates.begin(), guidance.recovery_estimates.end(),
+                    [&](const auto& item) { return item.owner == checkpoint.owner; });
+                if (estimate != guidance.recovery_estimates.end()) {
+                    for (std::size_t direction = 0; direction < 3; ++direction) {
+                        planning_saturating_add(
+                            recovery, machine_cost.transfer_ns(
+                                          static_cast<ContextTransferDirection>(direction),
+                                          estimate->additional_restore[direction]));
+                    }
+                }
+            }
+            portfolio_checkpoint_scratch_.push_back(
+                {.owner                = checkpoint.owner,
+                 .demand_mask          = checkpoint.demand_mask,
+                 .rebuild_ns           = checkpoint.rebuild_ns,
+                 .baseline_recovery_ns = checkpoint.baseline_recovery_ns,
+                 .target_recovery_ns   = recovery});
+        }
+        const auto value =
+            portfolio_value_.fold(portfolio_owner_scratch_, portfolio_checkpoint_scratch_);
+        cost.estimated_total_ns = priced.immediate_ns;
+        planning_saturating_add(cost.estimated_total_ns,
+                                value.baseline_public_value > value.target_public_value
+                                    ? value.baseline_public_value - value.target_public_value
+                                    : 0);
+        planning_saturating_add(cost.estimated_total_ns, value.private_transition_loss);
+        cost.recovery_complete = guidance.recovery_estimate_complete && !value.saturated;
         return cost;
     }
 
@@ -1058,90 +1283,8 @@ private:
         return result;
     }
 
-    [[nodiscard]] static bool guidance_dominates(const GuidanceCost& left,
-                                                 const GuidanceCost& right) noexcept {
-        const std::array<std::uint64_t, 13> left_dimensions{
-            left.estimated_remaining_steps, left.unsatisfied_constraints,
-            left.normalized_residual_q20,   left.affected_selected_hits,
-            left.newest_affected_hit_epoch, left.explicit_shared_losses,
-            left.retention_weight,          left.owner_evictions,
-            left.checkpoint_drops,          left.estimated_immediate_ns,
-            left.degradation_units,         left.copy_operations,
-            left.transferred_bytes,
-        };
-        const std::array<std::uint64_t, 13> right_dimensions{
-            right.estimated_remaining_steps, right.unsatisfied_constraints,
-            right.normalized_residual_q20,   right.affected_selected_hits,
-            right.newest_affected_hit_epoch, right.explicit_shared_losses,
-            right.retention_weight,          right.owner_evictions,
-            right.checkpoint_drops,          right.estimated_immediate_ns,
-            right.degradation_units,         right.copy_operations,
-            right.transferred_bytes,
-        };
-        bool strict = false;
-        for (std::size_t index = 0; index < left_dimensions.size(); ++index) {
-            if (left_dimensions[index] > right_dimensions[index]) { return false; }
-            strict = strict || left_dimensions[index] < right_dimensions[index];
-        }
-        return strict;
-    }
-
-    void guided_insert(GuidedEntry entry) {
-        if (std::any_of(guided_.begin(), guided_.end(), [&](const GuidedEntry& existing) {
-                return existing.candidate_index == entry.candidate_index &&
-                       existing.lower_bound_ns <= entry.lower_bound_ns &&
-                       guidance_dominates(existing.guidance, entry.guidance);
-            })) {
-            return;
-        }
-        std::erase_if(guided_, [&](const GuidedEntry& existing) {
-            return existing.candidate_index == entry.candidate_index &&
-                   entry.lower_bound_ns <= existing.lower_bound_ns &&
-                   guidance_dominates(entry.guidance, existing.guidance);
-        });
-        guided_.push_back(std::move(entry));
-        const std::uint32_t candidate_index = guided_.back().candidate_index;
-        const std::size_t candidate_size    = static_cast<std::size_t>(
-            std::count_if(guided_.begin(), guided_.end(), [&](const GuidedEntry& item) {
-                return item.candidate_index == candidate_index;
-            }));
-        if (candidate_size <= kGuidedBeamWidth) { return; }
-        auto worst = guided_.end();
-        for (auto item = guided_.begin(); item != guided_.end(); ++item) {
-            if (item->candidate_index != candidate_index) { continue; }
-            if (worst == guided_.end() ||
-                std::tuple{worst->lower_bound_ns, worst->guidance.key()} <
-                    std::tuple{item->lower_bound_ns, item->guidance.key()}) {
-                worst = item;
-            }
-        }
-        if (worst == guided_.end()) {
-            throw std::logic_error("candidate guided beam accounting is inconsistent");
-        }
-        guided_.erase(worst);
-    }
-
-    [[nodiscard]] GuidedEntry guided_pop() {
-        const auto key = [&](const GuidedEntry& entry) {
-            if (entry.candidate_index >= candidate_guided_steps_.size()) {
-                throw std::logic_error("guided target candidate index is invalid");
-            }
-            return std::tuple{
-                candidate_guided_steps_[entry.candidate_index] == 0 ? 0U : 1U,
-                entry.lower_bound_ns,
-                entry.guidance.key(),
-            };
-        };
-        const auto best    = std::min_element(guided_.begin(), guided_.end(),
-                                              [&](const GuidedEntry& left, const GuidedEntry& right) {
-                                               return key(left) < key(right);
-                                           });
-        GuidedEntry result = std::move(*best);
-        guided_.erase(best);
-        ++candidate_guided_steps_[result.candidate_index];
-        return result;
-    }
-
+    static constexpr std::uint8_t kTargetFeasible   = 8U;
+    static constexpr std::uint8_t kTargetExpandable = 16U;
     static constexpr std::uint8_t kTargetDiscovered = BoundedTargetLedger::Discovered;
     static constexpr std::uint8_t kTargetAssessed   = BoundedTargetLedger::Assessed;
     static constexpr std::uint8_t kTargetExpanded   = BoundedTargetLedger::Expanded;
@@ -1180,15 +1323,13 @@ private:
             .budget_exhausted           = budget_exhausted,
             .selected_degradation_units = degradation_units,
             .selected_maximal_fallback  = maximal_fallback,
+            .initial_predicted_total_ns = cost.total_ns,
         };
     }
 
     std::vector<QueueEntry> queue_;
     std::vector<PendingEntry> pending_;
-    std::vector<GuidedEntry> guided_;
     std::vector<FoldedCost> identity_costs_;
-    std::vector<std::uint32_t> candidate_guided_steps_;
-    std::vector<std::uint8_t> candidate_seed_complete_;
     BoundedTargetLedger target_ledger_;
     std::vector<CombinedImpact> impact_scratch_;
     ContextPortfolioValue portfolio_value_;

--- a/src/runtime/engine/resource_manager.h
+++ b/src/runtime/engine/resource_manager.h
@@ -270,7 +270,8 @@ public:
     }
 
     [[nodiscard]] Inspection inspect(Program& program, const PreparedPrompt& prompt,
-                                     const RequestBasePlan& base, std::uint64_t publication_order) {
+                                     const RequestBasePlan& base, std::uint64_t publication_order,
+                                     PlanningAllowance allowance = {}) {
         if (!std::holds_alternative<std::monostate>(transaction_) ||
             program.has_context_transaction()) {
             return {.readiness = Readiness::TemporarilyBlocked};
@@ -394,7 +395,7 @@ public:
 
         std::optional<Choice> selected =
             plan_materialization(program, prompt, base, *destination, candidates, publication_order,
-                                 planning_started, provisional_demand);
+                                 planning_started, provisional_demand, allowance);
         if (!selected) { return {.readiness = Readiness::TemporarilyBlocked}; }
         return {
             .readiness = selected->needs_transfer() ? Readiness::NeedsTransfer : Readiness::Ready,
@@ -1829,7 +1830,7 @@ private:
                          const RequestBasePlan& base, LaneId destination,
                          std::vector<Candidate>& candidates, std::uint64_t publication_order,
                          typename Planner::Clock::time_point planning_started,
-                         PrefixDemandRecord& provisional_demand) {
+                         PrefixDemandRecord& provisional_demand, PlanningAllowance allowance) {
         std::vector<typename Planner::CandidateInput> candidate_inputs;
         std::vector<const ContinuationHandle*> private_owners;
         std::vector<PlanningOwnerId> private_owner_ids;
@@ -2088,7 +2089,7 @@ private:
 
         std::optional<typename Planner::Result> planned =
             planner_.plan(program, prompt, cost_model_, candidate_inputs, 0, build_pressure_inputs,
-                          logical_goal, final_schedule, planning_started);
+                          logical_goal, final_schedule, planning_started, allowance);
         const auto selected_candidate =
             planned ? std::find_if(candidate_inputs.begin(), candidate_inputs.end(),
                                    [&](const typename Planner::CandidateInput& input) {

--- a/src/serve/request_log.cpp
+++ b/src/serve/request_log.cpp
@@ -328,6 +328,19 @@ Json materialization_json(const ninfer::MaterializationDiagnostics& diagnostics)
         {"budget_exhausted", diagnostics.budget_exhausted},
         {"selected_degradation_units", diagnostics.selected_degradation_units},
         {"selected_maximal_fallback", diagnostics.selected_maximal_fallback},
+        {"initial_predicted_total_ns", diagnostics.initial_predicted_total_ns},
+        {"first_improvement_ns", diagnostics.first_improvement_ns
+                                     ? Json(*diagnostics.first_improvement_ns)
+                                     : Json(nullptr)},
+        {"incumbent_improvements", diagnostics.incumbent_improvements},
+        {"search_work", diagnostics.search_work},
+        {"search_granted_ns", diagnostics.search_granted_ns},
+        {"search_renewals", diagnostics.search_renewals},
+        {"search_discovery_used", diagnostics.search_discovery_used},
+        {"search_overshoot_ns", diagnostics.search_overshoot_ns},
+        {"search_stop_phase",
+         ninfer::materialization_search_phase_name(diagnostics.search_stop_phase)},
+        {"search_boundary_limited", diagnostics.search_boundary_limited},
     };
 }
 

--- a/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
+++ b/src/targets/qwen3_6/export/ninfer/targets/qwen3_6/runtime.h
@@ -420,6 +420,33 @@ private:
     friend class PressurePlanningSession;
 };
 
+class PressureConstructionCursor {
+public:
+    PressureConstructionCursor(PressureConstructionCursor&& other) noexcept
+        : session_(std::exchange(other.session_, nullptr)), slot_(other.slot_),
+          generation_(other.generation_), release_(other.release_) {}
+
+    PressureConstructionCursor& operator=(PressureConstructionCursor&&)      = delete;
+    PressureConstructionCursor(const PressureConstructionCursor&)            = delete;
+    PressureConstructionCursor& operator=(const PressureConstructionCursor&) = delete;
+
+    ~PressureConstructionCursor() {
+        if (session_) { release_(session_, slot_, generation_); }
+    }
+
+private:
+    PressureConstructionCursor(const void* session, std::uint32_t slot, std::uint32_t generation,
+                               void (*release)(const void*, std::uint32_t, std::uint32_t) noexcept)
+        : session_(session), slot_(slot), generation_(generation), release_(release) {}
+
+    const void* session_;
+    std::uint32_t slot_;
+    std::uint32_t generation_;
+    void (*release_)(const void*, std::uint32_t, std::uint32_t) noexcept;
+    template <class Variant>
+    friend struct detail::PressurePlanningSessionImpl;
+};
+
 template <class Variant>
 class AssessedPressureTarget {
 public:
@@ -533,6 +560,7 @@ private:
 struct PressureExpansionView {
     std::span<const PressureTargetHandle> children;
     std::uint32_t new_canonical_count = 0;
+    bool complete                     = true;
 };
 
 template <class Variant>
@@ -549,12 +577,20 @@ public:
     identity_target(runtime::PlanningCandidateId candidate) const;
     [[nodiscard]] PressureTargetHandle
     root_maximal_target(runtime::PlanningCandidateId root_candidate);
+    [[nodiscard]] PressureTargetHandle maximal_target(runtime::PlanningCandidateId candidate);
+    [[nodiscard]] PressureConstructionCursor begin_construction(PressureTargetHandle target,
+                                                                bool restore = false);
+    [[nodiscard]] runtime::PressureConstructionStep
+    next_construction_option(PressureConstructionCursor& cursor);
+    void choose_construction(PressureConstructionCursor& cursor,
+                             runtime::PressureConstructionOptionId option);
     [[nodiscard]] std::optional<PressureTargetHandle>
-    guided_closure_target(runtime::PlanningCandidateId candidate,
-                          std::span<const runtime::PlanningOwnerId> preferred_owner_ids);
+    construction_target(const PressureConstructionCursor& cursor);
     [[nodiscard]] runtime::PressureTargetGuidance guidance(PressureTargetHandle target);
     [[nodiscard]] AssessedPressureTarget<Variant> assess(PressureTargetHandle target);
-    [[nodiscard]] PreparedPressureExpansion<Variant> prepare_expansion(PressureTargetHandle parent);
+    [[nodiscard]] PreparedPressureExpansion<Variant>
+    prepare_expansion(PressureTargetHandle parent,
+                      std::uint32_t maximum_owners = std::numeric_limits<std::uint32_t>::max());
     [[nodiscard]] PressureExpansionView
     commit_expansion(PreparedPressureExpansion<Variant>&& prepared);
     void discard_expansion(PreparedPressureExpansion<Variant>&& prepared) noexcept;

--- a/src/targets/qwen3_6/impl/runtime/api_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/api_impl.h
@@ -166,11 +166,33 @@ PressurePlanningSession<Variant>::root_maximal_target(runtime::PlanningCandidate
 }
 
 template <>
-std::optional<PressureTargetHandle> PressurePlanningSession<Variant>::guided_closure_target(
-    runtime::PlanningCandidateId candidate,
-    std::span<const runtime::PlanningOwnerId> preferred_owner_ids) {
-    if (impl_ == nullptr) { throw std::logic_error("pressure planning session is empty"); }
-    return impl_->guided_closure_target(candidate, preferred_owner_ids);
+PressureTargetHandle
+PressurePlanningSession<Variant>::maximal_target(runtime::PlanningCandidateId candidate) {
+    return impl_->maximal_target(candidate);
+}
+
+template <>
+PressureConstructionCursor
+PressurePlanningSession<Variant>::begin_construction(PressureTargetHandle target, bool restore) {
+    return impl_->begin_construction(target, restore);
+}
+
+template <>
+runtime::PressureConstructionStep
+PressurePlanningSession<Variant>::next_construction_option(PressureConstructionCursor& cursor) {
+    return impl_->next_construction_option(cursor);
+}
+
+template <>
+void PressurePlanningSession<Variant>::choose_construction(
+    PressureConstructionCursor& cursor, runtime::PressureConstructionOptionId option) {
+    impl_->choose_construction(cursor, option);
+}
+
+template <>
+std::optional<PressureTargetHandle>
+PressurePlanningSession<Variant>::construction_target(const PressureConstructionCursor& cursor) {
+    return impl_->construction_target(cursor);
 }
 
 template <>
@@ -189,9 +211,10 @@ PressurePlanningSession<Variant>::assess(PressureTargetHandle target) {
 
 template <>
 PreparedPressureExpansion<Variant>
-PressurePlanningSession<Variant>::prepare_expansion(PressureTargetHandle parent) {
+PressurePlanningSession<Variant>::prepare_expansion(PressureTargetHandle parent,
+                                                    std::uint32_t maximum_owners) {
     if (impl_ == nullptr) { throw std::logic_error("pressure planning session is empty"); }
-    return impl_->prepare_expansion(parent);
+    return impl_->prepare_expansion(parent, maximum_owners);
 }
 
 template <>

--- a/src/targets/qwen3_6/impl/runtime/pressure_planner.h
+++ b/src/targets/qwen3_6/impl/runtime/pressure_planner.h
@@ -241,6 +241,11 @@ inline PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::PressurePlanningSessi
     target_hash_table.assign(hash_capacity, std::numeric_limits<std::uint32_t>::max());
     expansion_scratch.reserve(maximum_scratch_targets);
     committed_children.reserve(maximum_scratch_targets);
+    for (auto& cursor : construction_slots) {
+        cursor.choices.reserve(owners.size());
+        cursor.options.reserve(maximum_scratch_targets + owners.size());
+    }
+    guidance_recovery.reserve(owners.size());
     selected_private_owners.reserve(private_owners.size());
     selected_private_owner_ids.reserve(private_owners.size());
     selected_private_decisions.reserve(private_owners.size());
@@ -256,6 +261,8 @@ inline PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::PressurePlanningSessi
     projected_owner_decisions.assign(owners.size(), nullptr);
     assessment_outcomes.reserve(owners.size());
     guidance_outcomes.reserve(owners.size());
+    guidance_checkpoint_changes.reserve(
+        owners.size() * (2U + owner.context_cache.max_long_anchors_per_continuation.value_or(0)));
     const std::size_t private_checkpoint_capacity =
         2U + owner.context_cache.max_long_anchors_per_continuation.value_or(0);
     if (private_checkpoint_capacity > std::numeric_limits<std::size_t>::max() - 3U ||
@@ -609,195 +616,189 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::root_maximal_target(
     return handle;
 }
 
-inline std::optional<qwen3_6::PressureTargetHandle>
-PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guided_closure_target(
-    runtime::PlanningCandidateId admission,
-    std::span<const runtime::PlanningOwnerId> preferred_owner_ids) {
-    if (scratch_live) {
-        throw std::logic_error("guided pressure closure conflicts with expansion scratch");
+inline qwen3_6::PressureTargetHandle
+PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::maximal_target(
+    runtime::PlanningCandidateId id) {
+    if (scratch_live) { throw std::logic_error("pressure expansion scratch is live"); }
+    const auto selected = candidate_index(id);
+    populate_options(selected);
+    choice_scratch.clear();
+    for (const auto& victim : candidate_options[selected].victims) {
+        choice_scratch.push_back(victim.eviction_choice);
     }
-    const std::uint32_t selected_candidate = candidate_index(admission);
-    populate_options(selected_candidate);
-    CandidateOptions& options       = candidate_options[selected_candidate];
-    const CandidateState& candidate = *candidates[selected_candidate].state;
-    const std::optional<typename Core::MaterializationSourceProtection> protection =
-        program->materialization_source_protection(candidate);
-    if (!protection) { return std::nullopt; }
+    const auto index = intern_target(selected, choice_scratch);
+    qwen3_6::PressureTargetHandle result;
+    result.session_    = this;
+    result.generation_ = generation;
+    result.index_      = index;
+    return result;
+}
 
-    std::vector<std::size_t> victim_order;
-    victim_order.reserve(options.victims.size());
-    const auto append_victim = [&](std::size_t victim_index) {
-        if (std::find(victim_order.begin(), victim_order.end(), victim_index) ==
-            victim_order.end()) {
-            victim_order.push_back(victim_index);
-        }
-    };
-    for (const runtime::PlanningOwnerId id : preferred_owner_ids) {
-        const auto found =
-            std::find_if(options.victims.begin(), options.victims.end(), [&](const auto& victim) {
-                return victim.owner_index < owners.size() && owners[victim.owner_index].id == id;
-            });
-        if (found != options.victims.end()) {
-            append_victim(static_cast<std::size_t>(found - options.victims.begin()));
+inline auto PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::construction_slot(
+    const qwen3_6::PressureConstructionCursor& cursor) -> ConstructionSlot& {
+    if (cursor.session_ != this || cursor.slot_ >= construction_slots.size() || scratch_live ||
+        resource_revision != program->resource_revision()) {
+        throw std::logic_error("pressure construction cursor is stale");
+    }
+    auto& slot = construction_slots[cursor.slot_];
+    if (!slot.leased || slot.generation != cursor.generation_) {
+        throw std::logic_error("pressure construction lease is stale");
+    }
+    return slot;
+}
+
+inline void PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::release_construction(
+    const void* owner, std::uint32_t index, std::uint32_t lease) noexcept {
+    auto& session = *const_cast<PressurePlanningSessionImpl*>(
+        static_cast<const PressurePlanningSessionImpl*>(owner));
+    if (index < session.construction_slots.size()) {
+        auto& slot = session.construction_slots[index];
+        if (slot.generation == lease) {
+            slot.leased = false;
+            slot.options.clear();
         }
     }
-    for (std::size_t index = 0; index < options.victims.size(); ++index) { append_victim(index); }
+}
 
-    const auto projected_residual = [&](std::span<const std::uint16_t> target_choices,
-                                        std::optional<std::size_t> override_owner,
-                                        const PressureDecision* override_decision) {
-        detail::PhysicalDelta pressure;
-        for (std::size_t index = 0; index < options.victims.size(); ++index) {
-            const PressureDecision* decision = nullptr;
-            if (override_owner && *override_owner == index) {
-                decision = override_decision;
-            } else {
-                const std::uint16_t choice = target_choices[index];
-                if (choice != 0) {
-                    if (choice > options.victims[index].decisions.size()) {
-                        throw std::logic_error("guided pressure choice is invalid");
-                    }
-                    decision = &options.victims[index].decisions[choice - 1U];
-                }
-            }
-            if (decision == nullptr) { continue; }
-            pressure.added = NINFER_QWEN36_RUNTIME_NS::planning_resource_sum(
-                pressure.added, decision->effect.added);
-            pressure.removed = NINFER_QWEN36_RUNTIME_NS::planning_resource_sum(
-                pressure.removed, decision->effect.removed);
+inline detail::PhysicalResources
+PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::construction_residual(
+    std::uint32_t index, std::span<const std::uint16_t> choices) const {
+    detail::PhysicalDelta pressure;
+    const auto& options = candidate_options[index];
+    for (std::size_t owner = 0; owner < choices.size(); ++owner) {
+        if (choices[owner] == 0) { continue; }
+        const auto& decision = options.victims[owner].decisions[choices[owner] - 1];
+        pressure.added =
+            NINFER_QWEN36_RUNTIME_NS::planning_resource_sum(pressure.added, decision.effect.added);
+        pressure.removed = NINFER_QWEN36_RUNTIME_NS::planning_resource_sum(pressure.removed,
+                                                                           decision.effect.removed);
+    }
+    auto result = program->guided_materialization_deficit(*candidates[index].state, pressure);
+    result.host.kv_bytes =
+        std::max(result.host.kv_bytes, candidates[index].state->blocked_host_allocation_bytes);
+    return result;
+}
+
+inline qwen3_6::PressureConstructionCursor
+PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::begin_construction(
+    qwen3_6::PressureTargetHandle target, bool restore) {
+    if (!valid(target) || scratch_live) { throw std::logic_error("invalid construction parent"); }
+    const auto& node = targets[target.index_];
+    populate_options(node.candidate_index);
+    for (std::uint32_t index = 0; index < construction_slots.size(); ++index) {
+        auto& slot = construction_slots[index];
+        if (slot.leased) { continue; }
+        const auto choices = victim_choices(node);
+        slot.choices.assign(choices.begin(), choices.end());
+        slot.options.clear();
+        slot.next_owner = slot.next_option = 0;
+        slot.candidate_index               = node.candidate_index;
+        slot.residual =
+            node.assessed_residual.value_or(construction_residual(node.candidate_index, choices));
+        slot.restore = restore;
+        slot.leased  = true;
+        if (++construction_generation == 0) { ++construction_generation; }
+        slot.generation      = construction_generation;
+        slot.scan_generation = 1;
+        return qwen3_6::PressureConstructionCursor(this, index, slot.generation,
+                                                   &release_construction);
+    }
+    throw std::length_error("all pressure construction cursors are leased");
+}
+
+inline runtime::PressureConstructionStep
+PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::next_construction_option(
+    qwen3_6::PressureConstructionCursor& cursor) {
+    auto& slot    = construction_slot(cursor);
+    auto& options = candidate_options[slot.candidate_index];
+    if (slot.next_option < slot.options.size()) {
+        const auto index   = static_cast<std::uint32_t>(slot.next_option++);
+        const auto& option = slot.options[index];
+        return {.guidance = guidance_choices(slot.candidate_index, slot.choices, 0, option.victim,
+                                             option.identity ? nullptr : &option.decision),
+                .option   = {.cursor_generation = slot.generation,
+                             .scan_generation   = slot.scan_generation,
+                             .index             = index}};
+    }
+    if (slot.next_owner == options.victims.size()) { return {.exhausted = true}; }
+    const auto owner_index          = slot.next_owner++;
+    const auto& victim              = options.victims[owner_index];
+    const auto choice               = slot.choices[owner_index];
+    const PressureDecision* current = choice == 0 ? nullptr : &victim.decisions[choice - 1];
+    const auto protection =
+        program->materialization_source_protection(*candidates[slot.candidate_index].state);
+    if (!protection) { throw std::logic_error("construction source protection is stale"); }
+    const auto append = [&](PressureDecision decision, bool identity = false) {
+        if (slot.options.size() == slot.options.capacity()) {
+            throw std::length_error("construction option capacity exceeded");
         }
-        detail::PhysicalResources residual =
-            program->guided_materialization_deficit(candidate, pressure);
-        residual.host.kv_bytes =
-            std::max(residual.host.kv_bytes, candidate.blocked_host_allocation_bytes);
-        return residual;
+        slot.options.push_back(
+            {.victim = owner_index, .decision = std::move(decision), .identity = identity});
     };
-    const detail::PhysicalResources capacity = program->admission_capacity();
-    constexpr std::uint64_t kResidualOne     = 1ULL << 20U;
-    const auto normalized                    = [](std::uint64_t value, std::uint64_t limit) {
-        if (value == 0) { return std::uint64_t{0}; }
-        if (limit == 0 || value >= limit) { return kResidualOne; }
-        if (value > std::numeric_limits<std::uint64_t>::max() / kResidualOne) {
-            return kResidualOne;
-        }
-        const std::uint64_t scaled = value * kResidualOne;
-        return std::max<std::uint64_t>(1, scaled / limit + (scaled % limit != 0 ? 1U : 0U));
-    };
-    const auto residual_key = [&](const detail::PhysicalResources& residual) {
-        std::uint32_t constraints = 0;
-        std::uint64_t total       = 0;
-        const auto append         = [&](std::uint64_t value, std::uint64_t limit) {
-            if (value == 0) { return; }
-            ++constraints;
-            NINFER_QWEN36_RUNTIME_NS::planning_saturating_add(total, normalized(value, limit));
-        };
-        append(residual.device.active_lanes, capacity.device.active_lanes);
-        append(residual.device.state_slots, capacity.device.state_slots);
-        append(residual.device.main_kv_pages, capacity.device.main_kv_pages);
-        append(residual.device.backend_kv_pages, capacity.device.backend_kv_pages);
-        append(residual.host.state_slots, capacity.host.state_slots);
-        append(residual.host.kv_bytes, capacity.host.kv_bytes);
-        return std::tuple{constraints, total};
-    };
-    const auto transfer_bytes = [](const PressureDecision& decision) {
-        std::uint64_t bytes = 0;
-        for (const runtime::ContextTransferRequirement& requirement :
-             decision.transfer_requirements) {
-            NINFER_QWEN36_RUNTIME_NS::planning_saturating_add(bytes,
-                                                              requirement.work.payload_bytes);
-        }
-        return bytes;
-    };
-
-    choice_scratch.assign(options.victims.size(), 0);
-
-    struct Selection {
-        std::size_t victim_index = 0;
-        PressureDecision decision;
-        detail::PhysicalResources residual;
-    };
-
-    const std::size_t maximum_steps = 16U * std::max<std::size_t>(1, options.victims.size()) + 16U;
-    for (std::size_t step = 0; step < maximum_steps; ++step) {
-        const detail::PhysicalResources residual =
-            projected_residual(choice_scratch, std::nullopt, nullptr);
-        if (residual == detail::PhysicalResources{}) {
-            TargetNode* existing = find_target(selected_candidate, choice_scratch);
-            const std::size_t maximum =
-                candidates.size() + 1U + planning_detail::kOptionalTargetCapacity;
-            if (existing == nullptr && targets.size() >= maximum) { return std::nullopt; }
-            const std::uint32_t target_index =
-                existing != nullptr ? static_cast<std::uint32_t>(existing - targets.data())
-                                    : intern_target(selected_candidate, choice_scratch);
-            qwen3_6::PressureTargetHandle handle;
-            handle.session_    = this;
-            handle.generation_ = generation;
-            handle.index_      = target_index;
-            return handle;
-        }
-
-        std::optional<Selection> selected;
-        for (int destructive = 0; destructive < 2 && !selected; ++destructive) {
-            for (const std::size_t victim_index : victim_order) {
-                const std::uint16_t current_choice = choice_scratch[victim_index];
-                const PressureDecision* current =
-                    current_choice == 0
-                        ? nullptr
-                        : &options.victims[victim_index].decisions[current_choice - 1U];
-                if (current != nullptr && current->evicts_continuation) { continue; }
-                std::vector<PressureDecision> successors = pressure_successors(
-                    options.victims[victim_index], residual, *protection, current);
-                std::optional<Selection> owner_best;
-                for (PressureDecision& successor : successors) {
-                    const std::uint32_t prior_drops =
-                        current == nullptr ? 0 : current->checkpoint_drops;
-                    const bool adds_destruction =
-                        successor.evicts_continuation || successor.checkpoint_drops > prior_drops;
-                    if (adds_destruction != (destructive != 0)) { continue; }
-                    const detail::PhysicalResources child_residual =
-                        projected_residual(choice_scratch, victim_index, &successor);
-                    if (child_residual == residual) { continue; }
-                    Selection candidate{
-                        .victim_index = victim_index,
-                        .decision     = std::move(successor),
-                        .residual     = child_residual,
-                    };
-                    const auto key = [&](const Selection& value) {
-                        return std::tuple{
-                            residual_key(value.residual),
-                            NINFER_QWEN36_RUNTIME_NS::degradation_units(value.decision),
-                            transfer_bytes(value.decision),
-                            value.decision.id,
-                        };
-                    };
-                    if (!owner_best || key(candidate) < key(*owner_best)) {
-                        owner_best = std::move(candidate);
-                    }
-                }
-                if (owner_best) {
-                    selected = std::move(owner_best);
-                    break;
+    if (slot.restore) {
+        if (current != nullptr) {
+            append({}, true);
+            // Rebuild ordinary alternatives from the immutable candidate requirement, not from a
+            // rewritten post-state. Complete assessment validates every less-destructive neighbor.
+            for (auto& decision : pressure_successors(
+                     victim, candidates[slot.candidate_index].state->identity_pressure_deficit,
+                     *protection, nullptr)) {
+                if (decision != *current && !decision.evicts_continuation) {
+                    append(std::move(decision));
                 }
             }
         }
-        if (!selected) { return std::nullopt; }
+    } else if (current == nullptr || !current->evicts_continuation) {
+        for (auto& decision : pressure_successors(victim, slot.residual, *protection, current)) {
+            if (current == nullptr || decision != *current) { append(std::move(decision)); }
+        }
+    }
+    return {}; // one owner's successor generation is a separately metered operation
+}
 
-        std::vector<PressureDecision>& decisions =
-            options.victims[selected->victim_index].decisions;
-        const auto existing  = std::find(decisions.begin(), decisions.end(), selected->decision);
-        std::uint16_t choice = 0;
-        if (existing != decisions.end()) {
-            choice = static_cast<std::uint16_t>(1U + (existing - decisions.begin()));
+inline void PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::choose_construction(
+    qwen3_6::PressureConstructionCursor& cursor, runtime::PressureConstructionOptionId id) {
+    auto& slot = construction_slot(cursor);
+    if (id.cursor_generation != slot.generation || id.scan_generation != slot.scan_generation ||
+        id.index >= slot.options.size()) {
+        throw std::logic_error("stale construction option");
+    }
+    auto& option         = slot.options[id.index];
+    auto& decisions      = candidate_options[slot.candidate_index].victims[option.victim].decisions;
+    std::uint16_t choice = 0;
+    if (!option.identity) {
+        const auto found = std::find(decisions.begin(), decisions.end(), option.decision);
+        if (found != decisions.end()) {
+            choice = static_cast<std::uint16_t>(1 + found - decisions.begin());
         } else {
-            if (decisions.size() >= std::numeric_limits<std::uint16_t>::max()) {
-                return std::nullopt;
+            if (decisions.size() == std::numeric_limits<std::uint16_t>::max()) {
+                throw std::length_error("construction owner decision capacity exceeded");
             }
-            decisions.push_back(std::move(selected->decision));
+            decisions.push_back(std::move(option.decision));
             choice = static_cast<std::uint16_t>(decisions.size());
         }
-        choice_scratch[selected->victim_index] = choice;
     }
-    return std::nullopt;
+    slot.choices[option.victim] = choice;
+    slot.residual               = construction_residual(slot.candidate_index, slot.choices);
+    slot.next_owner = slot.next_option = 0;
+    slot.options.clear();
+    if (++slot.scan_generation == 0) { ++slot.scan_generation; }
+}
+
+inline std::optional<qwen3_6::PressureTargetHandle>
+PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::construction_target(
+    const qwen3_6::PressureConstructionCursor& cursor) {
+    auto& slot = construction_slot(cursor);
+    if (!find_target(slot.candidate_index, slot.choices) &&
+        targets.size() >= candidates.size() + 1U + planning_detail::kOptionalTargetCapacity) {
+        return std::nullopt;
+    }
+    const auto index = intern_target(slot.candidate_index, slot.choices);
+    qwen3_6::PressureTargetHandle result;
+    result.session_    = this;
+    result.generation_ = generation;
+    result.index_      = index;
+    return result;
 }
 
 inline runtime::PressureTargetGuidance
@@ -806,15 +807,30 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guidance(qwen3_6::PressureTa
         throw std::logic_error("pressure target guidance is stale or conflicts with expansion");
     }
     TargetNode& node = targets[target.index_];
-    populate_options(node.candidate_index);
-    const CandidateState& candidate              = *candidates[node.candidate_index].state;
-    const CandidateOptions& options              = candidate_options[node.candidate_index];
-    const std::span<const std::uint16_t> choices = victim_choices(node);
+    auto result = guidance_choices(node.candidate_index, victim_choices(node), node.stable_ordinal);
+    if (node.assessed_residual &&
+        *node.assessed_residual !=
+            construction_residual(node.candidate_index, victim_choices(node))) {
+        result.physical.requires_exact_feedback = true;
+    }
+    return result;
+}
+
+inline runtime::PressureTargetGuidance
+PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guidance_choices(
+    std::uint32_t candidate_index, std::span<const std::uint16_t> choices, std::uint32_t ordinal,
+    std::optional<std::size_t> override_owner, const PressureDecision* override_decision) {
+    populate_options(candidate_index);
+    const CandidateState& candidate = *candidates[candidate_index].state;
+    const CandidateOptions& options = candidate_options[candidate_index];
     if (choices.size() != options.victims.size()) {
         throw std::logic_error("pressure target victim domain changed");
     }
 
     guidance_outcomes.clear();
+    guidance_checkpoint_changes.clear();
+    guidance_recovery.clear();
+    bool recovery_complete = true;
     NINFER_QWEN36_RUNTIME_NS::PlanningTransferAccumulator estimated_pressure;
     detail::PhysicalDelta approximate_pressure;
     std::uint32_t total_degradation = 0;
@@ -826,10 +842,32 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guidance(qwen3_6::PressureTa
             choice > victim_options.decisions.size()) {
             throw std::logic_error("pressure target guidance owner choice is invalid");
         }
-        if (choice == 0) { continue; }
+        const PressureDecision* selected =
+            override_owner && *override_owner == index
+                ? override_decision
+                : (choice == 0 ? nullptr : &victim_options.decisions[choice - 1U]);
+        if (selected == nullptr) { continue; }
         const Owner& victim_owner        = owners[victim_options.owner_index];
-        const PressureDecision& decision = victim_options.decisions[choice - 1U];
-        approximate_pressure.added       = NINFER_QWEN36_RUNTIME_NS::planning_resource_sum(
+        const PressureDecision& decision = *selected;
+        for (const auto checkpoint : decision.dropped_checkpoints) {
+            guidance_checkpoint_changes.push_back(
+                {.owner = victim_owner.id, .checkpoint = checkpoint, .survives = false});
+        }
+        NINFER_QWEN36_RUNTIME_NS::PlanningTransferAccumulator recovery;
+        for (auto transfer : decision.transfer_requirements) {
+            if (transfer.direction == runtime::ContextTransferDirection::DeviceToHost) {
+                transfer.direction = runtime::ContextTransferDirection::HostToDevice;
+                recovery.append(std::span<const runtime::ContextTransferRequirement>(&transfer, 1));
+            }
+        }
+        guidance_recovery.push_back(
+            {.owner = victim_owner.id, .additional_restore = recovery.work});
+        if (!decision.evicts_continuation && decision.transfer_requirements.empty() &&
+            (!decision.state_changes.empty() || !decision.main_kv_changes.empty() ||
+             !decision.backend_kv_changes.empty())) {
+            recovery_complete = false;
+        }
+        approximate_pressure.added = NINFER_QWEN36_RUNTIME_NS::planning_resource_sum(
             approximate_pressure.added, decision.effect.added);
         approximate_pressure.removed = NINFER_QWEN36_RUNTIME_NS::planning_resource_sum(
             approximate_pressure.removed, decision.effect.removed);
@@ -941,14 +979,19 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::guidance(qwen3_6::PressureTa
                 .unsatisfied_constraints   = constraints,
                 .estimated_remaining_steps = remaining_steps,
                 .normalized_residual_q20   = residual_q20,
+                .requires_exact_feedback   = candidate.blocked_host_allocation_bytes != 0,
             },
         .estimated_machine_work =
             NINFER_QWEN36_RUNTIME_NS::materialization_machine_work(candidate, estimated_pressure),
-        .owner_outcomes        = guidance_outcomes,
-        .candidate             = candidate_ids[node.candidate_index],
-        .stable_target_ordinal = node.stable_ordinal,
-        .degradation_units     = total_degradation,
-        .dropped_checkpoints   = total_dropped,
+        .owner_outcomes             = guidance_outcomes,
+        .candidate                  = candidate_ids[candidate_index],
+        .stable_target_ordinal      = ordinal,
+        .degradation_units          = total_degradation,
+        .dropped_checkpoints        = total_dropped,
+        .source_mode                = candidate.source_mode,
+        .checkpoint_changes         = guidance_checkpoint_changes,
+        .recovery_estimates         = guidance_recovery,
+        .recovery_estimate_complete = recovery_complete,
     };
 }
 
@@ -1202,8 +1245,8 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::assess(qwen3_6::PressureTarg
 
 inline qwen3_6::PreparedPressureExpansion<NINFER_QWEN36_VARIANT>
 PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::prepare_expansion(
-    qwen3_6::PressureTargetHandle parent) {
-    if (!valid(parent) || scratch_live) {
+    qwen3_6::PressureTargetHandle parent, std::uint32_t maximum_owners) {
+    if (!valid(parent) || scratch_live || maximum_owners == 0) {
         throw std::logic_error("pressure expansion parent is stale or scratch is busy");
     }
     const TargetNode& node = targets[parent.index_];
@@ -1298,8 +1341,12 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::prepare_expansion(
         return choice;
     };
 
+    prepared_owner_end = static_cast<std::uint32_t>(std::min<std::size_t>(
+        options.victims.size(),
+        static_cast<std::size_t>(node.next_expansion_owner) + maximum_owners));
     try {
-        for (std::size_t victim_index = 0; victim_index < options.victims.size(); ++victim_index) {
+        for (std::size_t victim_index = node.next_expansion_owner;
+             victim_index < prepared_owner_end; ++victim_index) {
             CandidateVictimOptions& victim_options   = options.victims[victim_index];
             const std::uint16_t current_choice       = parent_choices[victim_index];
             std::vector<PressureDecision>& decisions = victim_options.decisions;
@@ -1398,9 +1445,13 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::commit_expansion(
     }
     target_choice_arena.resize(choice_write);
     const std::uint32_t new_count = prepared_new_count;
-    prepared.session_             = nullptr;
-    prepared.session_generation_  = 0;
-    prepared.scratch_generation_  = 0;
+    auto& parent                  = targets[prepared.parent_index_];
+    parent.next_expansion_owner   = prepared_owner_end;
+    const bool complete =
+        prepared_owner_end == candidate_options[parent.candidate_index].victims.size();
+    prepared.session_            = nullptr;
+    prepared.session_generation_ = 0;
+    prepared.scratch_generation_ = 0;
     expansion_scratch.clear();
     prepared_owner_decisions.clear();
     prepared_new_count  = 0;
@@ -1409,6 +1460,7 @@ PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT>::commit_expansion(
     return qwen3_6::PressureExpansionView{
         .children            = committed_children,
         .new_canonical_count = new_count,
+        .complete            = complete,
     };
 }
 

--- a/src/targets/qwen3_6/impl/runtime/program.h
+++ b/src/targets/qwen3_6/impl/runtime/program.h
@@ -1230,7 +1230,7 @@ private:
     void bind_sequence_kv(SequenceState& sequence);
     void unbind_sequence_kv(SequenceState& sequence) noexcept;
     void ensure_sequence_kv_mapped(SequenceState& sequence, std::uint32_t main_tokens,
-                                 std::uint32_t backend_tokens = 0);
+                                   std::uint32_t backend_tokens = 0);
     void trim_sequence_kv(SequenceState& sequence, std::uint32_t main_tokens,
                           std::uint32_t backend_tokens = 0);
     void release_sequence_growth_entitlement(SequenceState& sequence) noexcept;
@@ -1280,8 +1280,9 @@ struct PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT> {
         std::uint32_t victim_choice_offset = 0;
         std::uint32_t victim_choice_count  = 0;
         std::optional<detail::PhysicalResources> assessed_residual;
-        std::uint32_t stable_ordinal = 0;
-        bool root_maximal            = false;
+        std::uint32_t next_expansion_owner = 0;
+        std::uint32_t stable_ordinal       = 0;
+        bool root_maximal                  = false;
     };
 
     struct CandidateVictimOptions {
@@ -1310,6 +1311,25 @@ struct PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT> {
         bool leased              = false;
     };
 
+    struct ConstructionOption {
+        std::size_t victim = 0;
+        PressureDecision decision;
+        bool identity = false;
+    };
+
+    struct ConstructionSlot {
+        std::vector<std::uint16_t> choices;
+        std::vector<ConstructionOption> options;
+        std::size_t next_owner        = 0;
+        std::size_t next_option       = 0;
+        std::uint32_t candidate_index = 0;
+        std::uint32_t generation      = 0;
+        std::uint32_t scan_generation = 1;
+        detail::PhysicalResources residual;
+        bool restore = false;
+        bool leased  = false;
+    };
+
     PressurePlanningSessionImpl(
         Core& owner, std::span<const PhysicalCandidateBinding> physical_candidates,
         std::span<const runtime::PlanningCandidateId> admission_candidate_ids,
@@ -1323,14 +1343,33 @@ struct PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT> {
     identity_target(runtime::PlanningCandidateId candidate) const;
     [[nodiscard]] qwen3_6::PressureTargetHandle
     root_maximal_target(runtime::PlanningCandidateId root_candidate);
+    [[nodiscard]] qwen3_6::PressureTargetHandle
+    maximal_target(runtime::PlanningCandidateId candidate);
+    [[nodiscard]] qwen3_6::PressureConstructionCursor
+    begin_construction(qwen3_6::PressureTargetHandle target, bool restore = false);
+    [[nodiscard]] runtime::PressureConstructionStep
+    next_construction_option(qwen3_6::PressureConstructionCursor& cursor);
+    void choose_construction(qwen3_6::PressureConstructionCursor& cursor,
+                             runtime::PressureConstructionOptionId option);
     [[nodiscard]] std::optional<qwen3_6::PressureTargetHandle>
-    guided_closure_target(runtime::PlanningCandidateId candidate,
-                          std::span<const runtime::PlanningOwnerId> preferred_owner_ids);
+    construction_target(const qwen3_6::PressureConstructionCursor& cursor);
+    [[nodiscard]] ConstructionSlot&
+    construction_slot(const qwen3_6::PressureConstructionCursor& cursor);
+    static void release_construction(const void*, std::uint32_t, std::uint32_t) noexcept;
+    [[nodiscard]] runtime::PressureTargetGuidance
+    guidance_choices(std::uint32_t candidate_index, std::span<const std::uint16_t> choices,
+                     std::uint32_t ordinal,
+                     std::optional<std::size_t> override_owner = std::nullopt,
+                     const PressureDecision* override_decision = nullptr);
+    [[nodiscard]] detail::PhysicalResources
+    construction_residual(std::uint32_t candidate_index,
+                          std::span<const std::uint16_t> choices) const;
     [[nodiscard]] runtime::PressureTargetGuidance guidance(qwen3_6::PressureTargetHandle target);
     [[nodiscard]] qwen3_6::AssessedPressureTarget<NINFER_QWEN36_VARIANT>
     assess(qwen3_6::PressureTargetHandle target);
     [[nodiscard]] qwen3_6::PreparedPressureExpansion<NINFER_QWEN36_VARIANT>
-    prepare_expansion(qwen3_6::PressureTargetHandle parent);
+    prepare_expansion(qwen3_6::PressureTargetHandle parent,
+                      std::uint32_t maximum_owners = std::numeric_limits<std::uint32_t>::max());
     [[nodiscard]] qwen3_6::PressureExpansionView
     commit_expansion(qwen3_6::PreparedPressureExpansion<NINFER_QWEN36_VARIANT>&& prepared);
     void discard_expansion(
@@ -1401,8 +1440,13 @@ struct PressurePlanningSessionImpl<NINFER_QWEN36_VARIANT> {
     std::vector<runtime::CheckpointRecoveryAlternativeWork> assessment_recovery_alternatives;
     typename Core::PressureRecoveryScratch recovery_scratch;
     std::vector<runtime::PressureOwnerOutcome> guidance_outcomes;
+    std::vector<runtime::PressureCheckpointOutcome> guidance_checkpoint_changes;
+    std::vector<runtime::PressureOwnerRecoveryGuidance> guidance_recovery;
+    std::array<ConstructionSlot, 4> construction_slots;
+    std::uint32_t construction_generation = 0;
     std::array<AssessmentSlot, 2> assessment_slots;
     std::uint32_t prepared_new_count = 0;
+    std::uint32_t prepared_owner_end = 0;
     std::size_t scratch_choice_mark  = 0;
     bool scratch_live                = false;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ ninfer_add_test(ninfer_arena_test        SOURCES test_arena.cpp)
 ninfer_add_test(ninfer_admission_policy_test SOURCES test_admission_policy.cpp)
 ninfer_add_test(ninfer_context_cost_test SOURCES test_context_cost.cpp)
 ninfer_add_test(ninfer_resource_manager_test SOURCES test_resource_manager.cpp)
+ninfer_add_test(ninfer_materialization_budget_test SOURCES test_materialization_budget.cpp)
 ninfer_add_test(ninfer_kv_capacity_test SOURCES test_kv_capacity.cpp)
 ninfer_add_test(ninfer_sampling_defaults_test
   SOURCES test_sampling_defaults.cpp

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,7 @@ benchmark-report, and external protocol behavior. Repository verification princi
   `test_tool_call_parser.cpp` — current protocol translation, Responses Item/state/SSE behavior,
   schema-guided tool-argument normalization, structural fallback, and chunk-invariant incremental
   tool-call behavior;
+- `test_materialization_budget.cpp` — deterministic planning-budget and shared admission-boundary behavior;
 - `test_request_log.cpp` — the consumed request JSONL schema and exact measurement fields, plus
   representative Serve request/throughput pretty records, failure severity, zero-field elision,
   and exclusion of arbitrary client error text;

--- a/tests/test_materialization_budget.cpp
+++ b/tests/test_materialization_budget.cpp
@@ -1,0 +1,80 @@
+#include "runtime/engine/materialization_budget.h"
+
+#include <iostream>
+#include <stdexcept>
+
+using namespace ninfer::runtime;
+
+static void require(bool value, const char* message) {
+    if (!value) { throw std::runtime_error(message); }
+}
+
+int main() {
+    constexpr std::uint64_t ms = 1'000'000;
+    try {
+        auto idle = PlanningAllowance::boundary(0, 0);
+        MaterializationSearchBudget expensive(idle, 0, 80'000 * ms);
+        require(expensive.allow(4 * ms, 2 * ms, 3 * ms, 70'000 * ms, true, 1),
+                "valuable completion could not cross the initial window");
+        require(expensive.granted_ns() == 10 * ms && expensive.renewals() == 1,
+                "extension did not retain cumulative accounting");
+        require(!expensive.allow(9 * ms, 2 * ms, 2 * ms, ms, true, 2),
+                "improved incumbent retained the expensive root's budget");
+        require(expensive.stop_reason() ==
+                    ninfer::MaterializationStopReason::InsufficientExpectedGain,
+                "economic stopping was reported as wall exhaustion");
+
+        MaterializationSearchBudget discovery(idle, 0, 80'000 * ms);
+        require(discovery.allow(5 * ms, ms, 4 * ms, 70'000 * ms, false, 1),
+                "unknown candidate could not receive bounded discovery");
+        require(!discovery.allow(10 * ms, ms, ms, 70'000 * ms, false, 2),
+                "unknown candidate repeatedly renewed discovery");
+        require(discovery.allow(10 * ms, ms, ms, 70'000 * ms, true, 2),
+                "complete prediction could not continue after discovery");
+
+        auto busy = PlanningAllowance::boundary(2, 0);
+        MaterializationSearchBudget first(busy, busy.limit_ns - 4 * ms, 80'000 * ms);
+        require(first.granted_ns() == 4 * ms, "mandatory work did not consume boundary time");
+        MaterializationSearchBudget backfill(busy, busy.limit_ns - ms, 80'000 * ms);
+        require(backfill.granted_ns() == ms, "backfill reset the boundary allowance");
+        require(!backfill.allow(busy.limit_ns, 1, 1, 70'000 * ms, true, 1),
+                "search delayed runnable requests beyond their boundary");
+        require(backfill.overshoot(busy.limit_ns + ms) == ms,
+                "indivisible overrun was not measured");
+
+        // The concurrent 55K rotation spends ~3.5 ms preparing/validating identities. A useful
+        // complete target must still be assessable; discarding the whole cache makes all six
+        // subsequent continuations cold. The old 5 ms boundary left only 1.5 ms and failed here.
+        MaterializationSearchBudget restore_after_setup(busy, 3 * ms + ms / 2, 80'000 * ms);
+        require(restore_after_setup.allow(3 * ms + ms / 2, 2 * ms, 2 * ms, 70'000 * ms, true, 1),
+                "mandatory setup starved the first complete reuse assessment in a busy boundary");
+
+        MaterializationSearchBudget cheap(idle, 0, ms);
+        require(cheap.granted_ns() == ms / 20, "cheap request received a minimum 5 ms grant");
+        require(!cheap.allow(ms / 20, ms, ms, ms, false, 1),
+                "discovery ignored the economic cap for a cheap request");
+        MaterializationSearchBudget saturated(idle, 0, UINT64_MAX);
+        require(saturated.granted_ns() == 0 && !saturated.allow(0, ms, ms, UINT64_MAX, true, 1),
+                "saturated cost was used as evidence of unlimited gain");
+        MaterializationSearchBudget seeded(idle, 0, 80'000 * ms);
+        require(!seeded.allow(5 * ms, ms, ms, 70'000 * ms, false, 1, false),
+                "an already-seeded candidate renewed solely on an incomplete optimistic estimate");
+        require(seeded.allow(5 * ms, ms, ms, 70'000 * ms, true, 1, false),
+                "a complete profitable refinement was denied after seeding");
+        std::atomic<bool> cancelled{false};
+        auto controlled                = PlanningAllowance::boundary(0, 0);
+        controlled.cancellation        = &cancelled;
+        controlled.control_deadline_ns = 3 * ms;
+        require(controlled.remaining(2 * ms) == ms, "control deadline did not constrain planning");
+        cancelled.store(true);
+        require(controlled.remaining(0) == 0, "cancelled request kept optional planning headroom");
+        MaterializationSearchBudget stalled(idle, 0, 80'000 * ms);
+        require(stalled.allow(5 * ms, ms, ms, 70'000 * ms, true, 7), "first forecast grant failed");
+        require(!stalled.allow(10 * ms, ms, ms, 70'000 * ms, true, 7),
+                "stalled work renewed its allowance");
+        std::cout << "ok\n";
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+}

--- a/tests/test_request_log.cpp
+++ b/tests/test_request_log.cpp
@@ -407,6 +407,14 @@ int main() {
                           .budget_exhausted           = false,
                           .selected_degradation_units = 2,
                           .selected_maximal_fallback  = false,
+                          .initial_predicted_total_ns = 500000,
+                          .first_improvement_ns       = 2000,
+                          .incumbent_improvements     = 2,
+                          .search_work                = 42,
+                          .search_granted_ns          = 8000,
+                          .search_renewals            = 1,
+                          .search_discovery_used      = true,
+                          .search_overshoot_ns        = 0,
     };
     outcome.thinking = ninfer::ThinkingBudgetStats{.configured_budget     = 256,
                                                    .model_thinking_tokens = 256,
@@ -414,6 +422,12 @@ int main() {
                                                    .applied               = true};
 
     const Json done = Json::parse(format_request_done_json("serve-test", 3000, context, outcome));
+    failures += check(done.at("materialization").at("initial_predicted_total_ns") == 500000 &&
+                          done.at("materialization").at("first_improvement_ns") == 2000 &&
+                          done.at("materialization").at("search_granted_ns") == 8000 &&
+                          done.at("materialization").at("search_renewals") == 1 &&
+                          done.at("materialization").at("search_discovery_used") == true,
+                      "materialization search quality or cumulative budget diagnostics missing");
     failures +=
         check(done.at("result").at("finish_reason") == "output_limit", "finish reason missing");
     failures += check(done.at("result").at("prompt_tokens") == 401, "prompt tokens missing");

--- a/tests/test_resource_manager.cpp
+++ b/tests/test_resource_manager.cpp
@@ -355,6 +355,7 @@ struct FakePreparedPressureExpansion {
 struct FakePressureExpansionView {
     std::span<const FakePressureTargetHandle> children;
     std::uint32_t new_canonical_count = 0;
+    bool complete                     = true;
 };
 
 class FakeAssessedPressureTarget {
@@ -556,12 +557,18 @@ public:
     }
 
     [[nodiscard]] FakePressureTargetHandle root_maximal_target(PlanningCandidateId candidate);
-    [[nodiscard]] std::optional<FakePressureTargetHandle>
-    guided_closure_target(PlanningCandidateId candidate,
-                          std::span<const PlanningOwnerId> preferred_owner_ids);
+    struct Cursor;
+    [[nodiscard]] FakePressureTargetHandle maximal_target(PlanningCandidateId candidate);
+    [[nodiscard]] Cursor begin_construction(FakePressureTargetHandle target, bool restore = false);
+    [[nodiscard]] ninfer::runtime::PressureConstructionStep
+    next_construction_option(Cursor& cursor);
+    void choose_construction(Cursor& cursor, ninfer::runtime::PressureConstructionOptionId option);
+    [[nodiscard]] std::optional<FakePressureTargetHandle> construction_target(const Cursor& cursor);
     [[nodiscard]] ninfer::runtime::PressureTargetGuidance guidance(FakePressureTargetHandle target);
     [[nodiscard]] FakeAssessedPressureTarget assess(FakePressureTargetHandle target);
-    [[nodiscard]] FakePreparedPressureExpansion prepare_expansion(FakePressureTargetHandle parent);
+    [[nodiscard]] FakePreparedPressureExpansion
+    prepare_expansion(FakePressureTargetHandle parent,
+                      std::uint32_t maximum_owners = std::numeric_limits<std::uint32_t>::max());
     [[nodiscard]] FakePressureExpansionView
     commit_expansion(FakePreparedPressureExpansion&& prepared);
     void discard_expansion(FakePreparedPressureExpansion&& prepared) noexcept;
@@ -586,10 +593,22 @@ private:
     struct Target {
         std::uint32_t candidate_index = 0;
         std::vector<std::uint16_t> choices;
-        std::uint32_t stable_ordinal = 0;
-        bool root_maximal            = false;
+        std::uint32_t stable_ordinal       = 0;
+        bool root_maximal                  = false;
+        std::uint32_t next_expansion_owner = 0;
     };
 
+public:
+    struct Cursor {
+        Target target;
+        std::vector<Target> options;
+        std::size_t next_owner = 0, next_option = 0;
+        std::uint32_t generation = 0, scan = 1;
+        bool restore = false;
+    };
+private:
+    std::uint32_t construction_generation_ = 0;
+    [[nodiscard]] ninfer::runtime::PressureTargetGuidance guidance_for(const Target& target);
     [[nodiscard]] bool valid(FakePressureTargetHandle target) const noexcept;
     [[nodiscard]] std::uint32_t candidate_index(PlanningCandidateId candidate) const;
     void populate_options(std::uint32_t candidate_index);
@@ -602,6 +621,7 @@ private:
     std::uint32_t generation_         = 0;
     std::uint32_t scratch_generation_ = 0;
     bool scratch_live_                = false;
+    std::uint32_t prepared_parent_ = 0, prepared_owner_end_ = 0;
     std::vector<const FakeAdmissionCandidate*> candidates_;
     std::vector<PlanningCandidateId> candidate_ids_;
     std::vector<Owner> owners_;
@@ -1108,6 +1128,7 @@ public:
 
     void invalidate_resources() noexcept { advance_revision(); }
 
+    std::vector<std::pair<std::uint32_t, std::vector<FakeTargetDecision>>> owner_decisions;
     std::size_t required_pressure_actions       = 0;
     std::size_t eviction_pressure_action_units  = 1;
     std::uint32_t private_pressure_alternatives = 1;
@@ -1246,6 +1267,11 @@ FakePressurePlanningSession::decisions_for(std::uint32_t selected_candidate,
         return {};
     }
 
+    if (!owner.shared) {
+        for (const auto& [id, decisions] : program_->owner_decisions) {
+            if (id == owner.private_handle->id) { return decisions; }
+        }
+    }
     std::vector<FakeTargetDecision> decisions;
     if (!owner.shared) {
         for (std::uint32_t index = 0; index < program_->private_pressure_alternatives; ++index) {
@@ -1333,73 +1359,90 @@ FakePressurePlanningSession::root_maximal_target(PlanningCandidateId candidate) 
     };
 }
 
-std::optional<FakePressureTargetHandle> FakePressurePlanningSession::guided_closure_target(
-    PlanningCandidateId candidate, std::span<const PlanningOwnerId> preferred_owner_ids) {
-    require(!scratch_live_, "fake guided pressure closure conflicts with expansion scratch");
-    const std::uint32_t selected_candidate = candidate_index(candidate);
-    populate_options(selected_candidate);
-    Target target{
-        .candidate_index = selected_candidate,
-        .choices         = std::vector<std::uint16_t>(owners_.size(), 0),
-    };
-    std::vector<std::size_t> order;
-    order.reserve(owners_.size());
-    const auto append = [&](std::size_t index) {
-        if (std::find(order.begin(), order.end(), index) == order.end()) { order.push_back(index); }
-    };
-    for (const PlanningOwnerId id : preferred_owner_ids) {
-        const auto found = std::find_if(owners_.begin(), owners_.end(),
-                                        [&](const Owner& owner) { return owner.id == id; });
-        if (found != owners_.end()) { append(static_cast<std::size_t>(found - owners_.begin())); }
-    }
-    for (std::size_t index = 0; index < owners_.size(); ++index) { append(index); }
+FakePressureTargetHandle
+FakePressurePlanningSession::maximal_target(PlanningCandidateId candidate) {
+    const auto target                   = root_maximal_target(candidate);
+    targets_[target.index].root_maximal = false;
+    return target;
+}
 
-    const auto selected_decisions = [&] {
-        std::vector<FakeTargetDecision> decisions;
-        for (std::size_t index = 0; index < owners_.size(); ++index) {
-            const std::uint16_t choice = target.choices[index];
-            if (choice != 0) {
-                decisions.push_back(options_[selected_candidate][index][choice - 1U]);
-            }
-        }
-        return decisions;
-    };
-    for (int destructive = 0; destructive < 2; ++destructive) {
-        for (const std::size_t owner_index : order) {
-            const auto& alternatives = options_[selected_candidate][owner_index];
-            if (target.choices[owner_index] != 0 || alternatives.empty()) { continue; }
-            const auto found = std::find_if(
-                alternatives.begin(), alternatives.end(), [&](const FakeTargetDecision& decision) {
-                    return decision.evicts_continuation == (destructive != 0);
-                });
-            if (found == alternatives.end()) { continue; }
-            target.choices[owner_index] =
-                static_cast<std::uint16_t>(1U + (found - alternatives.begin()));
-            if (program_->target_feasible(selected_decisions())) {
-                auto existing =
-                    std::find_if(targets_.begin(), targets_.end(),
-                                 [&](const Target& prior) { return same_target(prior, target); });
-                std::uint32_t target_index = 0;
-                if (existing != targets_.end()) {
-                    target_index = static_cast<std::uint32_t>(existing - targets_.begin());
-                } else {
-                    target.stable_ordinal = static_cast<std::uint32_t>(targets_.size());
-                    targets_.push_back(std::move(target));
-                    target_index = static_cast<std::uint32_t>(targets_.size() - 1U);
-                    program_->pressure_target_count_peak =
-                        std::max(program_->pressure_target_count_peak, targets_.size());
-                }
-                return FakePressureTargetHandle{.generation = generation_, .index = target_index};
-            }
-        }
+FakePressurePlanningSession::Cursor
+FakePressurePlanningSession::begin_construction(FakePressureTargetHandle handle, bool restore) {
+    require(valid(handle) && !scratch_live_, "invalid fake construction parent");
+    Cursor cursor;
+    cursor.target     = targets_[handle.index];
+    cursor.restore    = restore;
+    cursor.generation = ++construction_generation_;
+    populate_options(cursor.target.candidate_index);
+    return cursor;
+}
+
+ninfer::runtime::PressureConstructionStep
+FakePressurePlanningSession::next_construction_option(Cursor& cursor) {
+    if (cursor.next_option < cursor.options.size()) {
+        auto index = static_cast<std::uint32_t>(cursor.next_option++);
+        return {.guidance = guidance_for(cursor.options[index]),
+                .option   = {.cursor_generation = cursor.generation,
+                             .scan_generation   = cursor.scan,
+                             .index             = index}};
     }
-    return std::nullopt;
+    if (cursor.next_owner == owners_.size()) { return {.exhausted = true}; }
+    const auto owner         = cursor.next_owner++;
+    const auto& alternatives = options_[cursor.target.candidate_index][owner];
+    const auto current       = cursor.target.choices[owner];
+    for (std::size_t choice = cursor.restore ? 0 : 1; choice <= alternatives.size(); ++choice) {
+        if (choice == current) { continue; }
+        if (!cursor.restore && current != 0 &&
+            (alternatives[current - 1].evicts_continuation ||
+             !alternatives[choice - 1].evicts_continuation)) {
+            continue;
+        }
+        Target child         = cursor.target;
+        child.choices[owner] = static_cast<std::uint16_t>(choice);
+        child.root_maximal   = false;
+        cursor.options.push_back(std::move(child));
+    }
+    return {};
+}
+
+void FakePressurePlanningSession::choose_construction(
+    Cursor& cursor, ninfer::runtime::PressureConstructionOptionId id) {
+    require(id.cursor_generation == cursor.generation && id.scan_generation == cursor.scan &&
+                id.index < cursor.options.size(),
+            "stale fake construction option");
+    cursor.target = cursor.options[id.index];
+    cursor.options.clear();
+    cursor.next_owner = cursor.next_option = 0;
+    ++cursor.scan;
+}
+
+std::optional<FakePressureTargetHandle>
+FakePressurePlanningSession::construction_target(const Cursor& cursor) {
+    auto found = std::find_if(targets_.begin(), targets_.end(), [&](const Target& other) {
+        return same_target(other, cursor.target);
+    });
+    if (found == targets_.end()) {
+        if (targets_.size() >= candidates_.size() + 1U + 4096U) { return std::nullopt; }
+        auto target           = cursor.target;
+        target.stable_ordinal = static_cast<std::uint32_t>(targets_.size());
+        targets_.push_back(std::move(target));
+        program_->pressure_target_count_peak =
+            std::max(program_->pressure_target_count_peak, targets_.size());
+        return FakePressureTargetHandle{.generation = generation_,
+                                        .index = static_cast<std::uint32_t>(targets_.size() - 1)};
+    }
+    return FakePressureTargetHandle{.generation = generation_,
+                                    .index = static_cast<std::uint32_t>(found - targets_.begin())};
 }
 
 ninfer::runtime::PressureTargetGuidance
 FakePressurePlanningSession::guidance(FakePressureTargetHandle handle) {
     require(valid(handle) && !scratch_live_, "fake pressure guidance is stale");
-    const Target& target = targets_[handle.index];
+    return guidance_for(targets_[handle.index]);
+}
+
+ninfer::runtime::PressureTargetGuidance
+FakePressurePlanningSession::guidance_for(const Target& target) {
     populate_options(target.candidate_index);
     const FakeAdmissionCandidate& candidate = *candidates_[target.candidate_index];
     guidance_outcomes_.clear();
@@ -1451,12 +1494,14 @@ FakePressurePlanningSession::guidance(FakePressureTargetHandle handle) {
                 .estimated_remaining_steps = static_cast<std::uint32_t>(remaining),
                 .normalized_residual_q20   = static_cast<std::uint64_t>(remaining) << 20U,
             },
-        .estimated_machine_work = machine,
-        .owner_outcomes         = guidance_outcomes_,
-        .candidate              = candidate_ids_[target.candidate_index],
-        .stable_target_ordinal  = target.stable_ordinal,
-        .degradation_units      = degradation_units,
-        .dropped_checkpoints    = dropped,
+        .estimated_machine_work     = machine,
+        .owner_outcomes             = guidance_outcomes_,
+        .candidate                  = candidate_ids_[target.candidate_index],
+        .stable_target_ordinal      = target.stable_ordinal,
+        .degradation_units          = degradation_units,
+        .dropped_checkpoints        = dropped,
+        .source_mode                = candidate.source_mode,
+        .recovery_estimate_complete = true,
     };
 }
 
@@ -1577,19 +1622,24 @@ FakeAssessedPressureTarget FakePressurePlanningSession::assess(FakePressureTarge
 }
 
 FakePreparedPressureExpansion
-FakePressurePlanningSession::prepare_expansion(FakePressureTargetHandle handle) {
+FakePressurePlanningSession::prepare_expansion(FakePressureTargetHandle handle,
+                                               std::uint32_t maximum_owners) {
     require(valid(handle) && !scratch_live_, "fake pressure expansion is stale");
     const Target& parent = targets_[handle.index];
     populate_options(parent.candidate_index);
     expansion_scratch_.clear();
-    for (std::size_t owner = 0; owner < owners_.size(); ++owner) {
+    prepared_parent_    = handle.index;
+    prepared_owner_end_ = static_cast<std::uint32_t>(std::min<std::size_t>(
+        owners_.size(), static_cast<std::size_t>(parent.next_expansion_owner) + maximum_owners));
+    for (std::size_t owner = parent.next_expansion_owner; owner < prepared_owner_end_; ++owner) {
         const std::uint16_t current = parent.choices[owner];
         const auto& alternatives    = options_[parent.candidate_index][owner];
         if (current == 0) {
             for (std::size_t choice = 1; choice <= alternatives.size(); ++choice) {
-                Target child         = parent;
-                child.choices[owner] = static_cast<std::uint16_t>(choice);
-                child.root_maximal   = false;
+                Target child               = parent;
+                child.choices[owner]       = static_cast<std::uint16_t>(choice);
+                child.root_maximal         = false;
+                child.next_expansion_owner = 0;
                 if (std::none_of(expansion_scratch_.begin(), expansion_scratch_.end(),
                                  [&](const Target& prior) { return same_target(prior, child); })) {
                     expansion_scratch_.push_back(std::move(child));
@@ -1597,9 +1647,10 @@ FakePressurePlanningSession::prepare_expansion(FakePressureTargetHandle handle) 
             }
         } else if (current <= alternatives.size() &&
                    !alternatives[current - 1U].evicts_continuation) {
-            Target child         = parent;
-            child.choices[owner] = static_cast<std::uint16_t>(alternatives.size());
-            child.root_maximal   = false;
+            Target child               = parent;
+            child.choices[owner]       = static_cast<std::uint16_t>(alternatives.size());
+            child.root_maximal         = false;
+            child.next_expansion_owner = 0;
             if (std::none_of(expansion_scratch_.begin(), expansion_scratch_.end(),
                              [&](const Target& prior) { return same_target(prior, child); })) {
                 expansion_scratch_.push_back(std::move(child));
@@ -1651,10 +1702,12 @@ FakePressurePlanningSession::commit_expansion(FakePreparedPressureExpansion&& pr
         std::max(program_->pressure_target_count_peak, targets_.size());
     require(new_count == prepared.new_count, "fake expansion count changed before commit");
     expansion_scratch_.clear();
-    scratch_live_ = false;
+    scratch_live_                                   = false;
+    targets_[prepared_parent_].next_expansion_owner = prepared_owner_end_;
     return FakePressureExpansionView{
         .children            = committed_children_,
         .new_canonical_count = new_count,
+        .complete            = prepared_owner_end_ == owners_.size(),
     };
 }
 
@@ -3245,9 +3298,167 @@ void test_shortlist_collision_requires_program_exact_verification() {
             "shortlist collision bypassed Program exact identity verification");
 }
 
+// Enumerates raw owner choices independently of the search frontier/generator and portfolio fold.
+// Each owner can keep its cache, spill it (one relief unit), or drop it (two relief units).
+void test_complete_search_against_small_exhaustive_oracle() {
+    using Planner              = ninfer::runtime::MaterializationPlanner<FakePackage>;
+    constexpr std::uint64_t ms = 1'000'000;
+    const std::array<std::uint64_t, 3> rebuild{600 * ms, 200 * ms, 100 * ms};
+    const std::array<std::uint64_t, 3> spill{40 * ms, 200 * ms, 10 * ms};
+    const std::array<std::uint64_t, 3> drop{ms, 2 * ms, 3 * ms};
+    for (unsigned weight_rotation = 0; weight_rotation < 3; ++weight_rotation) {
+        for (unsigned required = 0; required <= 3; ++required) {
+            for (bool full_catalog : {false, true}) {
+                FakeProgram program;
+                program.required_pressure_actions       = required;
+                program.eviction_pressure_action_units  = 2;
+                program.pressure_checkpoint_recovery_ns = 1'000 * ms;
+                std::array<FakeContinuationHandle, 3> handles;
+                std::array<const FakeContinuationHandle*, 3> owners;
+                std::array<PlanningOwnerId, 3> ids;
+                std::array<ninfer::runtime::MaterializationOwnerPolicy, 3> policies;
+                std::array<ninfer::runtime::MaterializationCheckpointPolicy, 3> checkpoints;
+                const std::array<unsigned, 3> weights{1, 4, 16};
+                for (unsigned i = 0; i < 3; ++i) {
+                    handles[i]     = FakeContinuationHandle{i + 1, 0};
+                    owners[i]      = &handles[i];
+                    ids[i]         = {.value = i};
+                    policies[i]    = {.owner                    = ids[i],
+                                      .private_retention_weight = weights[(i + weight_rotation) % 3]};
+                    checkpoints[i] = {.owner       = ids[i],
+                                      .checkpoint  = {.kind     = CheckpointKind::SessionEndpoint,
+                                                      .frontier = 16,
+                                                      .ordinal  = 0},
+                                      .demand_mask = 1,
+                                      .rebuild_ns  = rebuild[i]};
+                    program.owner_decisions.push_back({i + 1,
+                                                       {{.id = 1000 + i, .immediate_ns = spill[i]},
+                                                        {.id                  = 2000 + i,
+                                                         .immediate_ns        = drop[i],
+                                                         .degradation_units   = 4,
+                                                         .dropped_checkpoints = 1,
+                                                         .evicts_continuation = true}}});
+                }
+                FakeAdmissionCandidate root, reuse;
+                set_fake_machine_costs(root.identity.machine_work, 800 * ms, 800 * ms);
+                set_fake_machine_costs(reuse.identity.machine_work, 100 * ms, 100 * ms);
+                reuse.private_source_id                          = 1;
+                reuse.value.reusable_prompt_tokens               = 48;
+                reuse.identity.machine_work.reused_prompt_tokens = 48;
+                for (auto* candidate : {&root, &reuse}) {
+                    candidate->identity.physical_status =
+                        required == 0 ? ninfer::runtime::MaterializationPhysicalStatus::Feasible
+                                      : ninfer::runtime::MaterializationPhysicalStatus::Infeasible;
+                    candidate->identity.expandable = required != 0;
+                }
+                const std::array candidates{
+                    Planner::CandidateInput{.candidate = &root, .id = {.value = 0}},
+                    Planner::CandidateInput{
+                        .candidate = &reuse, .id = {.value = 1}, .stable_ordinal = 1}};
+                const auto inputs = [&]() -> Planner::PressureInputs {
+                    return {.private_owners    = owners,
+                            .private_owner_ids = ids,
+                            .owner_policy      = policies,
+                            .checkpoint_policy = checkpoints};
+                };
+                const auto goal =
+                    [&](PlanningCandidateId candidate, PrivateSourceMode,
+                        std::span<const ninfer::runtime::PressureOwnerOutcome> outcomes)
+                    -> std::optional<Planner::LogicalGoal> {
+                    if (candidate.value == 1 || !full_catalog ||
+                        std::any_of(outcomes.begin(), outcomes.end(), [](auto outcome) {
+                            return outcome.disposition == VictimDisposition::Evicted;
+                        })) {
+                        return Planner::LogicalGoal{.publication_slot = 0};
+                    }
+                    return std::nullopt;
+                };
+                std::uint64_t oracle = UINT64_MAX;
+                for (unsigned source = 0; source < 2; ++source) {
+                    for (unsigned raw = 0; raw < 27; ++raw) {
+                        unsigned digits = raw, relief = 0;
+                        bool frees_slot = false, protects_source = true;
+                        std::uint64_t cost                    = (source ? 100 : 800) * ms;
+                        std::uint64_t remaining_public_saving = 0;
+                        for (unsigned owner = 0; owner < 3; ++owner) {
+                            unsigned choice = digits % 3;
+                            digits /= 3;
+                            if (source == 1 && owner == 0 && choice != 0) {
+                                protects_source = false;
+                            }
+                            relief += choice;
+                            if (choice == 2) {
+                                frees_slot = true;
+                                cost += drop[owner] +
+                                        rebuild[owner] * weights[(owner + weight_rotation) % 3];
+                            } else {
+                                remaining_public_saving =
+                                    std::max(remaining_public_saving, rebuild[owner]);
+                                if (choice == 1) { cost += spill[owner]; }
+                            }
+                        }
+                        if (!protects_source || relief < required ||
+                            (full_catalog && source == 0 && !frees_slot)) {
+                            continue;
+                        }
+                        cost += rebuild[0] - remaining_public_saving;
+                        oracle = std::min(oracle, cost);
+                    }
+                }
+                Planner planner;
+                auto allowance     = ninfer::runtime::PlanningAllowance::boundary(0);
+                allowance.limit_ns = 5 * ms;
+                auto result =
+                    planner.plan(program, FakePreparedPrompt{}, test_cost_model(), candidates, 0,
+                                 inputs, goal, Planner::Clock::now(), allowance);
+                require(result && result->plan,
+                        "exhaustive-oracle problem lost its feasible fallback");
+                if (result->diagnostics.predicted_total_ns != oracle) {
+                    std::cerr << "oracle rotation=" << weight_rotation << " relief=" << required
+                              << " full=" << full_catalog << " expected=" << oracle
+                              << " selected=" << result->diagnostics.predicted_total_ns << '\n';
+                }
+                require(result->diagnostics.predicted_total_ns == oracle,
+                        "complete search missed the independent small-problem optimum");
+                require(
+                    std::none_of(result->plan->private_owner_ids.begin(),
+                                 result->plan->private_owner_ids.end(),
+                                 [&](auto id) { return result->candidate.value == 1 && id == 1; }),
+                    "construction included the selected source as a victim");
+            }
+        }
+    }
+}
+
+void test_publication_only_pressure_constructs_adoptable_target() {
+    constexpr unsigned owners = 7;
+    FakeManager manager       = make_manager(1, owners);
+    FakeProgram program;
+    for (unsigned i = 0; i < owners; ++i) {
+        const auto active = start_active(manager, program, 500 + i, make_base(500 + i), i + 1);
+        (void)finish_active(manager, program, active);
+    }
+    require(program.required_pressure_actions == 0, "publication fixture has physical pressure");
+    auto allowance     = ninfer::runtime::PlanningAllowance::boundary(0);
+    allowance.limit_ns = 5'000'000;
+    auto result = manager.inspect(program, FakePreparedPrompt{600}, make_base(600), 20, allowance);
+    require(result.choice.has_value(),
+            "publication-only pressure did not produce an adoptable target");
+    program.abort_start = true;
+    (void)manager.reserve_materialization(program, std::move(*result.choice),
+                                          FakePreparedPrompt{600}, {});
+    require(program.started_action_ids.size() == 1 && program.started_action_ids.front() >= 2000,
+            "publication-only closure did not release exactly one private slot");
+}
+
+
 } // namespace
 
 int main() {
+    run_test("independent complete-target oracle",
+             test_complete_search_against_small_exhaustive_oracle);
+    run_test("publication-only construction",
+             test_publication_only_pressure_constructs_adoptable_target);
     run_test("private checkpoint identity loss",
              test_private_portfolio_loss_keeps_checkpoint_identity_fixed);
     run_test("portfolio demand and owner aggregation", test_portfolio_demand_and_owner_aggregation);


### PR DESCRIPTION
Catches up with `neroued/master` through `d4929686`. We were two commits behind:

- `9f0575bb` fix(build): include bf16 definitions in q4 topk kernel (one-line include)
- `d4929686` perf(runtime): improve materialization search and adapt planning budgets (upstream #176)

## Adapted for this fork (Windows / MSVC)

Upstream builds with GCC/Clang, and the merge did not build or pass here as-is:

1. **Compile error.** The new guidance comparator in `materialization_planner.h` uses `__uint128_t`, which MSVC doesn't have. It now uses `core::wide_multiply`/`wide_less` from `core/wide_math.h`, the helper the fork already uses for 128-bit host arithmetic. The operands are all `uint64_t`, so the result is identical.
2. **Test failure.** `test_candidate_search_prefers_deep_reuse_without_eviction` models 1 ms per fake assessment with `sleep_for`. On Windows that rounds up to the ~15.6 ms timer tick, so the 50 ms admission allowance runs out after three assessments and the test fails with "one-step eviction outranked the multi-step preserving reuse closure". The fake now busy-waits for the delay; 5 of 5 runs pass.
3. **Doc conflict.** `docs/serving.md` is resolved to upstream. Our copy described `model_optimal` / lower-bound diagnostics that no longer exist in `src/`.

## Verification (RTX 3090, CUDA 12.8, MSVC v143, `build-ninja`)

- Full build clean. `ctest -j2`: **134/134 pass** (the 6 real-model tests skip without `NINFER_*_WEIGHTS`, as usual).
- **Performance A/B**, master `a3d7a476` vs this branch, alternated case by case with a fresh server per run. Workload: upstream's own TTFT resource cases (`tools/bench/run_serve_ttft.py`) on `qwen3_8_27b.ninfer`, rk8v4 KV, with 3090-sized serve profiles:

| scenario | master | branch |
|---|---|---|
| 6 × 8K resume-after-interference cases, 3 reps each (36 runs) | same reuse on every resume, TTFT within noise | same |
| 8K cold prefill, median of 18 | 1,190 tok/s | 1,175 tok/s |
| decode, 256 tokens at c2, median of 36 | 41.95 tok/s | 41.60 tok/s |
| 55K cold prefill, median of 6 | 962 tok/s | 969 tok/s |
| 55K six-session rotation (25 requests, 1 rep) | 1,209 s, 4/19 resumes hit | 1,243 s, 3/19 resumes hit |

The throughput differences have mixed signs and sit inside this card's 3–5% process-to-process drift (see TODO.md). No kernel code changed.

In the 55K rotation the GPU holds one 55K session (KV 103,680 tokens), and Windows clamps pinned host KV to 424 MiB, so a resume either hits in ~0.1–0.4 s or re-prefills in ~57 s. Once the rotation settles, both builds keep one warm session and hit once per round. The whole difference is one early choice of which idle session survives the initial loads, with one sample per build. The old planner hit `time_budget` on every pressured admission. The new one stops at `insufficient_expected_gain` after its 5 ms initial grant, with 0 renewals.

## Known issue this exposes (follow-up PR)

The planner's machine-cost model uses `generic-default` coefficients on this card and predicts **26 s for a 55K prefill that takes 57 s**. Both the old and new search base their eviction decisions on it. Calibrating 3090 context-cost presets is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4RQebEZG9tTVTK6AKENC8
